### PR TITLE
Fix multi-track device ordering and device selection handling

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,11 @@
 
 import { Plugin } from 'obsidian';
 import { RecordingStatus } from './types';
-import { AudioRecorderSettings, mergeSettings } from './settings/Settings';
+import {
+	AudioRecorderSettings,
+	mergeSettings,
+	serializeSettings,
+} from './settings/Settings';
 import { AudioRecorderSettingTab } from './settings/SettingsTab';
 import { RecordingManager } from './recording/RecordingManager';
 import { updateStatusBar, initializeStatusBar } from './ui/StatusBar';
@@ -70,7 +74,7 @@ export default class AudioRecorderPlugin extends Plugin {
 	 * Saves plugin settings to storage.
 	 */
 	async saveSettings(): Promise<void> {
-		await this.saveData(this.settings);
+		await this.saveData(serializeSettings(this.settings));
 		this.recordingManager.updateSettings(this.settings);
 	}
 

--- a/tests/RecordingManager.fallback.test.ts
+++ b/tests/RecordingManager.fallback.test.ts
@@ -137,7 +137,13 @@ describe('AudioStreamHandler: Error Handling', () => {
         Object.defineProperty(navigator, 'mediaDevices', {
             value: {
                 getUserMedia: getUserMediaMock,
-                enumerateDevices: jest.fn().mockResolvedValue([]),
+                enumerateDevices: jest.fn().mockResolvedValue([
+                    {
+                        deviceId: 'test-device-id',
+                        kind: 'audioinput',
+                        label: 'Test Device',
+                    },
+                ]),
             },
             writable: true,
         });
@@ -160,7 +166,13 @@ describe('AudioStreamHandler: Error Handling', () => {
         Object.defineProperty(navigator, 'mediaDevices', {
             value: {
                 getUserMedia: getUserMediaMock,
-                enumerateDevices: jest.fn().mockResolvedValue([]),
+                enumerateDevices: jest.fn().mockResolvedValue([
+                    {
+                        deviceId: 'test-device-id',
+                        kind: 'audioinput',
+                        label: 'Test Device',
+                    },
+                ]),
             },
             writable: true,
         });
@@ -180,7 +192,13 @@ describe('AudioStreamHandler: Error Handling', () => {
         Object.defineProperty(navigator, 'mediaDevices', {
             value: {
                 getUserMedia: getUserMediaMock,
-                enumerateDevices: jest.fn().mockResolvedValue([]),
+                enumerateDevices: jest.fn().mockResolvedValue([
+                    {
+                        deviceId: 'test-device-id',
+                        kind: 'audioinput',
+                        label: 'Test Device',
+                    },
+                ]),
             },
             writable: true,
         });
@@ -202,7 +220,13 @@ describe('AudioStreamHandler: Error Handling', () => {
         Object.defineProperty(navigator, 'mediaDevices', {
             value: {
                 getUserMedia: getUserMediaMock,
-                enumerateDevices: jest.fn().mockResolvedValue([]),
+                enumerateDevices: jest.fn().mockResolvedValue([
+                    {
+                        deviceId: 'test-device-id',
+                        kind: 'audioinput',
+                        label: 'Test Device',
+                    },
+                ]),
             },
             writable: true,
         });
@@ -221,7 +245,13 @@ describe('AudioStreamHandler: Error Handling', () => {
         Object.defineProperty(navigator, 'mediaDevices', {
             value: {
                 getUserMedia: getUserMediaMock,
-                enumerateDevices: jest.fn().mockResolvedValue([]),
+                enumerateDevices: jest.fn().mockResolvedValue([
+                    {
+                        deviceId: 'test-device-id',
+                        kind: 'audioinput',
+                        label: 'Test Device',
+                    },
+                ]),
             },
             writable: true,
         });

--- a/tests/unit/AudioStreamHandler.test.ts
+++ b/tests/unit/AudioStreamHandler.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Unit tests for AudioStreamHandler utilities.
+ * @module tests/unit/AudioStreamHandler.test
+ */
+
+import { getOrderedTrackSources } from '../../src/recording/AudioStreamHandler';
+import { DEFAULT_SETTINGS } from '../../src/settings/Settings';
+
+describe('AudioStreamHandler', () => {
+    describe('getOrderedTrackSources', () => {
+        it('should return sources in track order regardless of Map insertion order', () => {
+            const settings = {
+                ...DEFAULT_SETTINGS,
+                enableMultiTrack: true,
+                maxTracks: 3,
+                trackAudioSources: new Map([
+                    [2, { deviceId: 'device-2' }],
+                    [1, { deviceId: 'device-1' }],
+                    [3, { deviceId: 'device-3' }],
+                ]),
+            };
+
+            const ordered = getOrderedTrackSources(settings);
+
+            expect(ordered.map((source) => source.trackNumber)).toEqual([1, 2, 3]);
+            expect(ordered.map((source) => source.deviceId)).toEqual([
+                'device-1',
+                'device-2',
+                'device-3',
+            ]);
+        });
+
+        it('should skip tracks without selected devices', () => {
+            const settings = {
+                ...DEFAULT_SETTINGS,
+                enableMultiTrack: true,
+                maxTracks: 3,
+                trackAudioSources: new Map([
+                    [1, { deviceId: 'device-1' }],
+                    [3, { deviceId: '' }],
+                ]),
+            };
+
+            const ordered = getOrderedTrackSources(settings);
+
+            expect(ordered.map((source) => source.trackNumber)).toEqual([1]);
+        });
+    });
+});

--- a/tests/unit/RecordingManager.test.ts
+++ b/tests/unit/RecordingManager.test.ts
@@ -22,6 +22,7 @@ jest.mock('../../src/recording/AudioStreamHandler', () => ({
     getAudioStreams: jest.fn(),
     getAudioSourceName: jest.fn().mockResolvedValue('TestDevice'),
     stopAllStreams: jest.fn(),
+    validateSelectedDevices: jest.fn(),
 }));
 
 // Mock WavEncoder
@@ -158,9 +159,12 @@ describe('RecordingManager', () => {
             const { getAudioStreams } = jest.requireMock('../../src/recording/AudioStreamHandler') as {
                 getAudioStreams: jest.Mock;
             };
-            getAudioStreams.mockResolvedValue([{
-                getTracks: () => [{ stop: jest.fn() }],
-            }]);
+            getAudioStreams.mockResolvedValue({
+                streams: [{
+                    getTracks: () => [{ stop: jest.fn() }],
+                }],
+                trackOrder: [],
+            });
         });
 
         it('should start recording when idle', async () => {
@@ -217,9 +221,12 @@ describe('RecordingManager', () => {
             const { getAudioStreams } = jest.requireMock('../../src/recording/AudioStreamHandler') as {
                 getAudioStreams: jest.Mock;
             };
-            getAudioStreams.mockResolvedValue([{
-                getTracks: () => [{ stop: jest.fn() }],
-            }]);
+            getAudioStreams.mockResolvedValue({
+                streams: [{
+                    getTracks: () => [{ stop: jest.fn() }],
+                }],
+                trackOrder: [],
+            });
         });
 
         it('should do nothing when idle', () => {
@@ -297,9 +304,12 @@ describe('RecordingManager', () => {
             const { getAudioStreams } = jest.requireMock('../../src/recording/AudioStreamHandler') as {
                 getAudioStreams: jest.Mock;
             };
-            getAudioStreams.mockResolvedValue([{
-                getTracks: () => [{ stop: mockStopTrack }],
-            }]);
+            getAudioStreams.mockResolvedValue({
+                streams: [{
+                    getTracks: () => [{ stop: mockStopTrack }],
+                }],
+                trackOrder: [],
+            });
         });
 
         it('should reset status to Idle even when save fails', async () => {
@@ -398,9 +408,12 @@ describe('RecordingManager', () => {
             const { getAudioStreams } = jest.requireMock('../../src/recording/AudioStreamHandler') as {
                 getAudioStreams: jest.Mock;
             };
-            getAudioStreams.mockResolvedValue([{
-                getTracks: () => [{ stop: jest.fn() }],
-            }]);
+            getAudioStreams.mockResolvedValue({
+                streams: [{
+                    getTracks: () => [{ stop: jest.fn() }],
+                }],
+                trackOrder: [],
+            });
         });
 
         it('should follow full lifecycle: idle -> recording -> paused -> recording -> idle', async () => {

--- a/tests/unit/Settings.test.ts
+++ b/tests/unit/Settings.test.ts
@@ -60,7 +60,8 @@ describe('Settings', () => {
         });
 
         it('should have empty track audio sources', () => {
-            expect(DEFAULT_SETTINGS.trackAudioSources).toEqual({});
+            expect(DEFAULT_SETTINGS.trackAudioSources).toBeInstanceOf(Map);
+            expect(DEFAULT_SETTINGS.trackAudioSources.size).toBe(0);
         });
 
         it('should have debug mode disabled by default', () => {
@@ -113,14 +114,25 @@ describe('Settings', () => {
         });
 
         it('should merge track audio sources', () => {
-            const trackSources: TrackAudioSources = {
-                1: 'device-id-1',
-                2: 'device-id-2',
-            };
+            const trackSources: TrackAudioSources = new Map([
+                [1, { deviceId: 'device-id-1' }],
+                [2, { deviceId: 'device-id-2' }],
+            ]);
 
             const result = mergeSettings({ trackAudioSources: trackSources });
 
-            expect(result.trackAudioSources).toEqual(trackSources);
+            expect(result.trackAudioSources.get(1)?.deviceId).toBe('device-id-1');
+            expect(result.trackAudioSources.get(2)?.deviceId).toBe('device-id-2');
+        });
+
+        it('should normalize serialized track audio sources into a Map', () => {
+            const result = mergeSettings({
+                trackAudioSources: { 1: 'device-id-1', 2: 'device-id-2' },
+            });
+
+            expect(result.trackAudioSources).toBeInstanceOf(Map);
+            expect(result.trackAudioSources.get(1)?.deviceId).toBe('device-id-1');
+            expect(result.trackAudioSources.get(2)?.deviceId).toBe('device-id-2');
         });
 
         it('should handle output mode changes', () => {
@@ -147,7 +159,10 @@ describe('Settings', () => {
                 maxTracks: 4,
                 outputMode: 'multiple',
                 useSourceNamesForTracks: false,
-                trackAudioSources: { 1: 'dev1', 2: 'dev2' },
+                trackAudioSources: new Map([
+                    [1, { deviceId: 'dev1' }],
+                    [2, { deviceId: 'dev2' }],
+                ]),
                 debug: true,
             };
 
@@ -191,15 +206,15 @@ describe('Settings', () => {
             expect(validModes).toHaveLength(2);
         });
 
-        it('TrackAudioSources should map numbers to strings', () => {
-            const sources: TrackAudioSources = {
-                1: 'device-1',
-                2: 'device-2',
-                3: 'device-3',
-            };
+        it('TrackAudioSources should map numbers to device IDs', () => {
+            const sources: TrackAudioSources = new Map([
+                [1, { deviceId: 'device-1' }],
+                [2, { deviceId: 'device-2' }],
+                [3, { deviceId: 'device-3' }],
+            ]);
 
-            expect(Object.keys(sources)).toHaveLength(3);
-            expect(sources[1]).toBe('device-1');
+            expect(sources.size).toBe(3);
+            expect(sources.get(1)?.deviceId).toBe('device-1');
         });
     });
 });

--- a/tests/unit/Settings.validation.test.ts
+++ b/tests/unit/Settings.validation.test.ts
@@ -68,7 +68,7 @@ describe('validateSettings', () => {
             ...DEFAULT_SETTINGS,
             audioDeviceId: 'valid-device',
             enableMultiTrack: true,
-            trackAudioSources: {},
+            trackAudioSources: new Map(),
         };
         expect(() => validateSettings(settings)).toThrow(SettingsValidationError);
         expect(() => validateSettings(settings)).toThrow(
@@ -81,7 +81,10 @@ describe('validateSettings', () => {
             ...DEFAULT_SETTINGS,
             audioDeviceId: 'valid-device',
             enableMultiTrack: true,
-            trackAudioSources: { 1: 'device-1', 2: '' },
+            trackAudioSources: new Map([
+                [1, { deviceId: 'device-1' }],
+                [2, { deviceId: '' }],
+            ]),
         };
         expect(() => validateSettings(settings)).toThrow(SettingsValidationError);
         expect(() => validateSettings(settings)).toThrow(
@@ -102,7 +105,10 @@ describe('validateSettings', () => {
             ...DEFAULT_SETTINGS,
             audioDeviceId: 'valid-device',
             enableMultiTrack: true,
-            trackAudioSources: { 1: 'device-1', 2: 'device-2' },
+            trackAudioSources: new Map([
+                [1, { deviceId: 'device-1' }],
+                [2, { deviceId: 'device-2' }],
+            ]),
         };
         expect(() => validateSettings(settings)).not.toThrow();
     });


### PR DESCRIPTION
### Motivation
- Multi-track device selection used `Object.values`/plain objects which lost track order and could misalign streams and filenames.
- Multiple mode relied on fragile index arithmetic (`i + 1`) instead of an explicit mapping between tracks and devices.
- Users had no easy single-recording device selector and the UI did not react to device change events, nor validated device availability at recording start.

### Description
- Replace `trackAudioSources: Record<number,string>` with a `Map<number, AudioSource>` and add `normalizeTrackAudioSources`, `serializeTrackAudioSources`, and `serializeSettings` to normalize and persist the new model.
- Change `getAudioStreams` to return `{ streams, trackOrder }`, add `getOrderedTrackSources` to iterate tracks `1..maxTracks` deterministically, and add `validateSelectedDevices` to check availability before recording.
- Update `RecordingManager` to call `validateSelectedDevices`, consume the ordered `trackOrder`, and use it when naming files so streams and filenames remain aligned.
- Add a single-recording input device dropdown to the settings UI, wire `navigator.mediaDevices.ondevicechange` to refresh dropdowns via `refreshDeviceList`, and update multi-track dropdown bindings to the `Map` model.
- Add unit tests for ordered track sources and update existing tests to the new settings model and `getAudioStreams` shape.

### Testing
- Ran unit tests with `npm test` and all suites passed: `85` tests across `8` suites (green).
- Ran linter with `npm run lint` (and `npm run lint:fix`) and resolved formatting issues so `eslint` completes without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a50b66c248320b8ee87fbc69aea72)