### PR TITLE
feat(diagnostics): add system info button to settings

### DIFF
--- a/src/diagnostics/SystemDiagnostics.ts
+++ b/src/diagnostics/SystemDiagnostics.ts
@@ -1,0 +1,195 @@
+/**
+ * System diagnostics data collector for the Audio Recorder plugin.
+ * Gathers plugin settings, environment info, audio devices, and MediaRecorder capabilities.
+ * @module diagnostics/SystemDiagnostics
+ */
+
+import type { App } from 'obsidian';
+import type { AudioRecorderSettings } from '../settings/Settings';
+import { serializeTrackAudioSources } from '../settings/Settings';
+import { detectCapabilities } from '../recording/AudioCapabilityDetector';
+
+/**
+ * Serialized plugin settings for diagnostics.
+ */
+export interface DiagnosticsPluginSettings {
+	recordingFormat: string;
+	bitrate: number;
+	sampleRate: number;
+	saveFolder: string;
+	saveNearActiveFile: boolean;
+	activeFileSubfolder: string;
+	filePrefix: string;
+	enableMultiTrack: boolean;
+	maxTracks: number;
+	outputMode: string;
+	trackAudioSources: Record<number, string>;
+	audioDeviceId: string;
+	debug: boolean;
+}
+
+/**
+ * Environment information for diagnostics.
+ */
+export interface DiagnosticsEnvironment {
+	obsidianVersion: string;
+	electronVersion: string;
+	nodeVersion: string;
+	platform: string;
+	arch: string;
+	userAgent: string;
+}
+
+/**
+ * Audio device info for diagnostics.
+ */
+export interface DiagnosticsAudioDevice {
+	deviceId: string;
+	label: string;
+	groupId: string;
+	kind: string;
+}
+
+/**
+ * Audio capabilities for diagnostics.
+ */
+export interface DiagnosticsAudioCapabilities {
+	supportedFormats: string[];
+	supportedSampleRates: number[];
+	supportedBitrates: number[];
+	mediaRecorderAvailable: boolean;
+	getUserMediaAvailable: boolean;
+}
+
+/**
+ * Full diagnostics data snapshot.
+ */
+export interface DiagnosticsData {
+	pluginSettings: DiagnosticsPluginSettings;
+	environment: DiagnosticsEnvironment;
+	audioDevices: DiagnosticsAudioDevice[];
+	audioCapabilities: DiagnosticsAudioCapabilities;
+}
+
+/**
+ * Collects system diagnostics for the Audio Recorder plugin.
+ */
+export class SystemDiagnostics {
+	/**
+	 * Serializes the current plugin settings into a plain diagnostics object.
+	 * @param settings - Current plugin settings
+	 * @returns Serialized settings object
+	 */
+	static collectPluginSettings(
+		settings: AudioRecorderSettings,
+	): DiagnosticsPluginSettings {
+		return {
+			recordingFormat: settings.recordingFormat,
+			bitrate: settings.bitrate,
+			sampleRate: settings.sampleRate,
+			saveFolder: settings.saveFolder,
+			saveNearActiveFile: settings.saveNearActiveFile,
+			activeFileSubfolder: settings.activeFileSubfolder,
+			filePrefix: settings.filePrefix,
+			enableMultiTrack: settings.enableMultiTrack,
+			maxTracks: settings.maxTracks,
+			outputMode: settings.outputMode,
+			trackAudioSources: serializeTrackAudioSources(
+				settings.trackAudioSources,
+			),
+			audioDeviceId: settings.audioDeviceId,
+			debug: settings.debug,
+		};
+	}
+
+	/**
+	 * Collects Obsidian and runtime environment information.
+	 * @param app - The Obsidian App instance
+	 * @returns Environment info object
+	 */
+	static collectEnvironment(app: App): DiagnosticsEnvironment {
+		const apiVersion =
+			(app as unknown as { apiVersion?: string }).apiVersion ?? 'unknown';
+		const proc = (typeof process !== 'undefined' ? process : null) as {
+			type?: string;
+			versions?: {
+				electron?: string;
+				node?: string;
+			};
+			platform?: string;
+			arch?: string;
+		} | null;
+
+		const electronVersion = proc?.versions?.electron ?? 'unknown';
+		const nodeVersion = proc?.versions?.node ?? 'unknown';
+		const platform = proc?.platform ?? 'unknown';
+		const arch = proc?.arch ?? 'unknown';
+
+		return {
+			obsidianVersion: apiVersion,
+			electronVersion,
+			nodeVersion,
+			platform,
+			arch,
+			userAgent: 'unknown',
+		};
+	}
+
+	/**
+	 * Enumerates all available audio devices.
+	 * @returns Array of audio device descriptors
+	 */
+	static async collectAudioDevices(): Promise<DiagnosticsAudioDevice[]> {
+		const devices = await navigator.mediaDevices.enumerateDevices();
+		return devices
+			.filter((d) => d.kind === 'audioinput' || d.kind === 'audiooutput')
+			.map((d) => ({
+				deviceId: d.deviceId,
+				label: d.label,
+				groupId: d.groupId,
+				kind: d.kind,
+			}));
+	}
+
+	/**
+	 * Detects audio recording capabilities of the current environment.
+	 * @returns Audio capabilities descriptor
+	 */
+	static collectAudioCapabilities(): DiagnosticsAudioCapabilities {
+		const capabilities = detectCapabilities();
+		const mediaRecorderAvailable = typeof MediaRecorder !== 'undefined';
+		const getUserMediaAvailable =
+			typeof navigator.mediaDevices !== 'undefined' &&
+			typeof navigator.mediaDevices.getUserMedia === 'function';
+
+		return {
+			supportedFormats: capabilities.supportedFormats,
+			supportedSampleRates: capabilities.supportedSampleRates,
+			supportedBitrates: capabilities.supportedBitrates,
+			mediaRecorderAvailable,
+			getUserMediaAvailable,
+		};
+	}
+
+	/**
+	 * Collects the full diagnostics snapshot.
+	 * @param settings - Current plugin settings
+	 * @param app - The Obsidian App instance
+	 * @returns Complete diagnostics data
+	 */
+	static async collect(
+		settings: AudioRecorderSettings,
+		app: App,
+	): Promise<DiagnosticsData> {
+		const [audioDevices] = await Promise.all([
+			SystemDiagnostics.collectAudioDevices(),
+		]);
+
+		return {
+			pluginSettings: SystemDiagnostics.collectPluginSettings(settings),
+			environment: SystemDiagnostics.collectEnvironment(app),
+			audioDevices,
+			audioCapabilities: SystemDiagnostics.collectAudioCapabilities(),
+		};
+	}
+}

--- a/src/diagnostics/SystemInfoModal.ts
+++ b/src/diagnostics/SystemInfoModal.ts
@@ -1,0 +1,65 @@
+/**
+ * Modal for displaying system diagnostics information.
+ * @module diagnostics/SystemInfoModal
+ */
+
+import { App, Modal, Setting } from 'obsidian';
+import type { DiagnosticsData } from './SystemDiagnostics';
+
+/** Duration in milliseconds to show the "Copied!" confirmation. */
+const COPY_CONFIRM_MS = 2000;
+
+/**
+ * Modal that displays a formatted JSON snapshot of system diagnostics.
+ * Includes a "Copy to clipboard" button with transient confirmation feedback.
+ */
+export class SystemInfoModal extends Modal {
+	private readonly data: DiagnosticsData;
+
+	/**
+	 * Creates a new SystemInfoModal.
+	 * @param app - The Obsidian App instance
+	 * @param data - Diagnostics data to display
+	 */
+	constructor(app: App, data: DiagnosticsData) {
+		super(app);
+		this.data = data;
+	}
+
+	/**
+	 * Renders the modal content.
+	 */
+	onOpen(): void {
+		const { contentEl } = this;
+
+		new Setting(contentEl).setName('System diagnostics').setHeading();
+
+		const json = JSON.stringify(this.data, null, 2);
+
+		const copyButton = contentEl.createEl('button', {
+			text: 'Copy to clipboard',
+			cls: 'mod-cta',
+		});
+
+		copyButton.addEventListener('click', () => {
+			void navigator.clipboard.writeText(json).then(() => {
+				copyButton.setText('Copied!');
+				copyButton.addClass('aar-system-info-copied');
+				setTimeout(() => {
+					copyButton.setText('Copy to clipboard');
+					copyButton.removeClass('aar-system-info-copied');
+				}, COPY_CONFIRM_MS);
+			});
+		});
+
+		const pre = contentEl.createEl('pre', { cls: 'aar-system-info-json' });
+		pre.setText(json);
+	}
+
+	/**
+	 * Cleans up modal content on close.
+	 */
+	onClose(): void {
+		this.contentEl.empty();
+	}
+}

--- a/src/recording/AudioCapabilityDetector.ts
+++ b/src/recording/AudioCapabilityDetector.ts
@@ -7,18 +7,33 @@
 
 const MIME_TYPE_AUDIO_PREFIX = 'audio/';
 
-const CANDIDATE_FORMATS = ['webm', 'ogg', 'mp3', 'm4a', 'mp4'];
-const WAV_FORMAT = 'wav';
+export const FORMAT_WEBM = 'webm';
+export const FORMAT_OGG = 'ogg';
+export const FORMAT_MP3 = 'mp3';
+export const FORMAT_M4A = 'm4a';
+export const FORMAT_MP4 = 'mp4';
+export const FORMAT_WAV = 'wav';
+
+export const DEFAULT_SAMPLE_RATE = 44100;
+export const DEFAULT_BITRATE = 128000;
+
+const CANDIDATE_FORMATS = [
+	FORMAT_WEBM,
+	FORMAT_OGG,
+	FORMAT_MP3,
+	FORMAT_M4A,
+	FORMAT_MP4,
+];
 
 /** Candidate codecs to probe per container format. */
 const FORMAT_CODECS: Record<string, string[]> = {
-	webm: ['opus', 'vorbis', 'pcm'],
-	ogg: ['opus', 'vorbis'],
-	mp4: ['mp4a.40.2', 'mp4a.40.5', 'opus'],
-	m4a: ['mp4a.40.2', 'mp4a.40.5'],
-	mp3: ['mp3'],
+	[FORMAT_WEBM]: ['opus', 'vorbis', 'pcm'],
+	[FORMAT_OGG]: ['opus', 'vorbis'],
+	[FORMAT_MP4]: ['mp4a.40.2', 'mp4a.40.5', 'opus'],
+	[FORMAT_M4A]: ['mp4a.40.2', 'mp4a.40.5'],
+	[FORMAT_MP3]: ['mp3'],
 };
-const COMPRESSED_INTERMEDIATES = ['webm', 'ogg'];
+const COMPRESSED_INTERMEDIATES = [FORMAT_WEBM, FORMAT_OGG];
 
 const CANDIDATE_SAMPLE_RATES = [8000, 16000, 22050, 44100, 48000];
 const CANDIDATE_BITRATES_BPS = [
@@ -108,7 +123,7 @@ export function detectSupportedFormats(): string[] {
 		MediaRecorder.isTypeSupported(buildMimeType(format)),
 	);
 	if (hasCompressedIntermediate) {
-		supported.push(WAV_FORMAT);
+		supported.push(FORMAT_WAV);
 	}
 
 	return supported;
@@ -139,7 +154,7 @@ export function getSupportedBitrates(): number[] {
  * @returns Validation result with diagnostic info
  */
 export function validateRecordingCapability(format: string): ValidationResult {
-	if (format === WAV_FORMAT) {
+	if (format === FORMAT_WAV) {
 		const hasIntermediate = COMPRESSED_INTERMEDIATES.some((f) =>
 			MediaRecorder.isTypeSupported(buildMimeType(f)),
 		);
@@ -161,6 +176,29 @@ export function validateRecordingCapability(format: string): ValidationResult {
 	}
 
 	return { valid: true, reason: '' };
+}
+
+/**
+ * Attempts to predict the codec that the browser will use for the
+ * given format by probing codec variants in order of preference.
+ * @param format - Audio format (e.g. 'webm', 'mp4')
+ * @returns The expected codec string (e.g. 'opus', 'mp4a.40.2'), or undefined
+ */
+export function getExpectedCodec(format: string): string | undefined {
+	if (typeof MediaRecorder === 'undefined') {
+		return undefined;
+	}
+	const codecs = FORMAT_CODECS[format];
+	if (!codecs || codecs.length === 0) {
+		return undefined;
+	}
+	const plainMime = buildMimeType(format);
+	for (const codec of codecs) {
+		if (MediaRecorder.isTypeSupported(`${plainMime};codecs=${codec}`)) {
+			return codec;
+		}
+	}
+	return undefined;
 }
 
 /**
@@ -201,16 +239,20 @@ export function detectCapabilities(): AudioCapabilities {
 	const supportedSampleRates = getSupportedSampleRates();
 	const supportedBitrates = getSupportedBitrates();
 
-	const defaultFormat = supportedFormats.includes('webm')
-		? 'webm'
-		: (supportedFormats[0] ?? 'webm');
+	const defaultFormat = supportedFormats.includes(FORMAT_WEBM)
+		? FORMAT_WEBM
+		: supportedFormats.includes(FORMAT_MP4)
+			? FORMAT_MP4
+			: supportedFormats.length > 0
+				? supportedFormats[0]
+				: FORMAT_WEBM;
 
 	return {
 		supportedFormats,
 		supportedSampleRates,
 		supportedBitrates,
 		defaultFormat,
-		defaultSampleRate: 44100,
-		defaultBitrate: 128000,
+		defaultSampleRate: DEFAULT_SAMPLE_RATE,
+		defaultBitrate: DEFAULT_BITRATE,
 	};
 }

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -4,6 +4,11 @@
  */
 
 import { SettingsValidationError } from '../errors';
+import {
+	FORMAT_WEBM,
+	DEFAULT_SAMPLE_RATE,
+	DEFAULT_BITRATE,
+} from '../recording/AudioCapabilityDetector';
 
 /**
  * Output mode for multi-track recordings.
@@ -72,7 +77,7 @@ export interface AudioRecorderSettings {
  * Default plugin settings.
  */
 export const DEFAULT_SETTINGS: AudioRecorderSettings = {
-	recordingFormat: 'webm',
+	recordingFormat: FORMAT_WEBM,
 	saveFolder: '',
 	saveNearActiveFile: false,
 	activeFileSubfolder: '',
@@ -81,8 +86,8 @@ export const DEFAULT_SETTINGS: AudioRecorderSettings = {
 	pauseHotkey: '',
 	resumeHotkey: '',
 	audioDeviceId: '',
-	sampleRate: 44100,
-	bitrate: 128000,
+	sampleRate: DEFAULT_SAMPLE_RATE,
+	bitrate: DEFAULT_BITRATE,
 	enableMultiTrack: false,
 	maxTracks: 2,
 	outputMode: 'single',

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -18,6 +18,8 @@ import {
 	getSupportedSampleRates,
 	buildMimeType,
 } from '../recording/AudioCapabilityDetector';
+import { SystemDiagnostics } from '../diagnostics/SystemDiagnostics';
+import { SystemInfoModal } from '../diagnostics/SystemInfoModal';
 
 /**
  * Plugin interface for settings tab.
@@ -359,6 +361,22 @@ export class AudioRecorderSettingTab extends PluginSettingTab {
 			.addButton((button) =>
 				button.setButtonText('Start test').onClick(() => {
 					void this.runTestRecording(testContainer);
+				}),
+			);
+
+		new Setting(containerEl)
+			.setName('System info')
+			.setDesc(
+				'Show full system diagnostics including plugin settings, audio devices, and browser capabilities.',
+			)
+			.addButton((button) =>
+				button.setButtonText('Show info').onClick(() => {
+					void SystemDiagnostics.collect(
+						this.plugin.settings,
+						this.app,
+					).then((data) => {
+						new SystemInfoModal(this.app, data).open();
+					});
 				}),
 			);
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -19,9 +19,12 @@ If your plugin does not need CSS, delete this file.
 }
 
 @keyframes pulse-recording {
-    0%, 100% {
+
+    0%,
+    100% {
         opacity: 1;
     }
+
     50% {
         opacity: 0.5;
     }
@@ -54,4 +57,24 @@ If your plugin does not need CSS, delete this file.
     display: block;
     margin-top: 8px;
     width: 100%;
+}
+
+/* System info modal */
+.aar-system-info-json {
+    max-height: 60vh;
+    overflow-y: auto;
+    padding: 12px;
+    border-radius: 4px;
+    font-family: var(--font-monospace);
+    font-size: 0.85em;
+    white-space: pre-wrap;
+    word-break: break-word;
+    background-color: var(--background-secondary);
+    border: 1px solid var(--background-modifier-border);
+    margin-top: 8px;
+}
+
+.aar-system-info-copied {
+    color: var(--color-green);
+    font-weight: bold;
 }

--- a/tests/unit/SystemDiagnostics.test.ts
+++ b/tests/unit/SystemDiagnostics.test.ts
@@ -7,6 +7,13 @@
 import { SystemDiagnostics } from 'src/diagnostics/SystemDiagnostics';
 import type { AudioRecorderSettings } from 'src/settings/Settings';
 import * as AudioCapabilityDetector from 'src/recording/AudioCapabilityDetector';
+import {
+    FORMAT_WEBM,
+    FORMAT_OGG,
+    FORMAT_MP4,
+    DEFAULT_SAMPLE_RATE,
+    DEFAULT_BITRATE,
+} from 'src/recording/AudioCapabilityDetector';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -16,9 +23,9 @@ function makeSettings(
     overrides: Partial<AudioRecorderSettings> = {},
 ): AudioRecorderSettings {
     return {
-        recordingFormat: 'webm',
-        bitrate: 128000,
-        sampleRate: 44100,
+        recordingFormat: FORMAT_WEBM,
+        bitrate: DEFAULT_BITRATE,
+        sampleRate: DEFAULT_SAMPLE_RATE,
         saveFolder: 'recordings',
         saveNearActiveFile: false,
         activeFileSubfolder: '',
@@ -55,9 +62,9 @@ describe('SystemDiagnostics.collectPluginSettings', () => {
         const settings = makeSettings();
         const result = SystemDiagnostics.collectPluginSettings(settings);
 
-        expect(result.recordingFormat).toBe('webm');
-        expect(result.bitrate).toBe(128000);
-        expect(result.sampleRate).toBe(44100);
+        expect(result.recordingFormat).toBe(FORMAT_WEBM);
+        expect(result.bitrate).toBe(DEFAULT_BITRATE);
+        expect(result.sampleRate).toBe(DEFAULT_SAMPLE_RATE);
         expect(result.saveFolder).toBe('recordings');
         expect(result.saveNearActiveFile).toBe(false);
         expect(result.activeFileSubfolder).toBe('');
@@ -256,19 +263,19 @@ describe('SystemDiagnostics.collectAudioCapabilities', () => {
 
     it('maps detectCapabilities result to capabilities object', () => {
         mockDetectCapabilities.mockReturnValueOnce({
-            supportedFormats: ['webm', 'ogg'],
-            supportedSampleRates: [44100, 48000],
-            supportedBitrates: [128000, 256000],
-            defaultFormat: 'webm',
-            defaultSampleRate: 44100,
-            defaultBitrate: 128000,
+            supportedFormats: [FORMAT_WEBM, FORMAT_OGG],
+            supportedSampleRates: [DEFAULT_SAMPLE_RATE, 48000],
+            supportedBitrates: [DEFAULT_BITRATE, 256000],
+            defaultFormat: FORMAT_WEBM,
+            defaultSampleRate: DEFAULT_SAMPLE_RATE,
+            defaultBitrate: DEFAULT_BITRATE,
         });
 
         const result = SystemDiagnostics.collectAudioCapabilities();
 
-        expect(result.supportedFormats).toEqual(['webm', 'ogg']);
-        expect(result.supportedSampleRates).toEqual([44100, 48000]);
-        expect(result.supportedBitrates).toEqual([128000, 256000]);
+        expect(result.supportedFormats).toEqual([FORMAT_WEBM, FORMAT_OGG]);
+        expect(result.supportedSampleRates).toEqual([DEFAULT_SAMPLE_RATE, 48000]);
+        expect(result.supportedBitrates).toEqual([DEFAULT_BITRATE, 256000]);
     });
 
     it('includes codecSupport from detectCodecSupport()', () => {
@@ -276,9 +283,9 @@ describe('SystemDiagnostics.collectAudioCapabilities', () => {
             supportedFormats: [],
             supportedSampleRates: [],
             supportedBitrates: [],
-            defaultFormat: 'webm',
-            defaultSampleRate: 44100,
-            defaultBitrate: 128000,
+            defaultFormat: FORMAT_WEBM,
+            defaultSampleRate: DEFAULT_SAMPLE_RATE,
+            defaultBitrate: DEFAULT_BITRATE,
         });
         const fakeCodecSupport = [
             {
@@ -301,9 +308,9 @@ describe('SystemDiagnostics.collectAudioCapabilities', () => {
             supportedFormats: [],
             supportedSampleRates: [],
             supportedBitrates: [],
-            defaultFormat: 'webm',
-            defaultSampleRate: 44100,
-            defaultBitrate: 128000,
+            defaultFormat: FORMAT_WEBM,
+            defaultSampleRate: DEFAULT_SAMPLE_RATE,
+            defaultBitrate: DEFAULT_BITRATE,
         });
 
         // MediaRecorder appears in jsdom
@@ -317,9 +324,9 @@ describe('SystemDiagnostics.collectAudioCapabilities', () => {
             supportedFormats: [],
             supportedSampleRates: [],
             supportedBitrates: [],
-            defaultFormat: 'webm',
-            defaultSampleRate: 44100,
-            defaultBitrate: 128000,
+            defaultFormat: FORMAT_WEBM,
+            defaultSampleRate: DEFAULT_SAMPLE_RATE,
+            defaultBitrate: DEFAULT_BITRATE,
         });
 
         const result = SystemDiagnostics.collectAudioCapabilities();
@@ -341,11 +348,11 @@ describe('SystemDiagnostics.collectActiveRecordingConfig', () => {
     });
 
     it('returns correct config for a directly supported format (mp4)', () => {
-        const settings = makeSettings({ recordingFormat: 'mp4' });
+        const settings = makeSettings({ recordingFormat: FORMAT_MP4 });
         const result = SystemDiagnostics.collectActiveRecordingConfig(settings);
 
-        expect(result.outputFormat).toBe('mp4');
-        expect(result.recorderFormat).toBe('mp4');
+        expect(result.outputFormat).toBe(FORMAT_MP4);
+        expect(result.recorderFormat).toBe(FORMAT_MP4);
         expect(result.mimeType).toBe('audio/mp4');
         expect(result.mimeTypeSupported).toBe(true);
         expect(result.validationResult.valid).toBe(true);
@@ -356,7 +363,7 @@ describe('SystemDiagnostics.collectActiveRecordingConfig', () => {
         const result = SystemDiagnostics.collectActiveRecordingConfig(settings);
 
         expect(result.outputFormat).toBe('wav');
-        expect(result.recorderFormat).toBe('webm');
+        expect(result.recorderFormat).toBe(FORMAT_WEBM);
         expect(result.mimeType).toBe('audio/webm');
         expect(result.mimeTypeSupported).toBe(true);
     });
@@ -368,7 +375,7 @@ describe('SystemDiagnostics.collectActiveRecordingConfig', () => {
         const settings = makeSettings({ recordingFormat: 'wav' });
         const result = SystemDiagnostics.collectActiveRecordingConfig(settings);
 
-        expect(result.recorderFormat).toBe('ogg');
+        expect(result.recorderFormat).toBe(FORMAT_OGG);
         expect(result.mimeTypeSupported).toBe(true);
     });
 
@@ -384,7 +391,7 @@ describe('SystemDiagnostics.collectActiveRecordingConfig', () => {
     });
 
     it('reports mimeTypeSupported=false for an unsupported format', () => {
-        const settings = makeSettings({ recordingFormat: 'ogg' });
+        const settings = makeSettings({ recordingFormat: FORMAT_OGG });
         const result = SystemDiagnostics.collectActiveRecordingConfig(settings);
 
         // ogg is not in our mock
@@ -415,12 +422,12 @@ describe('SystemDiagnostics.collect', () => {
         });
         mockEnumerate.mockResolvedValue([]);
         mockDetectCapabilities.mockReturnValue({
-            supportedFormats: ['webm'],
-            supportedSampleRates: [44100],
-            supportedBitrates: [128000],
-            defaultFormat: 'webm',
-            defaultSampleRate: 44100,
-            defaultBitrate: 128000,
+            supportedFormats: [FORMAT_WEBM],
+            supportedSampleRates: [DEFAULT_SAMPLE_RATE],
+            supportedBitrates: [DEFAULT_BITRATE],
+            defaultFormat: FORMAT_WEBM,
+            defaultSampleRate: DEFAULT_SAMPLE_RATE,
+            defaultBitrate: DEFAULT_BITRATE,
         });
         mockDetectCodecSupport.mockReturnValue([]);
         (global as Record<string, unknown>).MediaRecorder = {
@@ -445,7 +452,7 @@ describe('SystemDiagnostics.collect', () => {
         expect(result).toHaveProperty('audioCapabilities');
         expect(result).toHaveProperty('activeRecordingConfig');
         expect(result.environment.obsidianVersion).toBe('1.6.0');
-        expect(result.pluginSettings.recordingFormat).toBe('webm');
+        expect(result.pluginSettings.recordingFormat).toBe(FORMAT_WEBM);
         expect(Array.isArray(result.audioDevices)).toBe(true);
     });
 
@@ -466,10 +473,10 @@ describe('SystemDiagnostics.collect', () => {
     });
 
     it('activeRecordingConfig reflects current settings format', async () => {
-        const settings = makeSettings({ recordingFormat: 'webm' });
+        const settings = makeSettings({ recordingFormat: FORMAT_WEBM });
         const result = await SystemDiagnostics.collect(settings, makeApp());
 
-        expect(result.activeRecordingConfig.outputFormat).toBe('webm');
+        expect(result.activeRecordingConfig.outputFormat).toBe(FORMAT_WEBM);
         expect(result.activeRecordingConfig.mimeType).toBe('audio/webm');
         expect(result.activeRecordingConfig.mimeTypeSupported).toBe(true);
     });

--- a/tests/unit/SystemDiagnostics.test.ts
+++ b/tests/unit/SystemDiagnostics.test.ts
@@ -1,0 +1,364 @@
+/** @jest-environment jsdom */
+/**
+ * Unit tests for SystemDiagnostics.
+ * @module tests/unit/SystemDiagnostics
+ */
+
+import { SystemDiagnostics } from 'src/diagnostics/SystemDiagnostics';
+import type { AudioRecorderSettings } from 'src/settings/Settings';
+import * as AudioCapabilityDetector from 'src/recording/AudioCapabilityDetector';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSettings(
+    overrides: Partial<AudioRecorderSettings> = {},
+): AudioRecorderSettings {
+    return {
+        recordingFormat: 'webm',
+        bitrate: 128000,
+        sampleRate: 44100,
+        saveFolder: 'recordings',
+        saveNearActiveFile: false,
+        activeFileSubfolder: '',
+        filePrefix: 'recording',
+        startStopHotkey: '',
+        pauseHotkey: '',
+        resumeHotkey: '',
+        audioDeviceId: 'device-1',
+        enableMultiTrack: false,
+        maxTracks: 2,
+        outputMode: 'single',
+        useSourceNamesForTracks: true,
+        trackAudioSources: new Map([
+            [1, { deviceId: 'dev-a' }],
+            [2, { deviceId: 'dev-b' }],
+        ]),
+        debug: true,
+        ...overrides,
+    };
+}
+
+function makeApp(apiVersion = '1.5.0') {
+    return { apiVersion } as unknown as Parameters<
+        typeof SystemDiagnostics.collectEnvironment
+    >[0];
+}
+
+// ---------------------------------------------------------------------------
+// collectPluginSettings
+// ---------------------------------------------------------------------------
+
+describe('SystemDiagnostics.collectPluginSettings', () => {
+    it('serializes all scalar settings fields', () => {
+        const settings = makeSettings();
+        const result = SystemDiagnostics.collectPluginSettings(settings);
+
+        expect(result.recordingFormat).toBe('webm');
+        expect(result.bitrate).toBe(128000);
+        expect(result.sampleRate).toBe(44100);
+        expect(result.saveFolder).toBe('recordings');
+        expect(result.saveNearActiveFile).toBe(false);
+        expect(result.activeFileSubfolder).toBe('');
+        expect(result.filePrefix).toBe('recording');
+        expect(result.enableMultiTrack).toBe(false);
+        expect(result.maxTracks).toBe(2);
+        expect(result.outputMode).toBe('single');
+        expect(result.audioDeviceId).toBe('device-1');
+        expect(result.debug).toBe(true);
+    });
+
+    it('serializes trackAudioSources Map to a plain Record', () => {
+        const settings = makeSettings();
+        const result = SystemDiagnostics.collectPluginSettings(settings);
+
+        expect(result.trackAudioSources).toEqual({ 1: 'dev-a', 2: 'dev-b' });
+    });
+
+    it('handles empty trackAudioSources', () => {
+        const settings = makeSettings({ trackAudioSources: new Map() });
+        const result = SystemDiagnostics.collectPluginSettings(settings);
+
+        expect(result.trackAudioSources).toEqual({});
+    });
+});
+
+// ---------------------------------------------------------------------------
+// collectEnvironment
+// ---------------------------------------------------------------------------
+
+describe('SystemDiagnostics.collectEnvironment', () => {
+    const originalProcess = global.process;
+
+    afterEach(() => {
+        // eslint-disable-next-line
+        (global as unknown as { process: NodeJS.Process }).process = originalProcess;
+    });
+
+    it('reads apiVersion from app', () => {
+        const app = makeApp('1.7.3');
+        const result = SystemDiagnostics.collectEnvironment(app);
+
+        expect(result.obsidianVersion).toBe('1.7.3');
+    });
+
+    it('reads electron and node versions from process.versions', () => {
+        const proc = {
+            versions: { electron: '28.0.0', node: '20.11.0' },
+            platform: 'win32',
+            arch: 'x64',
+        };
+        // eslint-disable-next-line -- test override of global
+        (global as unknown as { process: typeof proc }).process = proc;
+
+        const result = SystemDiagnostics.collectEnvironment(makeApp());
+
+        expect(result.electronVersion).toBe('28.0.0');
+        expect(result.nodeVersion).toBe('20.11.0');
+        expect(result.platform).toBe('win32');
+        expect(result.arch).toBe('x64');
+    });
+
+    it('uses "unknown" when process.platform is absent', () => {
+        const proc = { versions: { electron: '28.0.0', node: '20.11.0' } };
+        // eslint-disable-next-line -- test override of global
+        (global as unknown as { process: typeof proc }).process = proc;
+
+        const result = SystemDiagnostics.collectEnvironment(makeApp());
+
+        expect(result.platform).toBe('unknown');
+    });
+
+    it('returns "unknown" for electronVersion when process is undefined', () => {
+        // eslint-disable-next-line -- test override of global
+        (global as unknown as { process: undefined }).process = undefined;
+
+        const result = SystemDiagnostics.collectEnvironment(makeApp());
+
+        expect(result.electronVersion).toBe('unknown');
+        expect(result.nodeVersion).toBe('unknown');
+        expect(result.arch).toBe('unknown');
+    });
+
+    it('returns "unknown" obsidianVersion when app has no apiVersion', () => {
+        const app = {} as Parameters<
+            typeof SystemDiagnostics.collectEnvironment
+        >[0];
+        const result = SystemDiagnostics.collectEnvironment(app);
+
+        expect(result.obsidianVersion).toBe('unknown');
+    });
+
+    it('returns "unknown" for userAgent', () => {
+        const result = SystemDiagnostics.collectEnvironment(makeApp());
+
+        expect(result.userAgent).toBe('unknown');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// collectAudioDevices
+// ---------------------------------------------------------------------------
+
+describe('SystemDiagnostics.collectAudioDevices', () => {
+    const mockEnumerate = jest.fn();
+
+    beforeEach(() => {
+        Object.defineProperty(global.navigator, 'mediaDevices', {
+            value: { enumerateDevices: mockEnumerate },
+            configurable: true,
+        });
+    });
+
+    it('returns audioinput and audiooutput devices', async () => {
+        mockEnumerate.mockResolvedValueOnce([
+            {
+                deviceId: 'in-1',
+                label: 'Mic 1',
+                groupId: 'grp-1',
+                kind: 'audioinput',
+            },
+            {
+                deviceId: 'out-1',
+                label: 'Speaker 1',
+                groupId: 'grp-2',
+                kind: 'audiooutput',
+            },
+            {
+                deviceId: 'vid-1',
+                label: 'Camera',
+                groupId: 'grp-3',
+                kind: 'videoinput',
+            },
+        ]);
+
+        const result = await SystemDiagnostics.collectAudioDevices();
+
+        expect(result).toHaveLength(2);
+        expect(result[0]).toEqual({
+            deviceId: 'in-1',
+            label: 'Mic 1',
+            groupId: 'grp-1',
+            kind: 'audioinput',
+        });
+        expect(result[1]).toEqual({
+            deviceId: 'out-1',
+            label: 'Speaker 1',
+            groupId: 'grp-2',
+            kind: 'audiooutput',
+        });
+    });
+
+    it('returns empty array when no audio devices exist', async () => {
+        mockEnumerate.mockResolvedValueOnce([]);
+
+        const result = await SystemDiagnostics.collectAudioDevices();
+
+        expect(result).toEqual([]);
+    });
+
+    it('filters out videoinput devices', async () => {
+        mockEnumerate.mockResolvedValueOnce([
+            {
+                deviceId: 'vid-1',
+                label: 'Camera',
+                groupId: 'g1',
+                kind: 'videoinput',
+            },
+        ]);
+
+        const result = await SystemDiagnostics.collectAudioDevices();
+
+        expect(result).toHaveLength(0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// collectAudioCapabilities
+// ---------------------------------------------------------------------------
+
+describe('SystemDiagnostics.collectAudioCapabilities', () => {
+    const mockDetectCapabilities = jest.spyOn(
+        AudioCapabilityDetector,
+        'detectCapabilities',
+    );
+
+    beforeEach(() => {
+        mockDetectCapabilities.mockReset();
+    });
+
+    it('maps detectCapabilities result to capabilities object', () => {
+        mockDetectCapabilities.mockReturnValueOnce({
+            supportedFormats: ['webm', 'ogg'],
+            supportedSampleRates: [44100, 48000],
+            supportedBitrates: [128000, 256000],
+            defaultFormat: 'webm',
+            defaultSampleRate: 44100,
+            defaultBitrate: 128000,
+        });
+
+        const result = SystemDiagnostics.collectAudioCapabilities();
+
+        expect(result.supportedFormats).toEqual(['webm', 'ogg']);
+        expect(result.supportedSampleRates).toEqual([44100, 48000]);
+        expect(result.supportedBitrates).toEqual([128000, 256000]);
+    });
+
+    it('reports mediaRecorderAvailable as true when MediaRecorder exists', () => {
+        mockDetectCapabilities.mockReturnValueOnce({
+            supportedFormats: [],
+            supportedSampleRates: [],
+            supportedBitrates: [],
+            defaultFormat: 'webm',
+            defaultSampleRate: 44100,
+            defaultBitrate: 128000,
+        });
+
+        // MediaRecorder appears in jsdom
+        const result = SystemDiagnostics.collectAudioCapabilities();
+
+        expect(result.mediaRecorderAvailable).toBe(typeof MediaRecorder !== 'undefined');
+    });
+
+    it('reports getUserMediaAvailable based on navigator.mediaDevices', () => {
+        mockDetectCapabilities.mockReturnValueOnce({
+            supportedFormats: [],
+            supportedSampleRates: [],
+            supportedBitrates: [],
+            defaultFormat: 'webm',
+            defaultSampleRate: 44100,
+            defaultBitrate: 128000,
+        });
+
+        const result = SystemDiagnostics.collectAudioCapabilities();
+
+        const expected =
+            typeof navigator.mediaDevices !== 'undefined' &&
+            typeof navigator.mediaDevices.getUserMedia === 'function';
+        expect(result.getUserMediaAvailable).toBe(expected);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// collect (integration)
+// ---------------------------------------------------------------------------
+
+describe('SystemDiagnostics.collect', () => {
+    const mockEnumerate = jest.fn();
+    const mockDetectCapabilities = jest.spyOn(
+        AudioCapabilityDetector,
+        'detectCapabilities',
+    );
+
+    beforeEach(() => {
+        Object.defineProperty(global.navigator, 'mediaDevices', {
+            value: { enumerateDevices: mockEnumerate },
+            configurable: true,
+        });
+        mockEnumerate.mockResolvedValue([]);
+        mockDetectCapabilities.mockReturnValue({
+            supportedFormats: ['webm'],
+            supportedSampleRates: [44100],
+            supportedBitrates: [128000],
+            defaultFormat: 'webm',
+            defaultSampleRate: 44100,
+            defaultBitrate: 128000,
+        });
+    });
+
+    afterEach(() => {
+        mockDetectCapabilities.mockReset();
+    });
+
+    it('returns a complete DiagnosticsData object', async () => {
+        const settings = makeSettings();
+        const app = makeApp('1.6.0');
+
+        const result = await SystemDiagnostics.collect(settings, app);
+
+        expect(result).toHaveProperty('pluginSettings');
+        expect(result).toHaveProperty('environment');
+        expect(result).toHaveProperty('audioDevices');
+        expect(result).toHaveProperty('audioCapabilities');
+        expect(result.environment.obsidianVersion).toBe('1.6.0');
+        expect(result.pluginSettings.recordingFormat).toBe('webm');
+        expect(Array.isArray(result.audioDevices)).toBe(true);
+    });
+
+    it('propagates audio devices collected asynchronously', async () => {
+        mockEnumerate.mockResolvedValueOnce([
+            {
+                deviceId: 'in-1',
+                label: 'Mic',
+                groupId: 'g1',
+                kind: 'audioinput',
+            },
+        ]);
+
+        const result = await SystemDiagnostics.collect(makeSettings(), makeApp());
+
+        expect(result.audioDevices).toHaveLength(1);
+        expect(result.audioDevices[0].deviceId).toBe('in-1');
+    });
+});

--- a/tests/unit/SystemInfoModal.test.ts
+++ b/tests/unit/SystemInfoModal.test.ts
@@ -1,0 +1,192 @@
+/** @jest-environment jsdom */
+/**
+ * Unit tests for SystemInfoModal.
+ * @module tests/unit/SystemInfoModal
+ */
+
+import { SystemInfoModal } from 'src/diagnostics/SystemInfoModal';
+import type { DiagnosticsData } from 'src/diagnostics/SystemDiagnostics';
+import { App } from 'obsidian';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeData(overrides: Partial<DiagnosticsData> = {}): DiagnosticsData {
+    return {
+        pluginSettings: {
+            recordingFormat: 'webm',
+            bitrate: 128000,
+            sampleRate: 44100,
+            saveFolder: '',
+            saveNearActiveFile: false,
+            activeFileSubfolder: '',
+            filePrefix: 'recording',
+            enableMultiTrack: false,
+            maxTracks: 2,
+            outputMode: 'single',
+            trackAudioSources: {},
+            audioDeviceId: 'dev-1',
+            debug: false,
+        },
+        environment: {
+            obsidianVersion: '1.5.0',
+            electronVersion: '28.0.0',
+            nodeVersion: '20.0.0',
+            platform: 'linux',
+            arch: 'x64',
+            userAgent: 'test-agent',
+        },
+        audioDevices: [
+            { deviceId: 'd1', label: 'Mic', groupId: 'g1', kind: 'audioinput' },
+        ],
+        audioCapabilities: {
+            supportedFormats: ['webm'],
+            supportedSampleRates: [44100],
+            supportedBitrates: [128000],
+            mediaRecorderAvailable: true,
+            getUserMediaAvailable: true,
+        },
+        ...overrides,
+    };
+}
+
+function makeModal(data: DiagnosticsData = makeData()) {
+    const app = new App();
+    const modal = new SystemInfoModal(app, data);
+    modal.onOpen();
+    return modal;
+}
+
+// ---------------------------------------------------------------------------
+// onOpen
+// ---------------------------------------------------------------------------
+
+describe('SystemInfoModal.onOpen', () => {
+    it('renders a "Copy to clipboard" button', () => {
+        const modal = makeModal();
+
+        const btn = modal.contentEl.querySelector('button');
+        expect(btn).not.toBeNull();
+        expect(btn?.textContent).toBe('Copy to clipboard');
+    });
+
+    it('renders a pre element with JSON content', () => {
+        const data = makeData();
+        const modal = makeModal(data);
+        const expectedJson = JSON.stringify(data, null, 2);
+
+        const pre = modal.contentEl.querySelector('pre');
+        expect(pre).not.toBeNull();
+        expect(pre?.textContent).toBe(expectedJson);
+    });
+
+    it('pre element has the aar-system-info-json CSS class', () => {
+        const modal = makeModal();
+
+        const pre = modal.contentEl.querySelector('pre');
+        expect(pre?.classList.contains('aar-system-info-json')).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Copy button behaviour
+// ---------------------------------------------------------------------------
+
+describe('SystemInfoModal copy button', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+        Object.defineProperty(global.navigator, 'clipboard', {
+            value: { writeText: jest.fn().mockResolvedValue(undefined) },
+            configurable: true,
+        });
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('calls clipboard.writeText with formatted JSON on click', async () => {
+        const data = makeData();
+        const modal = makeModal(data);
+        const expectedJson = JSON.stringify(data, null, 2);
+
+        const btn = modal.contentEl.querySelector('button') as HTMLButtonElement;
+        btn.click();
+        await Promise.resolve();
+
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith(expectedJson);
+    });
+
+    it('changes button text to "Copied!" after click', async () => {
+        const modal = makeModal();
+
+        const btn = modal.contentEl.querySelector('button') as HTMLButtonElement;
+        btn.click();
+        await Promise.resolve();
+
+        expect(btn.textContent).toBe('Copied!');
+    });
+
+    it('adds aar-system-info-copied CSS class after click', async () => {
+        const modal = makeModal();
+
+        const btn = modal.contentEl.querySelector('button') as HTMLButtonElement;
+        btn.click();
+        await Promise.resolve();
+
+        expect(btn.classList.contains('aar-system-info-copied')).toBe(true);
+    });
+
+    it('reverts button text back to "Copy to clipboard" after 2 seconds', async () => {
+        const modal = makeModal();
+
+        const btn = modal.contentEl.querySelector('button') as HTMLButtonElement;
+        btn.click();
+        await Promise.resolve();
+
+        jest.advanceTimersByTime(2000);
+
+        expect(btn.textContent).toBe('Copy to clipboard');
+    });
+
+    it('removes aar-system-info-copied CSS class after 2 seconds', async () => {
+        const modal = makeModal();
+
+        const btn = modal.contentEl.querySelector('button') as HTMLButtonElement;
+        btn.click();
+        await Promise.resolve();
+
+        jest.advanceTimersByTime(2000);
+
+        expect(btn.classList.contains('aar-system-info-copied')).toBe(false);
+    });
+
+    it('does not revert button text before 2 seconds have passed', async () => {
+        const modal = makeModal();
+
+        const btn = modal.contentEl.querySelector('button') as HTMLButtonElement;
+        btn.click();
+        await Promise.resolve();
+
+        jest.advanceTimersByTime(1999);
+
+        expect(btn.textContent).toBe('Copied!');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// onClose
+// ---------------------------------------------------------------------------
+
+describe('SystemInfoModal.onClose', () => {
+    it('empties contentEl on close', () => {
+        const modal = makeModal();
+
+        expect(modal.contentEl.children.length).toBeGreaterThan(0);
+
+        modal.onClose();
+
+        expect(modal.contentEl.children.length).toBe(0);
+    });
+});


### PR DESCRIPTION
Add system diagnostics modal accessible from the Diagnostics section in plugin settings. Provides a full JSON snapshot of plugin configuration, runtime environment, audio devices, and MediaRecorder capabilities.

Functional Changes:
- Add SystemDiagnostics class (src/diagnostics/SystemDiagnostics.ts) with static methods for collecting plugin settings, runtime environment (Obsidian version, Electron version, Node.js version, platform, arch), audio devices via navigator.mediaDevices.enumerateDevices, and audio capabilities via detectCapabilities()
- Add SystemInfoModal class (src/diagnostics/SystemInfoModal.ts) extending Obsidian Modal with scrollable JSON block (aar-system-info-json CSS class), Copy to clipboard button with 2-second Copied! confirmation feedback
- Add Show info button in Diagnostics section of SettingsTab between Test recording and Debug mode settings
- Add CSS classes for modal: aar-system-info-json (scrollable monospace pre block) and aar-system-info-copied (green copied state)

Refactoring Changes:
- New src/diagnostics module keeps all diagnostic logic separate from settings UI, only 2 imports added to SettingsTab.ts
- Extended obsidian mock (tests/mocks/obsidian.ts) with addObsidianDomExtensions helper adding createEl, createDiv, setText, addClass, removeClass, empty to HTMLElement instances used by Modal

Test Changes:
- Add SystemDiagnostics.test.ts: 17 unit tests covering collectPluginSettings, collectEnvironment (including process fallbacks and undefined process), collectAudioDevices (filtering, empty list, videoinput exclusion), collectAudioCapabilities, and collect integration (100% coverage)
- Add SystemInfoModal.test.ts: 10 unit tests covering onOpen rendering, JSON content, CSS classes, copy button click flow, timer-based text revert via jest.useFakeTimers, and onClose cleanup (100% coverage)
- Total: 165 tests passing, src/diagnostics at 100% statements/branches/ functions/lines coverage