### PR TITLE
feat(ui): add visual recording indicator to ribbon icon

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import { AudioRecorderSettings, mergeSettings } from './settings/Settings';
 import { AudioRecorderSettingTab } from './settings/SettingsTab';
 import { RecordingManager } from './recording/RecordingManager';
 import { updateStatusBar, initializeStatusBar } from './ui/StatusBar';
+import { updateRibbonIcon, initializeRibbonIcon } from './ui/RibbonIcon';
 import { showDeviceSelectionModal } from './ui/DeviceSelectionModal';
 
 /**
@@ -18,6 +19,7 @@ export default class AudioRecorderPlugin extends Plugin {
 	settings!: AudioRecorderSettings;
 	private recordingManager!: RecordingManager;
 	private statusBarItem: HTMLElement | null = null;
+	private ribbonIconEl: HTMLElement | null = null;
 
 	/**
 	 * Called when the plugin is loaded.
@@ -30,12 +32,13 @@ export default class AudioRecorderPlugin extends Plugin {
 			this.settings,
 			(status: RecordingStatus) => {
 				updateStatusBar(this.statusBarItem, status);
+				updateRibbonIcon(this.ribbonIconEl, status);
 			},
 		);
 
 		this.addSettingTab(new AudioRecorderSettingTab(this.app, this));
 		this.registerCommands();
-		this.addRibbonIcon('microphone', 'Start/stop recording', () => {
+		this.ribbonIconEl = this.addRibbonIcon('microphone', 'Start/stop recording', () => {
 			void this.recordingManager.toggleRecording();
 		});
 		this.setupStatusBar();
@@ -47,6 +50,7 @@ export default class AudioRecorderPlugin extends Plugin {
 	onunload(): void {
 		this.recordingManager.cleanup();
 		initializeStatusBar(this.statusBarItem);
+		initializeRibbonIcon(this.ribbonIconEl);
 	}
 
 	/**

--- a/src/ui/RibbonIcon.ts
+++ b/src/ui/RibbonIcon.ts
@@ -1,0 +1,51 @@
+/**
+ * Ribbon icon component for displaying recording status.
+ * @module ui/RibbonIcon
+ */
+
+import { setIcon } from 'obsidian';
+import { RecordingStatus } from '../types';
+
+/** Icon name for idle state */
+const ICON_IDLE = 'microphone';
+/** Icon name for recording state */
+const ICON_RECORDING = 'mic';
+
+/**
+ * Updates the ribbon icon element based on recording status.
+ * Changes the icon and toggles the recording CSS class.
+ * @param ribbonIconEl - The ribbon icon HTML element
+ * @param status - Current recording status
+ */
+export function updateRibbonIcon(
+    ribbonIconEl: HTMLElement | null,
+    status: RecordingStatus,
+): void {
+    if (!ribbonIconEl) {
+        return;
+    }
+
+    switch (status) {
+        case RecordingStatus.Recording:
+            setIcon(ribbonIconEl, ICON_RECORDING);
+            ribbonIconEl.classList.add('is-recording');
+            break;
+        case RecordingStatus.Paused:
+            setIcon(ribbonIconEl, ICON_RECORDING);
+            ribbonIconEl.classList.add('is-recording');
+            break;
+        case RecordingStatus.Idle:
+        default:
+            setIcon(ribbonIconEl, ICON_IDLE);
+            ribbonIconEl.classList.remove('is-recording');
+            break;
+    }
+}
+
+/**
+ * Initializes the ribbon icon to idle state.
+ * @param ribbonIconEl - The ribbon icon HTML element
+ */
+export function initializeRibbonIcon(ribbonIconEl: HTMLElement | null): void {
+    updateRibbonIcon(ribbonIconEl, RecordingStatus.Idle);
+}

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -11,3 +11,18 @@ If your plugin does not need CSS, delete this file.
     color: red;
     font-weight: bold;
 }
+
+/* Ribbon icon recording animation */
+.side-dock-ribbon-action.is-recording svg {
+    color: var(--color-red);
+    animation: pulse-recording 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse-recording {
+    0%, 100% {
+        opacity: 1;
+    }
+    50% {
+        opacity: 0.5;
+    }
+}

--- a/tests/unit/RibbonIcon.test.ts
+++ b/tests/unit/RibbonIcon.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for RibbonIcon module.
+ * Tests the ribbon icon state changes during recording.
+ * @module tests/unit/RibbonIcon.test
+ */
+/** @jest-environment jsdom */
+
+import { updateRibbonIcon, initializeRibbonIcon } from '../../src/ui/RibbonIcon';
+import { RecordingStatus } from '../../src/types';
+
+// Mock the setIcon function from obsidian
+jest.mock('obsidian', () => ({
+    setIcon: jest.fn((el: HTMLElement, iconName: string) => {
+        el.setAttribute('data-icon', iconName);
+    }),
+}));
+
+describe('RibbonIcon', () => {
+    let ribbonElement: HTMLElement;
+
+    beforeEach(() => {
+        ribbonElement = document.createElement('div');
+        ribbonElement.className = 'side-dock-ribbon-action';
+    });
+
+    describe('updateRibbonIcon', () => {
+        it('should handle null element gracefully', () => {
+            expect(() => {
+                updateRibbonIcon(null, RecordingStatus.Recording);
+            }).not.toThrow();
+        });
+
+        it('should change icon to mic and add is-recording class when recording', () => {
+            updateRibbonIcon(ribbonElement, RecordingStatus.Recording);
+
+            expect(ribbonElement.getAttribute('data-icon')).toBe('mic');
+            expect(ribbonElement.classList.contains('is-recording')).toBe(true);
+        });
+
+        it('should change icon to mic and add is-recording class when paused', () => {
+            updateRibbonIcon(ribbonElement, RecordingStatus.Paused);
+
+            expect(ribbonElement.getAttribute('data-icon')).toBe('mic');
+            expect(ribbonElement.classList.contains('is-recording')).toBe(true);
+        });
+
+        it('should change icon to microphone and remove is-recording class when idle', () => {
+            // First set to recording
+            ribbonElement.classList.add('is-recording');
+            ribbonElement.setAttribute('data-icon', 'mic');
+
+            updateRibbonIcon(ribbonElement, RecordingStatus.Idle);
+
+            expect(ribbonElement.getAttribute('data-icon')).toBe('microphone');
+            expect(ribbonElement.classList.contains('is-recording')).toBe(false);
+        });
+
+        it('should handle default case same as idle', () => {
+            ribbonElement.classList.add('is-recording');
+
+            // Force an unknown status value to test default case
+            updateRibbonIcon(ribbonElement, 'unknown' as RecordingStatus);
+
+            expect(ribbonElement.getAttribute('data-icon')).toBe('microphone');
+            expect(ribbonElement.classList.contains('is-recording')).toBe(false);
+        });
+    });
+
+    describe('initializeRibbonIcon', () => {
+        it('should handle null element gracefully', () => {
+            expect(() => {
+                initializeRibbonIcon(null);
+            }).not.toThrow();
+        });
+
+        it('should set ribbon icon to idle state', () => {
+            ribbonElement.classList.add('is-recording');
+            ribbonElement.setAttribute('data-icon', 'mic');
+
+            initializeRibbonIcon(ribbonElement);
+
+            expect(ribbonElement.getAttribute('data-icon')).toBe('microphone');
+            expect(ribbonElement.classList.contains('is-recording')).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
Add visual feedback when recording is active by changing the ribbon icon and adding a pulsing animation.

Functional Changes:
- Add new RibbonIcon module with updateRibbonIcon and initializeRibbonIcon functions
- Change ribbon icon from 'microphone' to 'mic' during recording
- Add 'is-recording' CSS class to ribbon element when recording
- Integrate ribbon icon updates with RecordingManager status callback

Refactoring Changes:
- Store ribbon element reference in main.ts for dynamic updates
- Extract ribbon icon logic into dedicated ui/RibbonIcon.ts module

Test Changes:
- Add 7 unit tests for RibbonIcon module (100% coverage)
- Test null element handling, recording/paused/idle states
- All 75 tests passing