### PR TITLE
fix(lint): resolve Obsidian plugin lint errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "advanced-audio-recorder",
-  "version": "1.2.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "advanced-audio-recorder",
-      "version": "1.2.0",
+      "version": "1.3.1",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.0",

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -119,7 +119,7 @@ export class AudioRecorderSettingTab extends PluginSettingTab {
 		new Setting(containerEl)
 			.setName('Sample rate')
 			.setDesc(
-				'Audio sample rate in hertz. 44.1 kHz or 48 kHz recommended for voice and general recording.',
+				'Audio sample rate in hertz. For voice and general recording, 44.1 kHz or 48 kHz are recommended.',
 			)
 			.addDropdown((dropdown) => {
 				const sampleRates = getSupportedSampleRates();

--- a/src/utils/AudioFileAnalyzer.ts
+++ b/src/utils/AudioFileAnalyzer.ts
@@ -43,7 +43,7 @@ export async function getAudioFileInfo(
 				'[AudioRecorder] AudioContext is not supported in this environment.',
 			);
 			new Notice(
-				'AudioContext is not supported. Cannot extract audio metadata.',
+				'Audio context is not supported. Cannot extract audio metadata.',
 			);
 			return null;
 		}

--- a/tests/unit/AudioFileAnalyzer.test.ts
+++ b/tests/unit/AudioFileAnalyzer.test.ts
@@ -156,7 +156,9 @@ describe('getAudioFileInfo', () => {
 
         const result = await getAudioFileInfo(app, file);
         expect(result).toBeNull();
-        expect(Notice).toHaveBeenCalledWith('AudioContext is not supported. Cannot extract audio metadata.');
+        expect(Notice).toHaveBeenCalledWith(
+            'Audio context is not supported. Cannot extract audio metadata.',
+        );
 
         consoleSpy.mockRestore();
     });


### PR DESCRIPTION
- Use sentence case for UI text in SettingsTab and AudioFileAnalyzer
- Replace any with EditorWithCM and MarkdownView|MarkdownFileInfo in ContextMenu
- Remove eslint-disable directives for no-explicit-any
- Update AudioFileAnalyzer test for new Notice message
