### PR TITLE
Ensure temporary `.partial` files are cleaned up (or rolled back) after recording finalization

### DIFF
--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -188,10 +188,11 @@ export class AudioRecorderSettingTab extends PluginSettingTab {
 			.setDesc(
 				'Select the default input device for single-track recordings. You can also change it from the command palette.',
 			)
-			.addDropdown(async (dropdown) => {
-				await this.populateAudioDevices(dropdown);
-				dropdown.setValue(this.plugin.settings.audioDeviceId || '');
+			.addDropdown((dropdown) => {
 				this.deviceDropdowns.push(dropdown);
+				void this.populateAudioDevices(dropdown).then(() => {
+					dropdown.setValue(this.plugin.settings.audioDeviceId || '');
+				});
 				dropdown.onChange(async (value) => {
 					this.plugin.settings.audioDeviceId = value;
 					await this.plugin.saveSettings();
@@ -347,13 +348,14 @@ export class AudioRecorderSettingTab extends PluginSettingTab {
 					.setDesc(
 						`Select the input device assigned to track ${String(i)}`,
 					)
-					.addDropdown(async (dropdown) => {
-						await this.populateAudioDevices(dropdown);
-						dropdown.setValue(
-							this.plugin.settings.trackAudioSources.get(i)
-								?.deviceId || '',
-						);
+					.addDropdown((dropdown) => {
 						this.deviceDropdowns.push(dropdown);
+						void this.populateAudioDevices(dropdown).then(() => {
+							dropdown.setValue(
+								this.plugin.settings.trackAudioSources.get(i)
+									?.deviceId || '',
+							);
+						});
 						dropdown.onChange(async (value) => {
 							if (value) {
 								this.plugin.settings.trackAudioSources.set(i, {

--- a/tests/unit/RecordingManager.test.ts
+++ b/tests/unit/RecordingManager.test.ts
@@ -723,6 +723,8 @@ describe('RecordingManager', () => {
                 Notice: jest.Mock;
             };
 
+            const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => { });
+
             const { Platform } = jest.requireMock('obsidian') as {
                 Platform: { isMobile: boolean; isMobileApp: boolean };
             };
@@ -806,6 +808,16 @@ describe('RecordingManager', () => {
             expect(Notice).toHaveBeenCalledWith(
                 expect.stringContaining('Error stopping recording:'),
             );
+            expect(consoleWarnSpy).toHaveBeenCalledWith(
+                expect.stringContaining('[AudioRecorder] Failed to remove intermediate recording file:'),
+                expect.objectContaining({
+                    error: expect.objectContaining({
+                        message: 'cleanup failed',
+                    }),
+                }),
+            );
+
+            consoleWarnSpy.mockRestore();
         });
 
 


### PR DESCRIPTION
### Motivation
- Recording finalization left orphaned `.partial` temporary files in the vault, leading to clutter and user confusion.  
- The cleanup path was not robustly enforced across single/multitrack and WAV conversion flows, allowing cases where the final file is created but temporary artifacts remain.  
- The goal is to guarantee either atomic finalization (final file exists and temporaries are removed) or a clear recovery state where temporaries remain intentionally and the final file is rolled back on cleanup failure.  

### Description
- Added a centralized `removeTemporaryArtifacts(paths, logContext): Promise<string[]>` helper that attempts to remove each path, logs warnings for individual failures, and returns the list of failed paths.  
- Changed `cleanupIntermediateFiles()` to return the list of failed cleanup paths and use the centralized remover.  
- Enforced cleanup-before-success in the merged single-file branch: after writing the merged file the code now calls cleanup and, on any failed cleanup, performs `rollbackFinalFile` (removes the newly created final file) and surfaces an explicit error so `.partial` remains as a recovery artifact.  
- Applied the same safe cleanup + rollback semantics to the WAV conversion path in `finalizeTrackFiles`.  
- Added unit tests covering both the successful cleanup (ensuring `.partial` files are removed) and the cleanup-failure scenario (ensuring rollback of final file and user-visible error flow).  
- Logging added for cleanup failures and rollback errors; comments use English and follow existing TypeScript/Obsidian plugin style.  

### Testing
- Ran the unit test suite with `npm test -- --runInBand` and all tests passed (including new tests in `tests/unit/RecordingManager.test.ts`).  
- Ran `npm run lint` and it completed successfully (existing UI sentence-case warning remains unchanged).  
- Built the project with `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cbaa4feb88320a1e28fde6a6e18ea)