### PR TITLE
Stream recording chunks to disk and add mobile buffering

### DIFF
--- a/src/recording/RecordingManager.ts
+++ b/src/recording/RecordingManager.ts
@@ -268,6 +268,8 @@ export class RecordingManager {
 		this.recorders = [];
 		this.chunkTargets = [];
 		this.streams = [];
+		this.recordingTimestamp = null;
+		this.totalChunks = 0;
 	}
 
 	private setStatus(status: RecordingStatus): void {

--- a/src/recording/RecordingManager.ts
+++ b/src/recording/RecordingManager.ts
@@ -3,7 +3,7 @@
  * @module recording/RecordingManager
  */
 
-import { MarkdownView, normalizePath, Notice } from 'obsidian';
+import { MarkdownView, normalizePath, Notice, Platform } from 'obsidian';
 import type { App } from 'obsidian';
 import { RecordingStatus } from '../types';
 import type { AudioRecorderSettings } from '../settings/Settings';
@@ -16,17 +16,34 @@ import { bufferToWave } from './WavEncoder';
 import { PLUGIN_LOG_PREFIX } from '../constants';
 import { DebugLogger } from '../utils/DebugLogger';
 
+type RecordingTarget = {
+	fileBaseName: string;
+	sourceName: string;
+	tempFilePath: string | null;
+	bufferedChunks: Blob[];
+	bufferedBytes: number;
+	segmentIndex: number;
+	segmentPaths: string[];
+	pendingWrite: Promise<void>;
+};
+
+const CHUNK_TIMESLICE_MS = 5000;
+const MOBILE_BUFFER_LIMIT_BYTES = 50 * 1024 * 1024;
+
 /**
  * Manages the audio recording lifecycle.
  */
 export class RecordingManager {
 	private recorders: MediaRecorder[] = [];
-	private audioChunks: Blob[][] = [];
+	private chunkTargets: RecordingTarget[] = [];
 	private streams: MediaStream[] = [];
 	private status: RecordingStatus = RecordingStatus.Idle;
 	private onStatusChange: (status: RecordingStatus) => void;
 	private debugLogger: DebugLogger;
 	private recordingStartTime: number = 0;
+	private recordingTimestamp: string | null = null;
+	private totalChunks: number = 0;
+	private isMobileRecording: boolean = false;
 
 	/**
 	 * Creates a new RecordingManager.
@@ -88,13 +105,48 @@ export class RecordingManager {
 			this.recorders = this.streams.map(
 				(stream) => new MediaRecorder(stream, { mimeType }),
 			);
-			this.audioChunks = this.recorders.map(() => []);
 			this.recordingStartTime = Date.now();
+			this.recordingTimestamp = new Date()
+				.toISOString()
+				.replace(/[:.]/g, '-');
+			this.totalChunks = 0;
+			this.isMobileRecording = Platform.isMobileApp || Platform.isMobile;
+			this.chunkTargets = await Promise.all(
+				this.recorders.map(async (_recorder, index) => {
+					const trackNumber = index + 1;
+					const deviceId =
+						this.settings.trackAudioSources[trackNumber];
+					const sourceName =
+						this.settings.useSourceNamesForTracks && deviceId
+							? await getAudioSourceName(deviceId)
+							: `Track${trackNumber}`;
+					const fileBaseName = `${this.settings.filePrefix}-${sourceName}-${this.recordingTimestamp}`;
+					let tempFilePath: string | null = null;
+					if (!this.isMobileRecording) {
+						const tempName = `${fileBaseName}.partial.${this.settings.recordingFormat}`;
+						tempFilePath = await this.resolveUniquePath(tempName);
+						await this.app.vault.createBinary(
+							tempFilePath,
+							new ArrayBuffer(0),
+						);
+					}
+					return {
+						fileBaseName,
+						sourceName,
+						tempFilePath,
+						bufferedChunks: [],
+						bufferedBytes: 0,
+						segmentIndex: 0,
+						segmentPaths: [],
+						pendingWrite: Promise.resolve(),
+					};
+				}),
+			);
 
 			this.recorders.forEach((recorder, index) => {
 				recorder.ondataavailable = (event: BlobEvent): void => {
 					if (event.data.size > 0) {
-						this.audioChunks[index].push(event.data);
+						void this.handleChunk(index, event.data);
 						this.debugLogger.logChunkSize(index, event.data.size);
 					}
 				};
@@ -107,7 +159,7 @@ export class RecordingManager {
 						'Recording error occurred. Check console for details.',
 					);
 				};
-				recorder.start();
+				recorder.start(CHUNK_TIMESLICE_MS);
 			});
 
 			this.setStatus(RecordingStatus.Recording);
@@ -163,12 +215,12 @@ export class RecordingManager {
 				),
 			);
 
-			const durationMs = Date.now() - this.recordingStartTime;
-			const totalChunks = this.audioChunks.reduce(
-				(sum, chunks) => sum + chunks.length,
-				0,
+			await Promise.all(
+				this.chunkTargets.map((target) => target.pendingWrite),
 			);
-			this.debugLogger.logRecordingStats(durationMs, totalChunks);
+
+			const durationMs = Date.now() - this.recordingStartTime;
+			this.debugLogger.logRecordingStats(durationMs, this.totalChunks);
 
 			await this.saveRecording();
 			new Notice('Recording stopped');
@@ -184,7 +236,9 @@ export class RecordingManager {
 			stopAllStreams(streamsToStop);
 			this.streams = [];
 			this.recorders = [];
-			this.audioChunks = [];
+			this.chunkTargets = [];
+			this.recordingTimestamp = null;
+			this.totalChunks = 0;
 			this.setStatus(RecordingStatus.Idle);
 		}
 	}
@@ -212,7 +266,7 @@ export class RecordingManager {
 	cleanup(): void {
 		stopAllStreams(this.streams);
 		this.recorders = [];
-		this.audioChunks = [];
+		this.chunkTargets = [];
 		this.streams = [];
 	}
 
@@ -222,36 +276,46 @@ export class RecordingManager {
 	}
 
 	private async saveRecording(): Promise<void> {
-		const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+		const timestamp =
+			this.recordingTimestamp ??
+			new Date().toISOString().replace(/[:.]/g, '-');
 		const fileLinks: string[] = [];
 
 		if (this.settings.outputMode === 'single') {
-			const mergedAudio = await this.mergeAudioTracks();
-			const fileName = `${this.settings.filePrefix}-multitrack-${timestamp}.wav`;
-			const filePath = await this.saveAudioFile(mergedAudio, fileName);
-			if (filePath) {
-				fileLinks.push(filePath);
-			}
-		} else {
-			for (let i = 0; i < this.audioChunks.length; i++) {
-				const chunks = this.audioChunks[i];
-				if (chunks.length === 0) {
-					continue;
+			if (this.chunkTargets.length === 1) {
+				const paths = await this.finalizeTrackFiles(
+					this.chunkTargets[0],
+					1,
+					timestamp,
+				);
+				fileLinks.push(...paths);
+			} else {
+				if (this.isMobileRecording) {
+					await Promise.all(
+						this.chunkTargets.map((target) =>
+							this.flushMobileBuffer(target),
+						),
+					);
 				}
-
-				const audioBlob = new Blob(chunks, {
-					type: `audio/${this.settings.recordingFormat}`,
-				});
-				const trackNumber = i + 1;
-				const deviceId = this.settings.trackAudioSources[trackNumber];
-				const sourceName = deviceId
-					? await getAudioSourceName(deviceId)
-					: `Track${trackNumber}`;
-				const fileName = `${this.settings.filePrefix}-${sourceName}-${timestamp}.${this.settings.recordingFormat}`;
-				const filePath = await this.saveAudioFile(audioBlob, fileName);
+				const mergedAudio = await this.mergeAudioTracks();
+				const fileName = `${this.settings.filePrefix}-multitrack-${timestamp}.wav`;
+				const filePath = await this.saveAudioFile(
+					mergedAudio,
+					fileName,
+				);
 				if (filePath) {
 					fileLinks.push(filePath);
+					await this.cleanupIntermediateFiles();
 				}
+			}
+		} else {
+			for (let i = 0; i < this.chunkTargets.length; i++) {
+				const paths = await this.finalizeTrackFiles(
+					this.chunkTargets[i],
+					i + 1,
+					timestamp,
+				);
+				fileLinks.push(...paths);
 			}
 		}
 
@@ -266,13 +330,11 @@ export class RecordingManager {
 	private async mergeAudioTracks(): Promise<Blob> {
 		const audioContext = new AudioContext();
 		const buffers = await Promise.all(
-			this.audioChunks.map(async (chunks) => {
-				if (chunks.length === 0) {
+			this.chunkTargets.map(async (target) => {
+				const blob = await this.buildTrackBlob(target);
+				if (!blob) {
 					return null;
 				}
-				const blob = new Blob(chunks, {
-					type: `audio/${this.settings.recordingFormat}`,
-				});
 				const arrayBuffer = await blob.arrayBuffer();
 				return audioContext.decodeAudioData(arrayBuffer);
 			}),
@@ -306,18 +368,141 @@ export class RecordingManager {
 		return bufferToWave(renderedBuffer, renderedBuffer.length);
 	}
 
-	private async saveAudioFile(
-		audioBlob: Blob,
-		fileName: string,
-	): Promise<string | null> {
-		if (audioBlob.size === 0) {
-			console.debug(
-				`${PLUGIN_LOG_PREFIX} Skipping empty file: ${fileName}`,
+	private async handleChunk(index: number, data: Blob): Promise<void> {
+		const target = this.chunkTargets[index];
+		if (!target) {
+			return;
+		}
+		this.totalChunks += 1;
+		const enqueue = async (): Promise<void> => {
+			if (this.isMobileRecording) {
+				target.bufferedChunks.push(data);
+				target.bufferedBytes += data.size;
+				if (target.bufferedBytes >= MOBILE_BUFFER_LIMIT_BYTES) {
+					await this.flushMobileBuffer(target);
+				}
+				return;
+			}
+
+			if (!target.tempFilePath) {
+				return;
+			}
+			try {
+				const arrayBuffer = await data.arrayBuffer();
+				await (
+					this.app.vault.adapter as unknown as {
+						append: (
+							path: string,
+							data: ArrayBuffer,
+						) => Promise<void>;
+					}
+				).append(target.tempFilePath, arrayBuffer);
+			} catch (error) {
+				console.error(
+					`${PLUGIN_LOG_PREFIX} Failed to append chunk:`,
+					error,
+				);
+				new Notice(
+					'Failed to save recording chunk. Check console for details.',
+				);
+			}
+		};
+
+		target.pendingWrite = target.pendingWrite.then(enqueue);
+		await target.pendingWrite;
+	}
+
+	private async flushMobileBuffer(target: RecordingTarget): Promise<void> {
+		if (target.bufferedChunks.length === 0) {
+			return;
+		}
+		target.segmentIndex += 1;
+		const segmentName = `${target.fileBaseName}-part${String(
+			target.segmentIndex,
+		)}.${this.settings.recordingFormat}`;
+		const segmentPath = await this.resolveUniquePath(segmentName);
+		const segmentBlob = new Blob(target.bufferedChunks, {
+			type: `audio/${this.settings.recordingFormat}`,
+		});
+		await this.app.vault.createBinary(
+			segmentPath,
+			await segmentBlob.arrayBuffer(),
+		);
+		target.segmentPaths.push(segmentPath);
+		target.bufferedChunks = [];
+		target.bufferedBytes = 0;
+	}
+
+	private async buildTrackBlob(
+		target: RecordingTarget,
+	): Promise<Blob | null> {
+		const type = `audio/${this.settings.recordingFormat}`;
+		if (target.tempFilePath) {
+			const data = await this.app.vault.adapter.readBinary(
+				target.tempFilePath,
 			);
+			return new Blob([data], { type });
+		}
+
+		if (
+			target.segmentPaths.length === 0 &&
+			target.bufferedChunks.length === 0
+		) {
 			return null;
 		}
 
-		const arrayBuffer = await audioBlob.arrayBuffer();
+		const segmentBuffers = await Promise.all(
+			target.segmentPaths.map((path) =>
+				this.app.vault.adapter.readBinary(path),
+			),
+		);
+
+		return new Blob([...segmentBuffers, ...target.bufferedChunks], {
+			type,
+		});
+	}
+
+	private async cleanupIntermediateFiles(): Promise<void> {
+		await Promise.all(
+			this.chunkTargets.flatMap((target) => {
+				const removals: Promise<void>[] = [];
+				if (target.tempFilePath) {
+					removals.push(
+						this.app.vault.adapter.remove(target.tempFilePath),
+					);
+				}
+				for (const path of target.segmentPaths) {
+					removals.push(this.app.vault.adapter.remove(path));
+				}
+				return removals;
+			}),
+		);
+	}
+
+	private async finalizeTrackFiles(
+		target: RecordingTarget,
+		trackNumber: number,
+		timestamp: string,
+	): Promise<string[]> {
+		const fileLinks: string[] = [];
+		if (this.isMobileRecording) {
+			await this.flushMobileBuffer(target);
+			fileLinks.push(...target.segmentPaths);
+			return fileLinks;
+		}
+
+		if (!target.tempFilePath) {
+			return fileLinks;
+		}
+
+		const fileName = `${this.settings.filePrefix}-${target.sourceName}-${timestamp}.${this.settings.recordingFormat}`;
+		const filePath = await this.resolveUniquePath(fileName);
+		await this.app.vault.adapter.rename(target.tempFilePath, filePath);
+		fileLinks.push(filePath);
+		return fileLinks;
+	}
+
+	private async resolveUniquePath(fileName: string): Promise<string> {
 		let sanitizedFileName = fileName.replace(/[\\/:*?"<>|]/g, '-');
 		let filePath = normalizePath(
 			`${this.settings.saveFolder}/${sanitizedFileName}`,
@@ -334,6 +519,23 @@ export class RecordingManager {
 			);
 			counter++;
 		}
+
+		return filePath;
+	}
+
+	private async saveAudioFile(
+		audioBlob: Blob,
+		fileName: string,
+	): Promise<string | null> {
+		if (audioBlob.size === 0) {
+			console.debug(
+				`${PLUGIN_LOG_PREFIX} Skipping empty file: ${fileName}`,
+			);
+			return null;
+		}
+
+		const arrayBuffer = await audioBlob.arrayBuffer();
+		const filePath = await this.resolveUniquePath(fileName);
 
 		await this.app.vault.createBinary(filePath, arrayBuffer);
 		return filePath;

--- a/tests/RecordingManager.fallback.test.ts
+++ b/tests/RecordingManager.fallback.test.ts
@@ -73,6 +73,10 @@ jest.mock('obsidian', () => ({
     Notice: jest.fn().mockImplementation((msg: string) => mockNotice(msg)),
     MarkdownView: jest.fn(),
     normalizePath: (path: string) => path.replace(/\\/g, '/'),
+    Platform: {
+        isMobile: false,
+        isMobileApp: false,
+    },
 }));
 
 // Mock WavEncoder
@@ -95,7 +99,13 @@ describe('AudioStreamHandler: Error Handling', () => {
 
         mockApp = {
             vault: {
-                adapter: { exists: jest.fn().mockResolvedValue(false) },
+                adapter: {
+                    exists: jest.fn().mockResolvedValue(false),
+                    append: jest.fn().mockResolvedValue(undefined),
+                    rename: jest.fn().mockResolvedValue(undefined),
+                    readBinary: jest.fn().mockResolvedValue(new ArrayBuffer(0)),
+                    remove: jest.fn().mockResolvedValue(undefined),
+                },
                 createBinary: jest.fn().mockResolvedValue(undefined),
             },
             workspace: {

--- a/tests/mocks/obsidian.ts
+++ b/tests/mocks/obsidian.ts
@@ -54,6 +54,17 @@ export class App {
 export class Vault {
     adapter = {
         exists: async (_path: string): Promise<boolean> => false,
+        append: async (_path: string, _data: ArrayBuffer): Promise<void> => {
+            // Mock implementation
+        },
+        rename: async (_oldPath: string, _newPath: string): Promise<void> => {
+            // Mock implementation
+        },
+        readBinary: async (_path: string): Promise<ArrayBuffer> =>
+            new ArrayBuffer(0),
+        remove: async (_path: string): Promise<void> => {
+            // Mock implementation
+        },
     };
 
     async createBinary(_path: string, _data: ArrayBuffer): Promise<void> {
@@ -318,6 +329,11 @@ export class SliderComponent {
 export function normalizePath(path: string): string {
     return path.replace(/\\/g, '/').replace(/\/+/g, '/');
 }
+
+export const Platform = {
+    isMobile: false,
+    isMobileApp: false,
+};
 
 // Type definitions
 export interface PluginManifest {

--- a/tests/unit/RecordingManager.test.ts
+++ b/tests/unit/RecordingManager.test.ts
@@ -15,6 +15,10 @@ jest.mock('obsidian', () => ({
     Notice: jest.fn(),
     MarkdownView: jest.fn(),
     normalizePath: (path: string) => path.replace(/\\/g, '/'),
+    Platform: {
+        isMobile: false,
+        isMobileApp: false,
+    },
 }));
 
 // Mock AudioStreamHandler
@@ -69,6 +73,13 @@ jest.mock('../../src/recording/WavEncoder', () => ({
     getChannelData: jest.fn().mockReturnValue(new Float32Array(44100)),
 }));
 
+if (!Blob.prototype.arrayBuffer) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test polyfill
+    (Blob.prototype as any).arrayBuffer = function (): Promise<ArrayBuffer> {
+        return Promise.resolve(new ArrayBuffer(0));
+    };
+}
+
 describe('RecordingManager', () => {
     let manager: RecordingManager;
     let mockApp: App;
@@ -84,6 +95,10 @@ describe('RecordingManager', () => {
             vault: {
                 adapter: {
                     exists: jest.fn().mockResolvedValue(false),
+                    append: jest.fn().mockResolvedValue(undefined),
+                    rename: jest.fn().mockResolvedValue(undefined),
+                    readBinary: jest.fn().mockResolvedValue(new ArrayBuffer(0)),
+                    remove: jest.fn().mockResolvedValue(undefined),
                 },
                 createBinary: jest.fn().mockResolvedValue(undefined),
             },
@@ -251,6 +266,105 @@ describe('RecordingManager', () => {
         });
     });
 
+    describe('streaming chunks', () => {
+        it('should append chunks to temp file on desktop', async () => {
+            const { Platform } = jest.requireMock('obsidian') as {
+                Platform: { isMobile: boolean; isMobileApp: boolean };
+            };
+            Platform.isMobile = false;
+            Platform.isMobileApp = false;
+
+            const mockMediaRecorder = {
+                start: jest.fn(),
+                stop: jest.fn(),
+                pause: jest.fn(),
+                resume: jest.fn(),
+                ondataavailable: null as ((event: BlobEvent) => void) | null,
+                onerror: null as ((event: Event) => void) | null,
+                addEventListener: jest.fn((event: string, handler: () => void) => {
+                    if (event === 'stop') {
+                        handler();
+                    }
+                }),
+            };
+
+            (global as Record<string, unknown>).MediaRecorder = jest.fn(
+                () => mockMediaRecorder,
+            );
+            (global as Record<string, unknown>).MediaRecorder.isTypeSupported = jest
+                .fn()
+                .mockReturnValue(true);
+
+            const { getAudioStreams } = jest.requireMock('../../src/recording/AudioStreamHandler') as {
+                getAudioStreams: jest.Mock;
+            };
+            getAudioStreams.mockResolvedValue([{
+                getTracks: () => [{ stop: jest.fn() }],
+            }]);
+
+            await manager.startRecording();
+
+            const chunk = new Blob([new Uint8Array([1, 2, 3])], {
+                type: 'audio/webm',
+            });
+            mockMediaRecorder.ondataavailable?.({ data: chunk } as BlobEvent);
+
+            await manager.stopRecording();
+
+            expect(mockApp.vault.adapter.append).toHaveBeenCalled();
+        });
+
+        it('should flush mobile buffer when limit reached', async () => {
+            const { Platform } = jest.requireMock('obsidian') as {
+                Platform: { isMobile: boolean; isMobileApp: boolean };
+            };
+            Platform.isMobile = true;
+            Platform.isMobileApp = true;
+
+            const mockMediaRecorder = {
+                start: jest.fn(),
+                stop: jest.fn(),
+                pause: jest.fn(),
+                resume: jest.fn(),
+                ondataavailable: null as ((event: BlobEvent) => void) | null,
+                onerror: null as ((event: Event) => void) | null,
+                addEventListener: jest.fn((event: string, handler: () => void) => {
+                    if (event === 'stop') {
+                        handler();
+                    }
+                }),
+            };
+
+            (global as Record<string, unknown>).MediaRecorder = jest.fn(
+                () => mockMediaRecorder,
+            );
+            (global as Record<string, unknown>).MediaRecorder.isTypeSupported = jest
+                .fn()
+                .mockReturnValue(true);
+
+            const { getAudioStreams } = jest.requireMock('../../src/recording/AudioStreamHandler') as {
+                getAudioStreams: jest.Mock;
+            };
+            getAudioStreams.mockResolvedValue([{
+                getTracks: () => [{ stop: jest.fn() }],
+            }]);
+
+            await manager.startRecording();
+
+            const target = (manager as unknown as { chunkTargets: Array<{ bufferedBytes: number }> }).chunkTargets[0];
+            target.bufferedBytes = 50 * 1024 * 1024 - 1;
+
+            const chunk = new Blob([new Uint8Array([1])], {
+                type: 'audio/webm',
+            });
+            mockMediaRecorder.ondataavailable?.({ data: chunk } as BlobEvent);
+
+            await manager.stopRecording();
+
+            expect(mockApp.vault.createBinary).toHaveBeenCalled();
+        });
+    });
+
     describe('cleanup', () => {
         it('should reset all internal state', () => {
             manager.cleanup();
@@ -308,7 +422,9 @@ describe('RecordingManager', () => {
             expect(manager.getStatus()).toBe(RecordingStatus.Recording);
 
             // Mock vault to throw error during save
-            (mockApp.vault.createBinary as jest.Mock).mockRejectedValue(new Error('Save failed'));
+            (mockApp.vault.adapter.rename as jest.Mock).mockRejectedValue(
+                new Error('Save failed'),
+            );
 
             // Stop recording - should recover
             await manager.stopRecording();
@@ -326,7 +442,9 @@ describe('RecordingManager', () => {
             await manager.startRecording();
 
             // Mock vault to throw error during save
-            (mockApp.vault.createBinary as jest.Mock).mockRejectedValue(new Error('Save failed'));
+            (mockApp.vault.adapter.rename as jest.Mock).mockRejectedValue(
+                new Error('Save failed'),
+            );
 
             await manager.stopRecording();
 

--- a/tests/unit/RecordingManager.test.ts
+++ b/tests/unit/RecordingManager.test.ts
@@ -305,9 +305,12 @@ describe('RecordingManager', () => {
             const { getAudioStreams } = jest.requireMock('../../src/recording/AudioStreamHandler') as {
                 getAudioStreams: jest.Mock;
             };
-            getAudioStreams.mockResolvedValue([{
-                getTracks: () => [{ stop: jest.fn() }],
-            }]);
+            getAudioStreams.mockResolvedValue({
+                streams: [{
+                    getTracks: () => [{ stop: jest.fn() }],
+                }],
+                trackOrder: [],
+            });
 
             await manager.startRecording();
 
@@ -352,9 +355,12 @@ describe('RecordingManager', () => {
             const { getAudioStreams } = jest.requireMock('../../src/recording/AudioStreamHandler') as {
                 getAudioStreams: jest.Mock;
             };
-            getAudioStreams.mockResolvedValue([{
-                getTracks: () => [{ stop: jest.fn() }],
-            }]);
+            getAudioStreams.mockResolvedValue({
+                streams: [{
+                    getTracks: () => [{ stop: jest.fn() }],
+                }],
+                trackOrder: [],
+            });
 
             await manager.startRecording();
 


### PR DESCRIPTION
### Motivation
- Long recordings accumulate `Blob` chunks in memory and decode them at stop, causing high memory/CPU usage and crashes for 30+ minute sessions.

### Description
- Switch `RecordingManager` to timeslice streaming with `MediaRecorder.start(CHUNK_TIMESLICE_MS)` and introduce per-track `RecordingTarget` structures to manage chunk persistence and state.
- Desktop behavior: append chunk `ArrayBuffer`s to a temporary file using `app.vault.adapter.append` and finalize files by renaming the temp file into the target path via `resolveUniquePath` and `finalizeTrackFiles`.
- Mobile behavior: buffer chunks in-memory with a `50 MB` limit and flush to segmented files using `createBinary` when the limit is reached; multiple segments are produced and returned for a recording session.
- Implemented chunk handling and recovery utilities: `handleChunk`, `flushMobileBuffer`, `buildTrackBlob`, `cleanupIntermediateFiles`, `resolveUniquePath`, and queued `pendingWrite` sequencing to avoid races; added intermediate-file cleanup on merge.
- Tests and mocks updated: added unit tests covering desktop append and mobile flush scenarios; added `Blob.arrayBuffer` test polyfill; extended test `Vault.adapter` mock with `append`, `readBinary`, `rename`, and `remove`.

### Testing
- Ran `npm run lint` and addressed reported issues (prettier/format fixes); lint passed.
- Ran `npm test` and all suites passed: 7 test suites, 84 tests passed (no failures).
- New/updated unit tests exercise chunk streaming, desktop append, and mobile buffer flush behavior and passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a50fa65d48320bac99f4c3c82c7bc)