### PR TITLE
fix(recorder): resolve long WAV recordings failing to save

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,25 @@ You can delete recordings using the context menu in two ways:
 
 - Available formats depend on your platform and browser **MediaRecorder** support.
 - Common options on most systems include: `webm`, `wav`, and `ogg`.
-- When **WAV** is selected, recording is captured in a compressed format and converted to WAV on save to ensure data integrity.
+- When **WAV** is selected on desktop, audio is captured as raw PCM in real time and assembled into a WAV file on save. This avoids memory-intensive post-hoc decoding and supports long recordings reliably.
 - In multi-track mode:
   - **Single file** output combines tracks into one file.
   - **Multiple files** output saves one file per track.
+
+## Save progress indicator
+
+For longer recordings, the save process (flushing buffers, assembling audio, writing the final file, and cleaning up temporary data) can take noticeable time. During this phase the plugin shows a progress bar in the status bar and a save icon in the ribbon so you always know what is happening:
+
+| Progress | Status |
+|----------|--------|
+| 0% | Saving... |
+| 20% | Flushing buffers... |
+| 40% | Assembling audio... |
+| 60% | Writing file... |
+| 80% | Cleaning up... |
+| 100% | Saved |
+
+For short recordings most of these steps complete instantly.
 
 ## Configuration
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@
 
 import { Plugin } from 'obsidian';
 import { RecordingStatus } from './types';
+import type { SaveProgress } from './types';
 import {
 	AudioRecorderSettings,
 	mergeSettingsAsync,
@@ -36,8 +37,8 @@ export default class AudioRecorderPlugin extends Plugin {
 		this.recordingManager = new RecordingManager(
 			this.app,
 			this.settings,
-			(status: RecordingStatus) => {
-				updateStatusBar(this.statusBarItem, status);
+			(status: RecordingStatus, saveProgress?: SaveProgress) => {
+				updateStatusBar(this.statusBarItem, status, saveProgress);
 				updateRibbonIcon(this.ribbonIconEl, status);
 			},
 		);

--- a/src/recording/AudioCapabilityDetector.ts
+++ b/src/recording/AudioCapabilityDetector.ts
@@ -130,11 +130,13 @@ export function detectSupportedFormats(): string[] {
 		}
 	}
 
-	// WAV is available if at least one compressed intermediate is supported
+	// WAV is always available on desktop via direct PCM capture,
+	// and available on mobile if a compressed intermediate is supported
 	const hasCompressedIntermediate = COMPRESSED_INTERMEDIATES.some((format) =>
 		MediaRecorder.isTypeSupported(buildMimeType(format)),
 	);
-	if (hasCompressedIntermediate) {
+	const hasAudioContext = typeof AudioContext !== 'undefined';
+	if (hasAudioContext || hasCompressedIntermediate) {
 		supported.push(FORMAT_WAV);
 	}
 
@@ -167,13 +169,16 @@ export function getSupportedBitrates(): number[] {
  */
 export function validateRecordingCapability(format: string): ValidationResult {
 	if (format === FORMAT_WAV) {
+		// WAV is available via direct PCM capture (AudioContext) on desktop,
+		// or via compressed intermediate on mobile
+		const hasAudioContext = typeof AudioContext !== 'undefined';
 		const hasIntermediate = COMPRESSED_INTERMEDIATES.some((f) =>
 			MediaRecorder.isTypeSupported(buildMimeType(f)),
 		);
-		if (!hasIntermediate) {
+		if (!hasAudioContext && !hasIntermediate) {
 			return {
 				valid: false,
-				reason: 'WAV output requires an intermediate compressed format, but neither WebM nor OGG is supported in this browser.',
+				reason: 'WAV output requires AudioContext or an intermediate compressed format, but neither is available in this browser.',
 			};
 		}
 		return { valid: true, reason: '' };

--- a/src/recording/PcmStreamRecorder.ts
+++ b/src/recording/PcmStreamRecorder.ts
@@ -1,0 +1,171 @@
+/**
+ * Real-time PCM audio capture using ScriptProcessorNode.
+ * Captures raw interleaved int16 PCM data from a MediaStream
+ * for direct WAV encoding, avoiding memory-intensive post-hoc
+ * decoding of compressed formats for long recordings.
+ * @module recording/PcmStreamRecorder
+ */
+
+/**
+ * Buffer size for ScriptProcessorNode (samples per channel per callback).
+ * 4096 at 44100 Hz gives ~93ms intervals (~11 callbacks/sec).
+ */
+const PROCESSOR_BUFFER_SIZE = 4096;
+
+/**
+ * Callback type for receiving interleaved int16 PCM data chunks.
+ */
+export type PcmChunkCallback = (data: ArrayBuffer) => void;
+
+/**
+ * Captures raw PCM audio from a MediaStream in real-time.
+ *
+ * Uses ScriptProcessorNode to intercept audio samples from an
+ * AudioContext, converts float32 to interleaved int16, and
+ * delivers chunks via callback. Output is muted through a
+ * zero-gain node to prevent speaker playback.
+ *
+ * ScriptProcessorNode is used over AudioWorkletNode for broader
+ * compatibility across Obsidian environments (desktop Electron
+ * and mobile WebView) and simpler setup (no module loading).
+ */
+export class PcmStreamRecorder {
+	private audioContext: AudioContext | null = null;
+	private sourceNode: MediaStreamAudioSourceNode | null = null;
+	private processorNode: ScriptProcessorNode | null = null;
+	private gainNode: GainNode | null = null;
+	private paused: boolean = false;
+	private channelCount: number = 1;
+	private actualSampleRate: number = 44100;
+
+	/**
+	 * Creates a new PcmStreamRecorder.
+	 * @param stream - MediaStream to capture audio from
+	 * @param requestedSampleRate - Desired sample rate in Hz
+	 * @param onChunk - Callback for receiving interleaved int16 PCM data
+	 */
+	constructor(
+		private stream: MediaStream,
+		private requestedSampleRate: number,
+		private onChunk: PcmChunkCallback,
+	) {}
+
+	/**
+	 * Number of audio channels being captured.
+	 */
+	get channels(): number {
+		return this.channelCount;
+	}
+
+	/**
+	 * Actual sample rate of the AudioContext (may differ from requested).
+	 */
+	get sampleRate(): number {
+		return this.actualSampleRate;
+	}
+
+	/**
+	 * Starts capturing PCM audio data.
+	 * Creates AudioContext, connects source → processor → gain(0) → destination.
+	 */
+	async start(): Promise<void> {
+		this.audioContext = new AudioContext({
+			sampleRate: this.requestedSampleRate,
+		});
+		this.actualSampleRate = this.audioContext.sampleRate;
+
+		this.sourceNode = this.audioContext.createMediaStreamSource(
+			this.stream,
+		);
+		this.channelCount = this.sourceNode.channelCount;
+
+		// ScriptProcessorNode captures audio frames on the main thread
+		this.processorNode = this.audioContext.createScriptProcessor(
+			PROCESSOR_BUFFER_SIZE,
+			this.channelCount,
+			this.channelCount,
+		);
+
+		// Mute output to prevent playback through speakers
+		this.gainNode = this.audioContext.createGain();
+		this.gainNode.gain.value = 0;
+
+		this.processorNode.onaudioprocess = (
+			event: AudioProcessingEvent,
+		): void => {
+			if (this.paused) {
+				return;
+			}
+
+			const inputBuffer = event.inputBuffer;
+			const numSamples = inputBuffer.length;
+			const numChannels = inputBuffer.numberOfChannels;
+
+			// Convert float32 to interleaved int16 PCM
+			const int16Data = new Int16Array(numSamples * numChannels);
+			for (let sampleIndex = 0; sampleIndex < numSamples; sampleIndex++) {
+				for (
+					let channelIndex = 0;
+					channelIndex < numChannels;
+					channelIndex++
+				) {
+					const sample = Math.max(
+						-1,
+						Math.min(
+							1,
+							inputBuffer.getChannelData(channelIndex)[
+								sampleIndex
+							],
+						),
+					);
+					int16Data[sampleIndex * numChannels + channelIndex] =
+						sample < 0 ? sample * 0x8000 : sample * 0x7fff;
+				}
+			}
+
+			this.onChunk(int16Data.buffer);
+		};
+
+		// Connect: source → processor → gain(0) → destination
+		this.sourceNode.connect(this.processorNode);
+		this.processorNode.connect(this.gainNode);
+		this.gainNode.connect(this.audioContext.destination);
+	}
+
+	/**
+	 * Pauses PCM capture. Audio data is silently discarded while paused.
+	 */
+	pause(): void {
+		this.paused = true;
+	}
+
+	/**
+	 * Resumes PCM capture after a pause.
+	 */
+	resume(): void {
+		this.paused = false;
+	}
+
+	/**
+	 * Stops PCM capture and releases all audio resources.
+	 */
+	async stop(): Promise<void> {
+		if (this.processorNode) {
+			this.processorNode.onaudioprocess = null;
+			this.processorNode.disconnect();
+			this.processorNode = null;
+		}
+		if (this.sourceNode) {
+			this.sourceNode.disconnect();
+			this.sourceNode = null;
+		}
+		if (this.gainNode) {
+			this.gainNode.disconnect();
+			this.gainNode = null;
+		}
+		if (this.audioContext) {
+			await this.audioContext.close();
+			this.audioContext = null;
+		}
+	}
+}

--- a/src/recording/PcmStreamRecorder.ts
+++ b/src/recording/PcmStreamRecorder.ts
@@ -28,6 +28,9 @@ export type PcmChunkCallback = (data: ArrayBuffer) => void;
  * ScriptProcessorNode is used over AudioWorkletNode for broader
  * compatibility across Obsidian environments (desktop Electron
  * and mobile WebView) and simpler setup (no module loading).
+ *
+ * TODO: Migrate to AudioWorkletNode when Obsidian's minimum
+ * Electron version supports it reliably across all platforms.
  */
 export class PcmStreamRecorder {
 	private audioContext: AudioContext | null = null;

--- a/src/recording/RecordingManager.ts
+++ b/src/recording/RecordingManager.ts
@@ -29,7 +29,6 @@ import { PcmStreamRecorder } from './PcmStreamRecorder';
 type RecordingTarget = {
 	fileBaseName: string;
 	sourceName: string;
-	tempFilePath: string | null;
 	bufferedChunks: Blob[];
 	bufferedBytes: number;
 	segmentIndex: number;
@@ -190,7 +189,6 @@ export class RecordingManager {
 				return {
 					fileBaseName,
 					sourceName,
-					tempFilePath: null,
 					bufferedChunks: [],
 					bufferedBytes: 0,
 					segmentIndex: 0,
@@ -251,7 +249,6 @@ export class RecordingManager {
 				return {
 					fileBaseName,
 					sourceName,
-					tempFilePath: null,
 					bufferedChunks: [],
 					bufferedBytes: 0,
 					segmentIndex: 0,
@@ -317,8 +314,6 @@ export class RecordingManager {
 		const streamsToStop = [...this.streams];
 
 		try {
-			this.updateSaveProgress(0, 'Saving...');
-
 			if (this.isWavPcmRecording) {
 				await Promise.all(
 					pcmRecordersToStop.map((recorder) => recorder.stop()),
@@ -342,6 +337,8 @@ export class RecordingManager {
 			await Promise.all(
 				this.chunkTargets.map((target) => target.pendingWrite),
 			);
+
+			this.updateSaveProgress(0, 'Saving...');
 
 			const durationMs = Date.now() - this.recordingStartTime;
 			this.debugLogger.logRecordingStats(durationMs, this.totalChunks);
@@ -733,14 +730,6 @@ export class RecordingManager {
 	private async buildTrackBlob(
 		target: RecordingTarget,
 	): Promise<Blob | null> {
-		const type = this.getRecorderMediaType();
-		if (target.tempFilePath) {
-			const data = await this.app.vault.adapter.readBinary(
-				target.tempFilePath,
-			);
-			return new Blob([data], { type });
-		}
-
 		if (
 			target.segmentPaths.length === 0 &&
 			target.bufferedChunks.length === 0
@@ -748,6 +737,7 @@ export class RecordingManager {
 			return null;
 		}
 
+		const type = this.getRecorderMediaType();
 		const segmentBuffers = await Promise.all(
 			target.segmentPaths.map((path) =>
 				this.app.vault.adapter.readBinary(path),
@@ -760,14 +750,9 @@ export class RecordingManager {
 	}
 
 	private async cleanupIntermediateFiles(): Promise<string[]> {
-		const intermediatePaths = this.chunkTargets.flatMap((target) => {
-			const paths: string[] = [];
-			if (target.tempFilePath) {
-				paths.push(target.tempFilePath);
-			}
-			paths.push(...target.segmentPaths);
-			return paths;
-		});
+		const intermediatePaths = this.chunkTargets.flatMap(
+			(target) => target.segmentPaths,
+		);
 
 		return this.removeTemporaryArtifacts(
 			intermediatePaths,

--- a/src/recording/RecordingManager.ts
+++ b/src/recording/RecordingManager.ts
@@ -13,7 +13,7 @@ import {
 	stopAllStreams,
 	validateSelectedDevices,
 } from './AudioStreamHandler';
-import { bufferToWave } from './WavEncoder';
+import { bufferToWave, assembleWavFromPcmSegments } from './WavEncoder';
 import { PLUGIN_LOG_PREFIX } from '../constants';
 import { DebugLogger } from '../utils/DebugLogger';
 import {
@@ -23,6 +23,7 @@ import {
 	FORMAT_OGG,
 	FORMAT_WAV,
 } from './AudioCapabilityDetector';
+import { PcmStreamRecorder } from './PcmStreamRecorder';
 
 type RecordingTarget = {
 	fileBaseName: string;
@@ -33,10 +34,15 @@ type RecordingTarget = {
 	segmentIndex: number;
 	segmentPaths: string[];
 	pendingWrite: Promise<void>;
+	pcmBuffers: ArrayBuffer[];
+	pcmBufferedBytes: number;
+	pcmChannels: number;
+	pcmSampleRate: number;
 };
 
 const CHUNK_TIMESLICE_MS = 5000;
 const MOBILE_BUFFER_LIMIT_BYTES = 50 * 1024 * 1024;
+const PCM_FLUSH_THRESHOLD_BYTES = 50 * 1024 * 1024;
 const MIME_TYPE_AUDIO_PREFIX = 'audio/';
 
 /**
@@ -44,6 +50,7 @@ const MIME_TYPE_AUDIO_PREFIX = 'audio/';
  */
 export class RecordingManager {
 	private recorders: MediaRecorder[] = [];
+	private pcmRecorders: PcmStreamRecorder[] = [];
 	private chunkTargets: RecordingTarget[] = [];
 	private streams: MediaStream[] = [];
 	private trackOrder: { trackNumber: number; deviceId: string }[] = [];
@@ -54,6 +61,7 @@ export class RecordingManager {
 	private recordingTimestamp: string | null = null;
 	private totalChunks: number = 0;
 	private isMobileRecording: boolean = false;
+	private isWavPcmRecording: boolean = false;
 	private activeRecorderFormat: string = FORMAT_WEBM;
 
 	/**
@@ -103,14 +111,26 @@ export class RecordingManager {
 	 */
 	async startRecording(): Promise<void> {
 		try {
-			const { recorderFormat, mimeType } = this.resolveRecorderFormat();
-			this.activeRecorderFormat = recorderFormat;
-			this.debugLogger.logMimeType(mimeType);
-			this.debugLogger.log('Recording format configuration', {
-				outputFormat: this.settings.recordingFormat,
-				recorderFormat,
-				bitrate: this.settings.bitrate,
-			});
+			this.isMobileRecording = Platform.isMobileApp || Platform.isMobile;
+			this.isWavPcmRecording =
+				this.settings.recordingFormat === FORMAT_WAV &&
+				!this.isMobileRecording;
+
+			if (!this.isWavPcmRecording) {
+				const { recorderFormat, mimeType } =
+					this.resolveRecorderFormat();
+				this.activeRecorderFormat = recorderFormat;
+				this.debugLogger.logMimeType(mimeType);
+				this.debugLogger.log('Recording format configuration', {
+					outputFormat: this.settings.recordingFormat,
+					recorderFormat,
+					bitrate: this.settings.bitrate,
+				});
+			} else {
+				this.debugLogger.log('WAV recording with direct PCM capture', {
+					sampleRate: this.settings.sampleRate,
+				});
+			}
 
 			const validation = validateRecordingCapability(
 				this.settings.recordingFormat,
@@ -125,75 +145,143 @@ export class RecordingManager {
 			);
 			this.streams = streams;
 			this.trackOrder = trackOrder;
-			this.recorders = this.streams.map(
-				(stream) =>
-					new MediaRecorder(stream, {
-						mimeType,
-						audioBitsPerSecond: this.settings.bitrate,
-					}),
-			);
+
 			this.recordingStartTime = Date.now();
 			this.recordingTimestamp = new Date()
 				.toISOString()
 				.replace(/[:.]/g, '-');
 			this.totalChunks = 0;
-			this.isMobileRecording = Platform.isMobileApp || Platform.isMobile;
-			this.chunkTargets = await Promise.all(
-				this.recorders.map(async (_recorder, index) => {
-					const trackInfo = this.trackOrder[index];
-					const trackNumber = trackInfo?.trackNumber ?? index + 1;
-					const deviceId = trackInfo?.deviceId;
-					const sourceName =
-						this.settings.useSourceNamesForTracks && deviceId
-							? await getAudioSourceName(deviceId)
-							: `Track${trackNumber}`;
-					const fileBaseName = `${this.settings.filePrefix}-${sourceName}-${this.recordingTimestamp}`;
-					let tempFilePath: string | null = null;
-					if (!this.isMobileRecording) {
-						const tempName = `${fileBaseName}.partial.${this.activeRecorderFormat}`;
-						tempFilePath = await this.resolveUniquePath(tempName);
-						await this.app.vault.createBinary(
-							tempFilePath,
-							new ArrayBuffer(0),
-						);
-					}
-					return {
-						fileBaseName,
-						sourceName,
-						tempFilePath,
-						bufferedChunks: [],
-						bufferedBytes: 0,
-						segmentIndex: 0,
-						segmentPaths: [],
-						pendingWrite: Promise.resolve(),
-					};
-				}),
-			);
 
-			this.recorders.forEach((recorder, index) => {
-				recorder.ondataavailable = (event: BlobEvent): void => {
-					if (event.data.size > 0) {
-						void this.handleChunk(index, event.data);
-						this.debugLogger.logChunkSize(index, event.data.size);
-					}
-				};
-				recorder.onerror = (event: Event): void => {
-					console.error(
-						`${PLUGIN_LOG_PREFIX} Recorder error:`,
-						event,
-					);
-					new Notice(
-						'Recording error occurred. Check console for details.',
-					);
-				};
-				recorder.start(CHUNK_TIMESLICE_MS);
-			});
+			if (this.isWavPcmRecording) {
+				await this.initPcmRecording();
+			} else {
+				await this.initMediaRecording();
+			}
 
 			this.setStatus(RecordingStatus.Recording);
 			new Notice('Recording started');
 		} catch (error) {
 			this.handleStartRecordingError(error);
 		}
+	}
+
+	/**
+	 * Initializes PCM recording for WAV output on desktop.
+	 * Creates PcmStreamRecorder instances and segment-based targets.
+	 */
+	private async initPcmRecording(): Promise<void> {
+		this.chunkTargets = await Promise.all(
+			this.streams.map(async (_stream, index) => {
+				const trackInfo = this.trackOrder[index];
+				const trackNumber = trackInfo?.trackNumber ?? index + 1;
+				const deviceId = trackInfo?.deviceId;
+				const sourceName =
+					this.settings.useSourceNamesForTracks && deviceId
+						? await getAudioSourceName(deviceId)
+						: `Track${trackNumber}`;
+				const fileBaseName = `${this.settings.filePrefix}-${sourceName}-${this.recordingTimestamp}`;
+				return {
+					fileBaseName,
+					sourceName,
+					tempFilePath: null,
+					bufferedChunks: [],
+					bufferedBytes: 0,
+					segmentIndex: 0,
+					segmentPaths: [],
+					pendingWrite: Promise.resolve(),
+					pcmBuffers: [],
+					pcmBufferedBytes: 0,
+					pcmChannels: 1,
+					pcmSampleRate: this.settings.sampleRate,
+				};
+			}),
+		);
+
+		this.pcmRecorders = this.streams.map(
+			(stream, index) =>
+				new PcmStreamRecorder(
+					stream,
+					this.settings.sampleRate,
+					(data: ArrayBuffer) => {
+						void this.handlePcmChunk(index, data);
+					},
+				),
+		);
+
+		await Promise.all(
+			this.pcmRecorders.map(async (recorder, index) => {
+				await recorder.start();
+				const target = this.chunkTargets[index];
+				target.pcmChannels = recorder.channels;
+				target.pcmSampleRate = recorder.sampleRate;
+			}),
+		);
+	}
+
+	/**
+	 * Initializes MediaRecorder-based recording for non-WAV formats
+	 * and mobile WAV.
+	 */
+	private async initMediaRecording(): Promise<void> {
+		const mimeType = buildMimeType(this.activeRecorderFormat);
+		this.recorders = this.streams.map(
+			(stream) =>
+				new MediaRecorder(stream, {
+					mimeType,
+					audioBitsPerSecond: this.settings.bitrate,
+				}),
+		);
+		this.chunkTargets = await Promise.all(
+			this.recorders.map(async (_recorder, index) => {
+				const trackInfo = this.trackOrder[index];
+				const trackNumber = trackInfo?.trackNumber ?? index + 1;
+				const deviceId = trackInfo?.deviceId;
+				const sourceName =
+					this.settings.useSourceNamesForTracks && deviceId
+						? await getAudioSourceName(deviceId)
+						: `Track${trackNumber}`;
+				const fileBaseName = `${this.settings.filePrefix}-${sourceName}-${this.recordingTimestamp}`;
+				let tempFilePath: string | null = null;
+				if (!this.isMobileRecording) {
+					const tempName = `${fileBaseName}.partial.${this.activeRecorderFormat}`;
+					tempFilePath = await this.resolveUniquePath(tempName);
+					await this.app.vault.createBinary(
+						tempFilePath,
+						new ArrayBuffer(0),
+					);
+				}
+				return {
+					fileBaseName,
+					sourceName,
+					tempFilePath,
+					bufferedChunks: [],
+					bufferedBytes: 0,
+					segmentIndex: 0,
+					segmentPaths: [],
+					pendingWrite: Promise.resolve(),
+					pcmBuffers: [],
+					pcmBufferedBytes: 0,
+					pcmChannels: 1,
+					pcmSampleRate: this.settings.sampleRate,
+				};
+			}),
+		);
+
+		this.recorders.forEach((recorder, index) => {
+			recorder.ondataavailable = (event: BlobEvent): void => {
+				if (event.data.size > 0) {
+					void this.handleChunk(index, event.data);
+					this.debugLogger.logChunkSize(index, event.data.size);
+				}
+			};
+			recorder.onerror = (event: Event): void => {
+				console.error(`${PLUGIN_LOG_PREFIX} Recorder error:`, event);
+				new Notice(
+					'Recording error occurred. Check console for details.',
+				);
+			};
+			recorder.start(CHUNK_TIMESLICE_MS);
+		});
 	}
 
 	/**
@@ -227,20 +315,29 @@ export class RecordingManager {
 	 */
 	async stopRecording(): Promise<void> {
 		const recordersToStop = [...this.recorders];
+		const pcmRecordersToStop = [...this.pcmRecorders];
 		const streamsToStop = [...this.streams];
 
 		try {
-			await Promise.all(
-				recordersToStop.map(
-					(recorder) =>
-						new Promise<void>((resolve) => {
-							recorder.addEventListener('stop', () => resolve(), {
-								once: true,
-							});
-							recorder.stop();
-						}),
-				),
-			);
+			if (this.isWavPcmRecording) {
+				await Promise.all(
+					pcmRecordersToStop.map((recorder) => recorder.stop()),
+				);
+			} else {
+				await Promise.all(
+					recordersToStop.map(
+						(recorder) =>
+							new Promise<void>((resolve) => {
+								recorder.addEventListener(
+									'stop',
+									() => resolve(),
+									{ once: true },
+								);
+								recorder.stop();
+							}),
+					),
+				);
+			}
 
 			await Promise.all(
 				this.chunkTargets.map((target) => target.pendingWrite),
@@ -263,10 +360,12 @@ export class RecordingManager {
 			stopAllStreams(streamsToStop);
 			this.streams = [];
 			this.recorders = [];
+			this.pcmRecorders = [];
 			this.chunkTargets = [];
 			this.trackOrder = [];
 			this.recordingTimestamp = null;
 			this.totalChunks = 0;
+			this.isWavPcmRecording = false;
 			this.setStatus(RecordingStatus.Idle);
 		}
 	}
@@ -276,11 +375,19 @@ export class RecordingManager {
 	 */
 	togglePauseResume(): void {
 		if (this.status === RecordingStatus.Recording) {
-			this.recorders.forEach((recorder) => recorder.pause());
+			if (this.isWavPcmRecording) {
+				this.pcmRecorders.forEach((recorder) => recorder.pause());
+			} else {
+				this.recorders.forEach((recorder) => recorder.pause());
+			}
 			this.setStatus(RecordingStatus.Paused);
 			new Notice('Recording paused');
 		} else if (this.status === RecordingStatus.Paused) {
-			this.recorders.forEach((recorder) => recorder.resume());
+			if (this.isWavPcmRecording) {
+				this.pcmRecorders.forEach((recorder) => recorder.resume());
+			} else {
+				this.recorders.forEach((recorder) => recorder.resume());
+			}
 			this.setStatus(RecordingStatus.Recording);
 			new Notice('Recording resumed');
 		} else {
@@ -294,10 +401,12 @@ export class RecordingManager {
 	cleanup(): void {
 		stopAllStreams(this.streams);
 		this.recorders = [];
+		this.pcmRecorders = [];
 		this.chunkTargets = [];
 		this.streams = [];
 		this.recordingTimestamp = null;
 		this.totalChunks = 0;
+		this.isWavPcmRecording = false;
 	}
 
 	private setStatus(status: RecordingStatus): void {
@@ -323,6 +432,13 @@ export class RecordingManager {
 					await Promise.all(
 						this.chunkTargets.map((target) =>
 							this.flushMobileBuffer(target),
+						),
+					);
+				}
+				if (this.isWavPcmRecording) {
+					await Promise.all(
+						this.chunkTargets.map((target) =>
+							this.flushPcmBuffer(target),
 						),
 					);
 				}
@@ -372,7 +488,9 @@ export class RecordingManager {
 		const audioContext = new AudioContext();
 		const buffers = await Promise.all(
 			this.chunkTargets.map(async (target) => {
-				const blob = await this.buildTrackBlob(target);
+				const blob = this.isWavPcmRecording
+					? await this.buildPcmTrackWavBlob(target)
+					: await this.buildTrackBlob(target);
 				if (!blob) {
 					return null;
 				}
@@ -477,6 +595,117 @@ export class RecordingManager {
 
 		target.pendingWrite = target.pendingWrite.then(enqueue);
 		await target.pendingWrite;
+	}
+
+	private async handlePcmChunk(
+		index: number,
+		data: ArrayBuffer,
+	): Promise<void> {
+		const target = this.chunkTargets[index];
+		if (!target) {
+			return;
+		}
+		this.totalChunks += 1;
+
+		const enqueue = async (): Promise<void> => {
+			target.pcmBuffers.push(data);
+			target.pcmBufferedBytes += data.byteLength;
+			if (target.pcmBufferedBytes >= PCM_FLUSH_THRESHOLD_BYTES) {
+				await this.flushPcmBuffer(target);
+			}
+		};
+
+		target.pendingWrite = target.pendingWrite.then(enqueue);
+		await target.pendingWrite;
+	}
+
+	private async flushPcmBuffer(target: RecordingTarget): Promise<void> {
+		if (target.pcmBuffers.length === 0) {
+			return;
+		}
+		target.segmentIndex += 1;
+		const segmentName = `${target.fileBaseName}-pcm-part${String(target.segmentIndex)}.tmp`;
+		const segmentPath = await this.resolveUniquePath(segmentName);
+
+		const totalSize = target.pcmBuffers.reduce(
+			(sum, buf) => sum + buf.byteLength,
+			0,
+		);
+		const merged = new Uint8Array(totalSize);
+		let offset = 0;
+		for (const buf of target.pcmBuffers) {
+			merged.set(new Uint8Array(buf), offset);
+			offset += buf.byteLength;
+		}
+
+		await this.app.vault.createBinary(segmentPath, merged.buffer);
+		target.segmentPaths.push(segmentPath);
+		target.pcmBuffers = [];
+		target.pcmBufferedBytes = 0;
+	}
+
+	private async assembleWavFile(
+		target: RecordingTarget,
+		filePath: string,
+	): Promise<void> {
+		const segments = await Promise.all(
+			target.segmentPaths.map((path) =>
+				this.app.vault.adapter.readBinary(path),
+			),
+		);
+
+		const wavBuffer = assembleWavFromPcmSegments(
+			segments,
+			target.pcmChannels,
+			target.pcmSampleRate,
+		);
+
+		await this.app.vault.createBinary(filePath, wavBuffer);
+
+		const failedPaths = await this.removeTemporaryArtifacts(
+			target.segmentPaths,
+			'Failed to remove PCM segment file after WAV assembly',
+		);
+		if (failedPaths.length > 0) {
+			await this.rollbackFinalFile(
+				filePath,
+				'Failed to rollback assembled WAV file',
+			);
+			throw new Error(
+				`Temporary recording artifacts were kept for recovery: ${failedPaths.join(', ')}`,
+			);
+		}
+	}
+
+	private async buildPcmTrackWavBlob(
+		target: RecordingTarget,
+	): Promise<Blob | null> {
+		if (
+			target.segmentPaths.length === 0 &&
+			target.pcmBuffers.length === 0
+		) {
+			return null;
+		}
+
+		await this.flushPcmBuffer(target);
+
+		if (target.segmentPaths.length === 0) {
+			return null;
+		}
+
+		const segments = await Promise.all(
+			target.segmentPaths.map((path) =>
+				this.app.vault.adapter.readBinary(path),
+			),
+		);
+
+		const wavBuffer = assembleWavFromPcmSegments(
+			segments,
+			target.pcmChannels,
+			target.pcmSampleRate,
+		);
+
+		return new Blob([wavBuffer], { type: 'audio/wav' });
 	}
 
 	private async flushMobileBuffer(target: RecordingTarget): Promise<void> {
@@ -588,6 +817,18 @@ export class RecordingManager {
 		if (this.isMobileRecording) {
 			await this.flushMobileBuffer(target);
 			fileLinks.push(...target.segmentPaths);
+			return fileLinks;
+		}
+
+		if (this.isWavPcmRecording) {
+			await this.flushPcmBuffer(target);
+			if (target.segmentPaths.length === 0) {
+				return fileLinks;
+			}
+			const fileName = `${this.settings.filePrefix}-${target.sourceName}-${timestamp}.wav`;
+			const filePath = await this.resolveUniquePath(fileName);
+			await this.assembleWavFile(target, filePath);
+			fileLinks.push(filePath);
 			return fileLinks;
 		}
 

--- a/src/recording/RecordingManager.ts
+++ b/src/recording/RecordingManager.ts
@@ -6,6 +6,7 @@
 import { MarkdownView, normalizePath, Notice, Platform } from 'obsidian';
 import type { App } from 'obsidian';
 import { RecordingStatus } from '../types';
+import type { SaveProgress } from '../types';
 import type { AudioRecorderSettings } from '../settings/Settings';
 import {
 	getAudioStreams,
@@ -55,7 +56,10 @@ export class RecordingManager {
 	private streams: MediaStream[] = [];
 	private trackOrder: { trackNumber: number; deviceId: string }[] = [];
 	private status: RecordingStatus = RecordingStatus.Idle;
-	private onStatusChange: (status: RecordingStatus) => void;
+	private onStatusChange: (
+		status: RecordingStatus,
+		saveProgress?: SaveProgress,
+	) => void;
 	private debugLogger: DebugLogger;
 	private recordingStartTime: number = 0;
 	private recordingTimestamp: string | null = null;
@@ -73,7 +77,10 @@ export class RecordingManager {
 	constructor(
 		private app: App,
 		private settings: AudioRecorderSettings,
-		onStatusChange: (status: RecordingStatus) => void,
+		onStatusChange: (
+			status: RecordingStatus,
+			saveProgress?: SaveProgress,
+		) => void,
 	) {
 		this.onStatusChange = onStatusChange;
 		this.debugLogger = new DebugLogger(settings);
@@ -241,19 +248,10 @@ export class RecordingManager {
 						? await getAudioSourceName(deviceId)
 						: `Track${trackNumber}`;
 				const fileBaseName = `${this.settings.filePrefix}-${sourceName}-${this.recordingTimestamp}`;
-				let tempFilePath: string | null = null;
-				if (!this.isMobileRecording) {
-					const tempName = `${fileBaseName}.partial.${this.activeRecorderFormat}`;
-					tempFilePath = await this.resolveUniquePath(tempName);
-					await this.app.vault.createBinary(
-						tempFilePath,
-						new ArrayBuffer(0),
-					);
-				}
 				return {
 					fileBaseName,
 					sourceName,
-					tempFilePath,
+					tempFilePath: null,
 					bufferedChunks: [],
 					bufferedBytes: 0,
 					segmentIndex: 0,
@@ -319,6 +317,8 @@ export class RecordingManager {
 		const streamsToStop = [...this.streams];
 
 		try {
+			this.updateSaveProgress(0, 'Saving...');
+
 			if (this.isWavPcmRecording) {
 				await Promise.all(
 					pcmRecordersToStop.map((recorder) => recorder.stop()),
@@ -347,6 +347,7 @@ export class RecordingManager {
 			this.debugLogger.logRecordingStats(durationMs, this.totalChunks);
 
 			await this.saveRecording();
+			this.updateSaveProgress(100, 'Saved');
 			new Notice('Recording stopped');
 		} catch (error) {
 			const message =
@@ -409,9 +410,16 @@ export class RecordingManager {
 		this.isWavPcmRecording = false;
 	}
 
-	private setStatus(status: RecordingStatus): void {
+	private setStatus(
+		status: RecordingStatus,
+		saveProgress?: SaveProgress,
+	): void {
 		this.status = status;
-		this.onStatusChange(status);
+		this.onStatusChange(status, saveProgress);
+	}
+
+	private updateSaveProgress(percent: number, description: string): void {
+		this.setStatus(RecordingStatus.Saving, { percent, description });
 	}
 
 	private async saveRecording(): Promise<void> {
@@ -419,6 +427,8 @@ export class RecordingManager {
 			this.recordingTimestamp ??
 			new Date().toISOString().replace(/[:.]/g, '-');
 		const fileLinks: string[] = [];
+
+		this.updateSaveProgress(20, 'Flushing buffers...');
 
 		if (this.settings.outputMode === 'single') {
 			if (this.chunkTargets.length === 1) {
@@ -442,16 +452,19 @@ export class RecordingManager {
 						),
 					);
 				}
+				this.updateSaveProgress(40, 'Assembling audio...');
 				const mergedAudio =
 					this.settings.recordingFormat === FORMAT_WAV
 						? await this.mergeAudioTracks()
 						: await this.combineTracksWithoutConversion();
+				this.updateSaveProgress(60, 'Writing file...');
 				const fileName = `${this.settings.filePrefix}-multitrack-${timestamp}.${this.settings.recordingFormat}`;
 				const filePath = await this.saveAudioFile(
 					mergedAudio,
 					fileName,
 				);
 				if (filePath) {
+					this.updateSaveProgress(80, 'Cleaning up...');
 					const failedCleanupPaths =
 						await this.cleanupIntermediateFiles();
 					if (failedCleanupPaths.length > 0) {
@@ -565,26 +578,16 @@ export class RecordingManager {
 				return;
 			}
 
-			if (!target.tempFilePath) {
-				return;
-			}
 			try {
-				const newData = await data.arrayBuffer();
-				const existing = await this.app.vault.adapter.readBinary(
-					target.tempFilePath,
-				);
-				const merged = new Uint8Array(
-					existing.byteLength + newData.byteLength,
-				);
-				merged.set(new Uint8Array(existing), 0);
-				merged.set(new Uint8Array(newData), existing.byteLength);
-				await this.app.vault.adapter.writeBinary(
-					target.tempFilePath,
-					merged.buffer,
-				);
+				target.segmentIndex += 1;
+				const segmentName = `${target.fileBaseName}-part${String(target.segmentIndex)}.${this.activeRecorderFormat}.tmp`;
+				const segmentPath = await this.resolveUniquePath(segmentName);
+				const arrayBuffer = await data.arrayBuffer();
+				await this.app.vault.createBinary(segmentPath, arrayBuffer);
+				target.segmentPaths.push(segmentPath);
 			} catch (error) {
 				console.error(
-					`${PLUGIN_LOG_PREFIX} Failed to append chunk:`,
+					`${PLUGIN_LOG_PREFIX} Failed to write segment:`,
 					error,
 				);
 				new Notice(
@@ -821,18 +824,22 @@ export class RecordingManager {
 		}
 
 		if (this.isWavPcmRecording) {
+			this.updateSaveProgress(20, 'Flushing buffers...');
 			await this.flushPcmBuffer(target);
 			if (target.segmentPaths.length === 0) {
 				return fileLinks;
 			}
+			this.updateSaveProgress(40, 'Assembling audio...');
 			const fileName = `${this.settings.filePrefix}-${target.sourceName}-${timestamp}.wav`;
 			const filePath = await this.resolveUniquePath(fileName);
+			this.updateSaveProgress(60, 'Writing file...');
 			await this.assembleWavFile(target, filePath);
 			fileLinks.push(filePath);
 			return fileLinks;
 		}
 
-		if (!target.tempFilePath) {
+		const blob = await this.buildTrackBlob(target);
+		if (!blob || blob.size === 0) {
 			return fileLinks;
 		}
 
@@ -840,34 +847,36 @@ export class RecordingManager {
 		const filePath = await this.resolveUniquePath(fileName);
 
 		if (this.settings.recordingFormat === FORMAT_WAV) {
-			const data = await this.app.vault.adapter.readBinary(
-				target.tempFilePath,
-			);
-			const wavBlob = await this.convertBlobToWav(
-				new Blob([data], {
-					type: this.getRecorderMediaType(),
-				}),
-			);
+			this.updateSaveProgress(40, 'Assembling audio...');
+			const wavBlob = await this.convertBlobToWav(blob);
+			this.updateSaveProgress(60, 'Writing file...');
 			await this.app.vault.createBinary(
 				filePath,
 				await wavBlob.arrayBuffer(),
 			);
-			const failedCleanupPaths = await this.removeTemporaryArtifacts(
-				[target.tempFilePath],
-				'Failed to remove temporary track file after WAV conversion',
-			);
-			if (failedCleanupPaths.length > 0) {
-				await this.rollbackFinalFile(
-					filePath,
-					'Failed to rollback finalized WAV track',
-				);
-				throw new Error(
-					`Temporary recording artifacts were kept for recovery: ${failedCleanupPaths.join(', ')}`,
-				);
-			}
 		} else {
-			await this.app.vault.adapter.rename(target.tempFilePath, filePath);
+			this.updateSaveProgress(60, 'Writing file...');
+			await this.app.vault.createBinary(
+				filePath,
+				await blob.arrayBuffer(),
+			);
 		}
+
+		this.updateSaveProgress(80, 'Cleaning up...');
+		const failedCleanupPaths = await this.removeTemporaryArtifacts(
+			target.segmentPaths,
+			'Failed to remove segment file after finalization',
+		);
+		if (failedCleanupPaths.length > 0) {
+			await this.rollbackFinalFile(
+				filePath,
+				'Failed to rollback finalized track',
+			);
+			throw new Error(
+				`Temporary recording artifacts were kept for recovery: ${failedCleanupPaths.join(', ')}`,
+			);
+		}
+
 		fileLinks.push(filePath);
 		return fileLinks;
 	}

--- a/src/recording/RecordingManager.ts
+++ b/src/recording/RecordingManager.ts
@@ -172,12 +172,15 @@ export class RecordingManager {
 	}
 
 	/**
-	 * Initializes PCM recording for WAV output on desktop.
-	 * Creates PcmStreamRecorder instances and segment-based targets.
+	 * Creates recording targets for each stream, resolving track
+	 * names from device IDs or sequential numbering.
+	 * @param count - Number of targets to create
 	 */
-	private async initPcmRecording(): Promise<void> {
-		this.chunkTargets = await Promise.all(
-			this.streams.map(async (_stream, index) => {
+	private async createChunkTargets(
+		count: number,
+	): Promise<RecordingTarget[]> {
+		return Promise.all(
+			Array.from({ length: count }, async (_, index) => {
 				const trackInfo = this.trackOrder[index];
 				const trackNumber = trackInfo?.trackNumber ?? index + 1;
 				const deviceId = trackInfo?.deviceId;
@@ -201,6 +204,14 @@ export class RecordingManager {
 				};
 			}),
 		);
+	}
+
+	/**
+	 * Initializes PCM recording for WAV output on desktop.
+	 * Creates PcmStreamRecorder instances and segment-based targets.
+	 */
+	private async initPcmRecording(): Promise<void> {
+		this.chunkTargets = await this.createChunkTargets(this.streams.length);
 
 		this.pcmRecorders = this.streams.map(
 			(stream, index) =>
@@ -236,30 +247,8 @@ export class RecordingManager {
 					audioBitsPerSecond: this.settings.bitrate,
 				}),
 		);
-		this.chunkTargets = await Promise.all(
-			this.recorders.map(async (_recorder, index) => {
-				const trackInfo = this.trackOrder[index];
-				const trackNumber = trackInfo?.trackNumber ?? index + 1;
-				const deviceId = trackInfo?.deviceId;
-				const sourceName =
-					this.settings.useSourceNamesForTracks && deviceId
-						? await getAudioSourceName(deviceId)
-						: `Track${trackNumber}`;
-				const fileBaseName = `${this.settings.filePrefix}-${sourceName}-${this.recordingTimestamp}`;
-				return {
-					fileBaseName,
-					sourceName,
-					bufferedChunks: [],
-					bufferedBytes: 0,
-					segmentIndex: 0,
-					segmentPaths: [],
-					pendingWrite: Promise.resolve(),
-					pcmBuffers: [],
-					pcmBufferedBytes: 0,
-					pcmChannels: 1,
-					pcmSampleRate: this.settings.sampleRate,
-				};
-			}),
+		this.chunkTargets = await this.createChunkTargets(
+			this.recorders.length,
 		);
 
 		this.recorders.forEach((recorder, index) => {

--- a/src/recording/WavEncoder.ts
+++ b/src/recording/WavEncoder.ts
@@ -1,5 +1,6 @@
 /**
- * WAV encoder utility for converting AudioBuffer to WAV format.
+ * WAV encoder utility for converting AudioBuffer to WAV format
+ * and assembling WAV files from raw PCM segments.
  * @module recording/WavEncoder
  */
 
@@ -103,4 +104,98 @@ export function getWavHeaderInfo(
 		totalSize: dataLength + 44,
 		byteRate: sampleRate * 2 * numChannels,
 	};
+}
+
+/**
+ * WAV header size in bytes.
+ */
+const WAV_HEADER_SIZE = 44;
+
+/**
+ * Bits per sample for 16-bit PCM.
+ */
+const BITS_PER_SAMPLE = 16;
+
+/**
+ * Creates a 44-byte WAV file header for raw int16 PCM data.
+ * @param numChannels - Number of audio channels
+ * @param sampleRate - Sample rate in Hz
+ * @param pcmDataLength - Total length of PCM data in bytes
+ * @returns ArrayBuffer containing the WAV header
+ */
+export function createWavHeader(
+	numChannels: number,
+	sampleRate: number,
+	pcmDataLength: number,
+): ArrayBuffer {
+	const header = new ArrayBuffer(WAV_HEADER_SIZE);
+	const view = new DataView(header);
+	const byteRate = sampleRate * numChannels * (BITS_PER_SAMPLE / 8);
+	const blockAlign = numChannels * (BITS_PER_SAMPLE / 8);
+	let offset = 0;
+
+	// RIFF header
+	writeString(view, offset, 'RIFF');
+	offset += 4;
+	view.setUint32(offset, WAV_HEADER_SIZE - 8 + pcmDataLength, true);
+	offset += 4;
+	writeString(view, offset, 'WAVE');
+	offset += 4;
+
+	// fmt subchunk
+	writeString(view, offset, 'fmt ');
+	offset += 4;
+	view.setUint32(offset, 16, true); // Subchunk1Size
+	offset += 4;
+	view.setUint16(offset, 1, true); // AudioFormat (PCM)
+	offset += 2;
+	view.setUint16(offset, numChannels, true);
+	offset += 2;
+	view.setUint32(offset, sampleRate, true);
+	offset += 4;
+	view.setUint32(offset, byteRate, true);
+	offset += 4;
+	view.setUint16(offset, blockAlign, true);
+	offset += 2;
+	view.setUint16(offset, BITS_PER_SAMPLE, true);
+	offset += 2;
+
+	// data subchunk header
+	writeString(view, offset, 'data');
+	offset += 4;
+	view.setUint32(offset, pcmDataLength, true);
+
+	return header;
+}
+
+/**
+ * Assembles a complete WAV file from raw int16 PCM data segments.
+ * Concatenates all segments after a proper WAV header.
+ * @param segments - Array of raw interleaved int16 PCM data buffers
+ * @param numChannels - Number of audio channels
+ * @param sampleRate - Sample rate in Hz
+ * @returns ArrayBuffer containing the complete WAV file
+ */
+export function assembleWavFromPcmSegments(
+	segments: ArrayBuffer[],
+	numChannels: number,
+	sampleRate: number,
+): ArrayBuffer {
+	const totalPcmSize = segments.reduce((sum, buf) => sum + buf.byteLength, 0);
+
+	const header = createWavHeader(numChannels, sampleRate, totalPcmSize);
+	const wavBuffer = new ArrayBuffer(WAV_HEADER_SIZE + totalPcmSize);
+	const wavView = new Uint8Array(wavBuffer);
+
+	// Copy header
+	wavView.set(new Uint8Array(header), 0);
+
+	// Copy PCM segments
+	let offset = WAV_HEADER_SIZE;
+	for (const segment of segments) {
+		wavView.set(new Uint8Array(segment), offset);
+		offset += segment.byteLength;
+	}
+
+	return wavBuffer;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,4 +10,13 @@ export enum RecordingStatus {
 	Idle = 'idle',
 	Recording = 'recording',
 	Paused = 'paused',
+	Saving = 'saving',
 }
+
+/**
+ * Progress information during the save phase.
+ */
+export type SaveProgress = {
+	percent: number;
+	description: string;
+};

--- a/src/ui/RibbonIcon.ts
+++ b/src/ui/RibbonIcon.ts
@@ -10,6 +10,8 @@ import { RecordingStatus } from '../types';
 const ICON_IDLE = 'microphone';
 /** Icon name for recording state */
 const ICON_RECORDING = 'mic';
+/** Icon name for saving state */
+const ICON_SAVING = 'save';
 
 /**
  * Updates the ribbon icon element based on recording status.
@@ -29,15 +31,23 @@ export function updateRibbonIcon(
 		case RecordingStatus.Recording:
 			setIcon(ribbonIconEl, ICON_RECORDING);
 			ribbonIconEl.classList.add('is-recording');
+			ribbonIconEl.classList.remove('is-saving');
 			break;
 		case RecordingStatus.Paused:
 			setIcon(ribbonIconEl, ICON_RECORDING);
 			ribbonIconEl.classList.add('is-recording');
+			ribbonIconEl.classList.remove('is-saving');
+			break;
+		case RecordingStatus.Saving:
+			setIcon(ribbonIconEl, ICON_SAVING);
+			ribbonIconEl.classList.remove('is-recording');
+			ribbonIconEl.classList.add('is-saving');
 			break;
 		case RecordingStatus.Idle:
 		default:
 			setIcon(ribbonIconEl, ICON_IDLE);
 			ribbonIconEl.classList.remove('is-recording');
+			ribbonIconEl.classList.remove('is-saving');
 			break;
 	}
 }

--- a/src/ui/StatusBar.ts
+++ b/src/ui/StatusBar.ts
@@ -50,10 +50,9 @@ export function updateStatusBar(
 				cls: 'aar-save-progress-bar',
 			});
 			const percent = saveProgress?.percent ?? 0;
-			progressBar.style.setProperty(
-				'--save-progress',
-				`${String(percent)}%`,
-			);
+			progressBar.setCssProps({
+				'--save-progress': `${String(percent)}%`,
+			});
 			break;
 		}
 		case RecordingStatus.Idle:

--- a/src/ui/StatusBar.ts
+++ b/src/ui/StatusBar.ts
@@ -4,16 +4,19 @@
  */
 
 import { RecordingStatus } from '../types';
+import type { SaveProgress } from '../types';
 
 /**
  * Updates the status bar element based on recording status.
  * Uses Obsidian's extended HTMLElement methods.
  * @param statusBarItem - The status bar HTML element
  * @param status - Current recording status
+ * @param saveProgress - Optional save progress info for Saving state
  */
 export function updateStatusBar(
 	statusBarItem: HTMLElement | null,
 	status: RecordingStatus,
+	saveProgress?: SaveProgress,
 ): void {
 	if (!statusBarItem) {
 		return;
@@ -21,17 +24,44 @@ export function updateStatusBar(
 
 	switch (status) {
 		case RecordingStatus.Recording:
+			statusBarItem.empty();
 			statusBarItem.textContent = 'Recording...';
 			statusBarItem.classList.add('is-recording');
+			statusBarItem.classList.remove('is-saving');
 			break;
 		case RecordingStatus.Paused:
+			statusBarItem.empty();
 			statusBarItem.textContent = 'Recording paused';
 			statusBarItem.classList.add('is-recording');
+			statusBarItem.classList.remove('is-saving');
 			break;
+		case RecordingStatus.Saving: {
+			statusBarItem.empty();
+			statusBarItem.classList.remove('is-recording');
+			statusBarItem.classList.add('is-saving');
+
+			const text = statusBarItem.createSpan();
+			text.textContent = saveProgress?.description ?? 'Saving...';
+
+			const progressContainer = statusBarItem.createDiv({
+				cls: 'aar-save-progress',
+			});
+			const progressBar = progressContainer.createDiv({
+				cls: 'aar-save-progress-bar',
+			});
+			const percent = saveProgress?.percent ?? 0;
+			progressBar.style.setProperty(
+				'--save-progress',
+				`${String(percent)}%`,
+			);
+			break;
+		}
 		case RecordingStatus.Idle:
 		default:
+			statusBarItem.empty();
 			statusBarItem.textContent = '';
 			statusBarItem.classList.remove('is-recording');
+			statusBarItem.classList.remove('is-saving');
 			break;
 	}
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -30,6 +30,46 @@ If your plugin does not need CSS, delete this file.
     }
 }
 
+/* Saving state */
+.is-saving {
+    color: var(--color-accent);
+    font-weight: bold;
+}
+
+.side-dock-ribbon-action.is-saving svg {
+    color: var(--color-accent);
+    animation: pulse-saving 1.5s ease-in-out infinite;
+}
+
+.aar-save-progress {
+    height: 3px;
+    width: 100%;
+    background-color: var(--background-modifier-border);
+    border-radius: 2px;
+    margin-top: 2px;
+    overflow: hidden;
+}
+
+.aar-save-progress-bar {
+    height: 100%;
+    width: var(--save-progress, 0%);
+    background-color: var(--color-accent);
+    border-radius: 2px;
+    transition: width 0.3s ease;
+}
+
+@keyframes pulse-saving {
+
+    0%,
+    100% {
+        opacity: 1;
+    }
+
+    50% {
+        opacity: 0.6;
+    }
+}
+
 /* Test recording states */
 .aar-test-status {
     margin-top: 8px;

--- a/tests/unit/PcmStreamRecorder.test.ts
+++ b/tests/unit/PcmStreamRecorder.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Unit tests for PcmStreamRecorder module.
+ * Tests real-time PCM capture from MediaStream using ScriptProcessorNode.
+ * @module tests/unit/PcmStreamRecorder.test
+ */
+/** @jest-environment jsdom */
+
+import { PcmStreamRecorder } from '../../src/recording/PcmStreamRecorder';
+
+// Mock AudioContext and related Web Audio API
+let mockProcessorCallback: ((event: AudioProcessingEvent) => void) | null =
+	null;
+
+const mockScriptProcessor = {
+	onaudioprocess: null as ((event: AudioProcessingEvent) => void) | null,
+	connect: jest.fn(),
+	disconnect: jest.fn(),
+};
+
+const mockGainNode = {
+	gain: { value: 1 },
+	connect: jest.fn(),
+	disconnect: jest.fn(),
+};
+
+const mockSourceNode = {
+	channelCount: 1,
+	connect: jest.fn(),
+	disconnect: jest.fn(),
+};
+
+const mockAudioContext = {
+	sampleRate: 44100,
+	destination: {},
+	createMediaStreamSource: jest.fn().mockReturnValue(mockSourceNode),
+	createScriptProcessor: jest.fn().mockImplementation(() => {
+		const processor = { ...mockScriptProcessor, onaudioprocess: null };
+		// Capture the onaudioprocess setter
+		const proxy = new Proxy(processor, {
+			set(target, prop, value) {
+				if (prop === 'onaudioprocess') {
+					mockProcessorCallback = value as
+						| ((event: AudioProcessingEvent) => void)
+						| null;
+				}
+				(target as Record<string, unknown>)[prop as string] = value;
+				return true;
+			},
+		});
+		return proxy;
+	}),
+	createGain: jest.fn().mockReturnValue(mockGainNode),
+	close: jest.fn().mockResolvedValue(undefined),
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- mock global AudioContext
+(global as any).AudioContext = jest
+	.fn()
+	.mockImplementation(() => mockAudioContext);
+
+function createMockStream(channelCount: number = 1): MediaStream {
+	return {
+		getAudioTracks: () => [
+			{
+				stop: jest.fn(),
+				getSettings: () => ({ channelCount }),
+			},
+		],
+		getTracks: () => [{ stop: jest.fn() }],
+	} as unknown as MediaStream;
+}
+
+function createMockAudioProcessingEvent(
+	numSamples: number,
+	numChannels: number,
+): AudioProcessingEvent {
+	const channels: Float32Array[] = [];
+	for (let c = 0; c < numChannels; c++) {
+		const data = new Float32Array(numSamples);
+		for (let i = 0; i < numSamples; i++) {
+			data[i] = Math.sin((2 * Math.PI * 440 * i) / 44100) * 0.5;
+		}
+		channels.push(data);
+	}
+
+	return {
+		inputBuffer: {
+			length: numSamples,
+			numberOfChannels: numChannels,
+			getChannelData: (ch: number) => channels[ch],
+		},
+	} as unknown as AudioProcessingEvent;
+}
+
+describe('PcmStreamRecorder', () => {
+	let onChunkMock: jest.Mock;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockProcessorCallback = null;
+		mockGainNode.gain.value = 1;
+		mockSourceNode.channelCount = 1;
+		onChunkMock = jest.fn();
+	});
+
+	describe('start', () => {
+		it('should create AudioContext with requested sample rate', async () => {
+			const stream = createMockStream();
+			const recorder = new PcmStreamRecorder(stream, 48000, onChunkMock);
+
+			await recorder.start();
+
+			expect(global.AudioContext).toHaveBeenCalledWith({
+				sampleRate: 48000,
+			});
+		});
+
+		it('should connect audio graph: source → processor → gain(0) → destination', async () => {
+			const stream = createMockStream();
+			const recorder = new PcmStreamRecorder(
+				stream,
+				44100,
+				onChunkMock,
+			);
+
+			await recorder.start();
+
+			expect(
+				mockAudioContext.createMediaStreamSource,
+			).toHaveBeenCalledWith(stream);
+			expect(
+				mockAudioContext.createScriptProcessor,
+			).toHaveBeenCalledWith(4096, 1, 1);
+			expect(mockAudioContext.createGain).toHaveBeenCalled();
+			expect(mockGainNode.gain.value).toBe(0);
+		});
+
+		it('should expose actual channels and sampleRate from AudioContext', async () => {
+			mockSourceNode.channelCount = 2;
+			const stream = createMockStream(2);
+			const recorder = new PcmStreamRecorder(
+				stream,
+				44100,
+				onChunkMock,
+			);
+
+			await recorder.start();
+
+			expect(recorder.channels).toBe(2);
+			expect(recorder.sampleRate).toBe(44100);
+		});
+	});
+
+	describe('onaudioprocess callback', () => {
+		it('should deliver interleaved int16 PCM data via onChunk', async () => {
+			const stream = createMockStream();
+			const recorder = new PcmStreamRecorder(
+				stream,
+				44100,
+				onChunkMock,
+			);
+
+			await recorder.start();
+
+			const event = createMockAudioProcessingEvent(128, 1);
+			mockProcessorCallback?.(event);
+
+			expect(onChunkMock).toHaveBeenCalledTimes(1);
+			const chunkBuffer = onChunkMock.mock.calls[0][0] as ArrayBuffer;
+			// 128 samples * 1 channel * 2 bytes per int16 = 256 bytes
+			expect(chunkBuffer.byteLength).toBe(256);
+		});
+
+		it('should interleave stereo samples correctly', async () => {
+			mockSourceNode.channelCount = 2;
+			const stream = createMockStream(2);
+			const recorder = new PcmStreamRecorder(
+				stream,
+				44100,
+				onChunkMock,
+			);
+
+			await recorder.start();
+
+			const event = createMockAudioProcessingEvent(64, 2);
+			mockProcessorCallback?.(event);
+
+			expect(onChunkMock).toHaveBeenCalledTimes(1);
+			const chunkBuffer = onChunkMock.mock.calls[0][0] as ArrayBuffer;
+			// 64 samples * 2 channels * 2 bytes = 256 bytes
+			expect(chunkBuffer.byteLength).toBe(256);
+		});
+
+		it('should clamp sample values to [-1, 1] range', async () => {
+			const stream = createMockStream();
+			const recorder = new PcmStreamRecorder(
+				stream,
+				44100,
+				onChunkMock,
+			);
+
+			await recorder.start();
+
+			// Create event with out-of-range values
+			const event = {
+				inputBuffer: {
+					length: 2,
+					numberOfChannels: 1,
+					getChannelData: () => new Float32Array([2.0, -2.0]),
+				},
+			} as unknown as AudioProcessingEvent;
+
+			mockProcessorCallback?.(event);
+
+			const chunkBuffer = onChunkMock.mock.calls[0][0] as ArrayBuffer;
+			const int16View = new Int16Array(chunkBuffer);
+			// 2.0 clamped to 1.0 → 0x7FFF = 32767
+			expect(int16View[0]).toBe(32767);
+			// -2.0 clamped to -1.0 → -0x8000 = -32768
+			expect(int16View[1]).toBe(-32768);
+		});
+
+		it('should not deliver chunks when paused', async () => {
+			const stream = createMockStream();
+			const recorder = new PcmStreamRecorder(
+				stream,
+				44100,
+				onChunkMock,
+			);
+
+			await recorder.start();
+			recorder.pause();
+
+			const event = createMockAudioProcessingEvent(128, 1);
+			mockProcessorCallback?.(event);
+
+			expect(onChunkMock).not.toHaveBeenCalled();
+		});
+
+		it('should resume delivering chunks after resume', async () => {
+			const stream = createMockStream();
+			const recorder = new PcmStreamRecorder(
+				stream,
+				44100,
+				onChunkMock,
+			);
+
+			await recorder.start();
+			recorder.pause();
+			recorder.resume();
+
+			const event = createMockAudioProcessingEvent(128, 1);
+			mockProcessorCallback?.(event);
+
+			expect(onChunkMock).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('stop', () => {
+		it('should close AudioContext and disconnect nodes', async () => {
+			const stream = createMockStream();
+			const recorder = new PcmStreamRecorder(
+				stream,
+				44100,
+				onChunkMock,
+			);
+
+			await recorder.start();
+			await recorder.stop();
+
+			expect(mockAudioContext.close).toHaveBeenCalled();
+		});
+
+		it('should nullify onaudioprocess callback', async () => {
+			const stream = createMockStream();
+			const recorder = new PcmStreamRecorder(
+				stream,
+				44100,
+				onChunkMock,
+			);
+
+			await recorder.start();
+			await recorder.stop();
+
+			expect(mockProcessorCallback).toBeNull();
+		});
+
+		it('should handle stop when not started', async () => {
+			const stream = createMockStream();
+			const recorder = new PcmStreamRecorder(
+				stream,
+				44100,
+				onChunkMock,
+			);
+
+			// Should not throw
+			await expect(recorder.stop()).resolves.toBeUndefined();
+		});
+	});
+});

--- a/tests/unit/RecordingManager.test.ts
+++ b/tests/unit/RecordingManager.test.ts
@@ -410,6 +410,125 @@ describe('RecordingManager', () => {
 
             expect(mockApp.vault.createBinary).toHaveBeenCalled();
         });
+
+        it('should write multiple chunks as separate segment files and clean up after finalization', async () => {
+            const { Platform } = jest.requireMock('obsidian') as {
+                Platform: { isMobile: boolean; isMobileApp: boolean };
+            };
+            Platform.isMobile = false;
+            Platform.isMobileApp = false;
+
+            const mockMediaRecorder = {
+                start: jest.fn(),
+                stop: jest.fn(),
+                pause: jest.fn(),
+                resume: jest.fn(),
+                ondataavailable: null as ((event: BlobEvent) => void) | null,
+                onerror: null as ((event: Event) => void) | null,
+                addEventListener: jest.fn((event: string, handler: () => void) => {
+                    if (event === 'stop') {
+                        handler();
+                    }
+                }),
+            };
+
+            (global as Record<string, unknown>).MediaRecorder = jest.fn(
+                () => mockMediaRecorder,
+            );
+            (global as Record<string, unknown>).MediaRecorder.isTypeSupported = jest
+                .fn()
+                .mockReturnValue(true);
+
+            const { getAudioStreams } = jest.requireMock('../../src/recording/AudioStreamHandler') as {
+                getAudioStreams: jest.Mock;
+            };
+            getAudioStreams.mockResolvedValue({
+                streams: [{
+                    getTracks: () => [{ stop: jest.fn() }],
+                }],
+                trackOrder: [],
+            });
+
+            (mockApp.vault.adapter.readBinary as jest.Mock).mockResolvedValue(
+                new Uint8Array([1, 2, 3]).buffer,
+            );
+
+            await manager.startRecording();
+
+            // Send 3 chunks
+            for (let i = 0; i < 3; i++) {
+                const chunk = new Blob([new Uint8Array([1, 2, 3])], {
+                    type: 'audio/webm',
+                });
+                mockMediaRecorder.ondataavailable?.({ data: chunk } as BlobEvent);
+            }
+            await Promise.resolve();
+
+            await manager.stopRecording();
+
+            // 3 segment files + 1 final file
+            expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
+                expect.stringMatching(/-part1\.webm\.tmp$/),
+                expect.any(ArrayBuffer),
+            );
+            expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
+                expect.stringMatching(/-part2\.webm\.tmp$/),
+                expect.any(ArrayBuffer),
+            );
+            expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
+                expect.stringMatching(/-part3\.webm\.tmp$/),
+                expect.any(ArrayBuffer),
+            );
+            // Segments cleaned up
+            expect(mockApp.vault.adapter.remove).toHaveBeenCalledTimes(3);
+        });
+
+        it('should save multi-track WAV via PCM capture and merge', async () => {
+            const { Platform } = jest.requireMock('obsidian') as {
+                Platform: { isMobile: boolean; isMobileApp: boolean };
+            };
+            Platform.isMobile = false;
+            Platform.isMobileApp = false;
+
+            mockSettings = {
+                ...DEFAULT_SETTINGS,
+                enableMultiTrack: true,
+                outputMode: 'single',
+                recordingFormat: 'wav',
+            };
+            manager = new RecordingManager(mockApp, mockSettings, statusChangeCallback);
+
+            (global as Record<string, unknown>).MediaRecorder = jest.fn();
+            (global as Record<string, unknown>).MediaRecorder.isTypeSupported = jest
+                .fn()
+                .mockImplementation((mime: string) => mime === 'audio/webm');
+
+            const { getAudioStreams } = jest.requireMock('../../src/recording/AudioStreamHandler') as {
+                getAudioStreams: jest.Mock;
+            };
+            getAudioStreams.mockResolvedValue({
+                streams: [
+                    { getTracks: () => [{ stop: jest.fn() }] },
+                    { getTracks: () => [{ stop: jest.fn() }] },
+                ],
+                trackOrder: [],
+            });
+
+            await manager.startRecording();
+
+            // Simulate PCM chunks for both tracks
+            const pcmData = new Int16Array([100, -100, 200, -200]).buffer;
+            capturedPcmChunkCallback?.(pcmData);
+
+            await Promise.resolve();
+            await manager.stopRecording();
+
+            // Should have created WAV file via mergeAudioTracks path
+            expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
+                expect.stringMatching(/multitrack-.*\.wav$/),
+                expect.any(ArrayBuffer),
+            );
+        });
     });
 
     describe('cleanup', () => {

--- a/tests/unit/RecordingManager.test.ts
+++ b/tests/unit/RecordingManager.test.ts
@@ -215,7 +215,7 @@ describe('RecordingManager', () => {
             await manager.toggleRecording();
 
             expect(manager.getStatus()).toBe(RecordingStatus.Recording);
-            expect(statusChangeCallback).toHaveBeenCalledWith(RecordingStatus.Recording);
+            expect(statusChangeCallback).toHaveBeenCalledWith(RecordingStatus.Recording, undefined);
         });
 
         it('should stop recording when recording', async () => {
@@ -285,7 +285,7 @@ describe('RecordingManager', () => {
             manager.togglePauseResume();
 
             expect(manager.getStatus()).toBe(RecordingStatus.Paused);
-            expect(statusChangeCallback).toHaveBeenCalledWith(RecordingStatus.Paused);
+            expect(statusChangeCallback).toHaveBeenCalledWith(RecordingStatus.Paused, undefined);
         });
 
         it('should resume when paused', async () => {
@@ -296,12 +296,12 @@ describe('RecordingManager', () => {
             manager.togglePauseResume(); // Resume
 
             expect(manager.getStatus()).toBe(RecordingStatus.Recording);
-            expect(statusChangeCallback).toHaveBeenCalledWith(RecordingStatus.Recording);
+            expect(statusChangeCallback).toHaveBeenCalledWith(RecordingStatus.Recording, undefined);
         });
     });
 
     describe('streaming chunks', () => {
-        it('should append chunks to temp file on desktop', async () => {
+        it('should write chunks as segment files on desktop', async () => {
             const { Platform } = jest.requireMock('obsidian') as {
                 Platform: { isMobile: boolean; isMobileApp: boolean };
             };
@@ -352,7 +352,10 @@ describe('RecordingManager', () => {
 
             await manager.stopRecording();
 
-            expect(mockApp.vault.adapter.writeBinary).toHaveBeenCalled();
+            expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
+                expect.stringMatching(/-part1\.webm\.tmp$/),
+                expect.any(ArrayBuffer),
+            );
         });
 
         it('should flush mobile buffer when limit reached', async () => {
@@ -478,7 +481,7 @@ describe('RecordingManager', () => {
 
             // Status should be Idle despite error
             expect(manager.getStatus()).toBe(RecordingStatus.Idle);
-            expect(statusChangeCallback).toHaveBeenLastCalledWith(RecordingStatus.Idle);
+            expect(statusChangeCallback).toHaveBeenLastCalledWith(RecordingStatus.Idle, undefined);
         });
 
         it('should stop streams even when save fails', async () => {
@@ -645,11 +648,17 @@ describe('RecordingManager', () => {
             manager.togglePauseResume();
             await manager.toggleRecording();
 
-            expect(statusChangeCallback).toHaveBeenCalledTimes(4);
-            expect(statusChangeCallback).toHaveBeenNthCalledWith(1, RecordingStatus.Recording);
-            expect(statusChangeCallback).toHaveBeenNthCalledWith(2, RecordingStatus.Paused);
-            expect(statusChangeCallback).toHaveBeenNthCalledWith(3, RecordingStatus.Recording);
-            expect(statusChangeCallback).toHaveBeenNthCalledWith(4, RecordingStatus.Idle);
+            // Recording, Paused, Recording, Saving(0%), Saving(20%), Saving(100%), Idle
+            expect(statusChangeCallback).toHaveBeenNthCalledWith(1, RecordingStatus.Recording, undefined);
+            expect(statusChangeCallback).toHaveBeenNthCalledWith(2, RecordingStatus.Paused, undefined);
+            expect(statusChangeCallback).toHaveBeenNthCalledWith(3, RecordingStatus.Recording, undefined);
+            // Saving progress callbacks
+            expect(statusChangeCallback).toHaveBeenCalledWith(
+                RecordingStatus.Saving,
+                expect.objectContaining({ percent: 0 }),
+            );
+            // Final idle
+            expect(statusChangeCallback).toHaveBeenLastCalledWith(RecordingStatus.Idle, undefined);
         });
     });
 
@@ -733,7 +742,7 @@ describe('RecordingManager', () => {
                 expect.any(ArrayBuffer),
             );
             expect(mockApp.vault.adapter.remove).toHaveBeenCalledWith(
-                expect.stringMatching(/\.partial\.webm$/),
+                expect.stringMatching(/-part\d+\.webm\.tmp$/),
             );
         });
 
@@ -798,7 +807,7 @@ describe('RecordingManager', () => {
             );
             (mockApp.vault.adapter.remove as jest.Mock).mockImplementation(
                 async (path: string) => {
-                    if (path.includes('.partial.')) {
+                    if (path.includes('.tmp')) {
                         throw new Error('cleanup failed');
                     }
                     return undefined;
@@ -828,7 +837,7 @@ describe('RecordingManager', () => {
                 expect.stringContaining('Error stopping recording:'),
             );
             expect(consoleWarnSpy).toHaveBeenCalledWith(
-                expect.stringContaining('[AudioRecorder] Failed to remove intermediate recording file:'),
+                expect.stringContaining('[AudioRecorder]'),
                 expect.objectContaining({
                     error: expect.objectContaining({
                         message: 'cleanup failed',
@@ -921,10 +930,15 @@ describe('RecordingManager', () => {
             });
 
             await manager.startRecording();
+
+            const chunk = new Blob([new Uint8Array([1, 2, 3])], { type: 'audio/webm' });
+            mockMediaRecorder.ondataavailable?.({ data: chunk } as BlobEvent);
+            await Promise.resolve();
+
             await manager.stopRecording();
 
             expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
-                expect.stringMatching(/^Meetings\/2026\/recording-Track1-.*\.partial\.webm$/),
+                expect.stringMatching(/^Meetings\/2026\/recording-Track1-.*-part1\.webm\.tmp$/),
                 expect.any(ArrayBuffer),
             );
         });
@@ -966,11 +980,16 @@ describe('RecordingManager', () => {
             });
 
             await manager.startRecording();
+
+            const chunk = new Blob([new Uint8Array([1, 2, 3])], { type: 'audio/webm' });
+            mockMediaRecorder.ondataavailable?.({ data: chunk } as BlobEvent);
+            await Promise.resolve();
+
             await manager.stopRecording();
 
             expect(mockApp.vault.createFolder).toHaveBeenCalledWith('Meetings/2026/Audio');
             expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
-                expect.stringMatching(/^Meetings\/2026\/Audio\/recording-Track1-.*\.partial\.webm$/),
+                expect.stringMatching(/^Meetings\/2026\/Audio\/recording-Track1-.*-part1\.webm\.tmp$/),
                 expect.any(ArrayBuffer),
             );
         });
@@ -1013,10 +1032,15 @@ describe('RecordingManager', () => {
             });
 
             await manager.startRecording();
+
+            const chunk = new Blob([new Uint8Array([1, 2, 3])], { type: 'audio/webm' });
+            mockMediaRecorder.ondataavailable?.({ data: chunk } as BlobEvent);
+            await Promise.resolve();
+
             await manager.stopRecording();
 
             expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
-                expect.stringMatching(/^Recordings\/recording-Track1-.*\.partial\.webm$/),
+                expect.stringMatching(/^Recordings\/recording-Track1-.*-part1\.webm\.tmp$/),
                 expect.any(ArrayBuffer),
             );
         });
@@ -1054,7 +1078,16 @@ describe('RecordingManager', () => {
                 trackOrder: [],
             });
 
+            (mockApp.vault.adapter.readBinary as jest.Mock).mockResolvedValue(
+                new Uint8Array([1, 2, 3]).buffer,
+            );
+
             await manager.startRecording();
+
+            const chunk = new Blob([new Uint8Array([1, 2, 3])], { type: 'audio/webm' });
+            mockMediaRecorder.ondataavailable?.({ data: chunk } as BlobEvent);
+            await Promise.resolve();
+
             await manager.stopRecording();
 
             expect(mockReplaceSelection).toHaveBeenCalled();
@@ -1104,7 +1137,16 @@ describe('RecordingManager', () => {
                 trackOrder: [],
             });
 
+            (mockApp.vault.adapter.readBinary as jest.Mock).mockResolvedValue(
+                new Uint8Array([1, 2, 3]).buffer,
+            );
+
             await manager.startRecording();
+
+            const chunk = new Blob([new Uint8Array([1, 2, 3])], { type: 'audio/webm' });
+            mockMediaRecorder.ondataavailable?.({ data: chunk } as BlobEvent);
+            await Promise.resolve();
+
             await manager.stopRecording();
 
             expect(mockReplaceSelection).toHaveBeenCalled();

--- a/tests/unit/RecordingManager.test.ts
+++ b/tests/unit/RecordingManager.test.ts
@@ -32,6 +32,25 @@ jest.mock('../../src/recording/AudioStreamHandler', () => ({
 // Mock WavEncoder
 jest.mock('../../src/recording/WavEncoder', () => ({
     bufferToWave: jest.fn().mockReturnValue(new Blob(['test'], { type: 'audio/wav' })),
+    assembleWavFromPcmSegments: jest.fn().mockReturnValue(new ArrayBuffer(44)),
+}));
+
+// Mock PcmStreamRecorder
+let capturedPcmChunkCallback: ((data: ArrayBuffer) => void) | null = null;
+jest.mock('../../src/recording/PcmStreamRecorder', () => ({
+    PcmStreamRecorder: jest.fn().mockImplementation(
+        (_stream: MediaStream, _sampleRate: number, onChunk: (data: ArrayBuffer) => void) => {
+            capturedPcmChunkCallback = onChunk;
+            return {
+                channels: 1,
+                sampleRate: 44100,
+                start: jest.fn().mockResolvedValue(undefined),
+                stop: jest.fn().mockResolvedValue(undefined),
+                pause: jest.fn(),
+                resume: jest.fn(),
+            };
+        },
+    ),
 }));
 
 // Mock AudioContext and OfflineAudioContext
@@ -822,8 +841,8 @@ describe('RecordingManager', () => {
 
 
         /**
-         * Ensures that WAV output mode performs explicit conversion and writes
-         * files with .wav extension after recording in a supported intermediary format.
+         * Ensures that WAV output mode uses direct PCM capture on desktop
+         * and writes files with .wav extension assembled from PCM segments.
          */
         it('should convert to wav only when output format is wav', async () => {
             mockSettings = {
@@ -832,21 +851,7 @@ describe('RecordingManager', () => {
             };
             manager = new RecordingManager(mockApp, mockSettings, statusChangeCallback);
 
-            const mockMediaRecorder = {
-                start: jest.fn(),
-                stop: jest.fn(),
-                pause: jest.fn(),
-                resume: jest.fn(),
-                ondataavailable: null as ((event: BlobEvent) => void) | null,
-                onerror: null as ((event: Event) => void) | null,
-                addEventListener: jest.fn((event: string, handler: () => void) => {
-                    if (event === 'stop') {
-                        handler();
-                    }
-                }),
-            };
-
-            (global as Record<string, unknown>).MediaRecorder = jest.fn(() => mockMediaRecorder);
+            (global as Record<string, unknown>).MediaRecorder = jest.fn();
             (global as Record<string, unknown>).MediaRecorder.isTypeSupported = jest
                 .fn()
                 .mockImplementation((mime: string) => mime === 'audio/webm');
@@ -863,15 +868,13 @@ describe('RecordingManager', () => {
 
             await manager.startRecording();
 
-            const chunk = new Blob([new Uint8Array([5, 6, 7])], {
-                type: 'audio/webm',
-            });
-            mockMediaRecorder.ondataavailable?.({ data: chunk } as BlobEvent);
+            // Simulate PCM chunk via captured callback
+            const pcmData = new Int16Array([100, -100, 200, -200]).buffer;
+            capturedPcmChunkCallback?.(pcmData);
 
             await Promise.resolve();
             await manager.stopRecording();
 
-            expect(global.MediaRecorder.isTypeSupported).toHaveBeenCalledWith('audio/webm');
             expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
                 expect.stringMatching(/\.wav$/),
                 expect.any(ArrayBuffer),

--- a/tests/unit/RibbonIcon.test.ts
+++ b/tests/unit/RibbonIcon.test.ts
@@ -55,6 +55,24 @@ describe('RibbonIcon', () => {
             expect(ribbonElement.classList.contains('is-recording')).toBe(false);
         });
 
+        it('should change icon to save and add is-saving class when saving', () => {
+            updateRibbonIcon(ribbonElement, RecordingStatus.Saving);
+
+            expect(ribbonElement.getAttribute('data-icon')).toBe('save');
+            expect(ribbonElement.classList.contains('is-saving')).toBe(true);
+            expect(ribbonElement.classList.contains('is-recording')).toBe(false);
+        });
+
+        it('should remove is-saving class when transitioning from saving to idle', () => {
+            ribbonElement.classList.add('is-saving');
+            ribbonElement.setAttribute('data-icon', 'save');
+
+            updateRibbonIcon(ribbonElement, RecordingStatus.Idle);
+
+            expect(ribbonElement.getAttribute('data-icon')).toBe('microphone');
+            expect(ribbonElement.classList.contains('is-saving')).toBe(false);
+        });
+
         it('should handle default case same as idle', () => {
             ribbonElement.classList.add('is-recording');
 

--- a/tests/unit/StatusBar.test.ts
+++ b/tests/unit/StatusBar.test.ts
@@ -37,6 +37,11 @@ function addObsidianElementMethods(el: HTMLElement): HTMLElement {
 		this.appendChild(div);
 		return div;
 	};
+	obsEl.setCssProps = function (props: Record<string, string>) {
+		for (const [key, value] of Object.entries(props)) {
+			this.style.setProperty(key, value);
+		}
+	};
 	return el;
 }
 

--- a/tests/unit/StatusBar.test.ts
+++ b/tests/unit/StatusBar.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Unit tests for StatusBar module.
+ * Tests the status bar state changes during recording and saving.
+ * @module tests/unit/StatusBar.test
+ */
+/** @jest-environment jsdom */
+
+import { updateStatusBar, initializeStatusBar } from '../../src/ui/StatusBar';
+import { RecordingStatus } from '../../src/types';
+
+/**
+ * Polyfill Obsidian's HTMLElement extensions for jsdom.
+ */
+function addObsidianElementMethods(el: HTMLElement): HTMLElement {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const obsEl = el as any;
+	obsEl.empty = function () {
+		while (this.firstChild) {
+			this.removeChild(this.firstChild);
+		}
+	};
+	obsEl.createSpan = function (opts?: { cls?: string }) {
+		const span = document.createElement('span');
+		if (opts?.cls) {
+			span.className = opts.cls;
+		}
+		addObsidianElementMethods(span);
+		this.appendChild(span);
+		return span;
+	};
+	obsEl.createDiv = function (opts?: { cls?: string }) {
+		const div = document.createElement('div');
+		if (opts?.cls) {
+			div.className = opts.cls;
+		}
+		addObsidianElementMethods(div);
+		this.appendChild(div);
+		return div;
+	};
+	return el;
+}
+
+describe('StatusBar', () => {
+	let statusBarItem: HTMLElement;
+
+	beforeEach(() => {
+		statusBarItem = addObsidianElementMethods(document.createElement('div'));
+	});
+
+	describe('updateStatusBar', () => {
+		it('should handle null element gracefully', () => {
+			expect(() => {
+				updateStatusBar(null, RecordingStatus.Recording);
+			}).not.toThrow();
+		});
+
+		it('should show "Recording..." and add is-recording class when recording', () => {
+			updateStatusBar(statusBarItem, RecordingStatus.Recording);
+
+			expect(statusBarItem.textContent).toBe('Recording...');
+			expect(statusBarItem.classList.contains('is-recording')).toBe(true);
+			expect(statusBarItem.classList.contains('is-saving')).toBe(false);
+		});
+
+		it('should show "Recording paused" when paused', () => {
+			updateStatusBar(statusBarItem, RecordingStatus.Paused);
+
+			expect(statusBarItem.textContent).toBe('Recording paused');
+			expect(statusBarItem.classList.contains('is-recording')).toBe(true);
+		});
+
+		it('should clear text and remove classes when idle', () => {
+			statusBarItem.classList.add('is-recording');
+			statusBarItem.classList.add('is-saving');
+			statusBarItem.textContent = 'Something';
+
+			updateStatusBar(statusBarItem, RecordingStatus.Idle);
+
+			expect(statusBarItem.textContent).toBe('');
+			expect(statusBarItem.classList.contains('is-recording')).toBe(false);
+			expect(statusBarItem.classList.contains('is-saving')).toBe(false);
+		});
+
+		it('should show saving state with progress bar', () => {
+			updateStatusBar(statusBarItem, RecordingStatus.Saving, {
+				percent: 40,
+				description: 'Assembling audio...',
+			});
+
+			expect(statusBarItem.classList.contains('is-saving')).toBe(true);
+			expect(statusBarItem.classList.contains('is-recording')).toBe(false);
+
+			const text = statusBarItem.querySelector('span');
+			expect(text?.textContent).toBe('Assembling audio...');
+
+			const progressBar = statusBarItem.querySelector('.aar-save-progress-bar') as HTMLElement;
+			expect(progressBar).not.toBeNull();
+			expect(progressBar?.style.getPropertyValue('--save-progress')).toBe('40%');
+		});
+
+		it('should show default "Saving..." when no progress provided', () => {
+			updateStatusBar(statusBarItem, RecordingStatus.Saving);
+
+			const text = statusBarItem.querySelector('span');
+			expect(text?.textContent).toBe('Saving...');
+
+			const progressBar = statusBarItem.querySelector('.aar-save-progress-bar') as HTMLElement;
+			expect(progressBar?.style.getPropertyValue('--save-progress')).toBe('0%');
+		});
+
+		it('should have progress container with correct classes', () => {
+			updateStatusBar(statusBarItem, RecordingStatus.Saving, {
+				percent: 60,
+				description: 'Writing file...',
+			});
+
+			const container = statusBarItem.querySelector('.aar-save-progress');
+			expect(container).not.toBeNull();
+
+			const bar = container?.querySelector('.aar-save-progress-bar');
+			expect(bar).not.toBeNull();
+		});
+
+		it('should remove is-saving when transitioning from saving to idle', () => {
+			updateStatusBar(statusBarItem, RecordingStatus.Saving, {
+				percent: 100,
+				description: 'Saved',
+			});
+			expect(statusBarItem.classList.contains('is-saving')).toBe(true);
+
+			updateStatusBar(statusBarItem, RecordingStatus.Idle);
+			expect(statusBarItem.classList.contains('is-saving')).toBe(false);
+			expect(statusBarItem.textContent).toBe('');
+		});
+
+		it('should clear previous content when transitioning between states', () => {
+			updateStatusBar(statusBarItem, RecordingStatus.Saving, {
+				percent: 50,
+				description: 'Assembling...',
+			});
+			expect(statusBarItem.querySelector('.aar-save-progress')).not.toBeNull();
+
+			updateStatusBar(statusBarItem, RecordingStatus.Recording);
+			expect(statusBarItem.querySelector('.aar-save-progress')).toBeNull();
+			expect(statusBarItem.textContent).toBe('Recording...');
+		});
+
+		it('should handle default case same as idle', () => {
+			statusBarItem.classList.add('is-recording');
+
+			updateStatusBar(statusBarItem, 'unknown' as RecordingStatus);
+
+			expect(statusBarItem.textContent).toBe('');
+			expect(statusBarItem.classList.contains('is-recording')).toBe(false);
+		});
+	});
+
+	describe('initializeStatusBar', () => {
+		it('should handle null element gracefully', () => {
+			expect(() => {
+				initializeStatusBar(null);
+			}).not.toThrow();
+		});
+
+		it('should set status bar to idle state', () => {
+			statusBarItem.classList.add('is-recording');
+			statusBarItem.textContent = 'Recording...';
+
+			initializeStatusBar(statusBarItem);
+
+			expect(statusBarItem.textContent).toBe('');
+			expect(statusBarItem.classList.contains('is-recording')).toBe(false);
+		});
+	});
+});

--- a/tests/unit/WavEncoder.test.ts
+++ b/tests/unit/WavEncoder.test.ts
@@ -4,7 +4,7 @@
  */
 /** @jest-environment jsdom */
 
-import { bufferToWave, getWavHeaderInfo } from '../../src/recording/WavEncoder';
+import { bufferToWave, getWavHeaderInfo, createWavHeader, assembleWavFromPcmSegments } from '../../src/recording/WavEncoder';
 
 describe('WavEncoder', () => {
     describe('bufferToWave', () => {
@@ -113,6 +113,124 @@ describe('WavEncoder', () => {
         });
     });
 });
+
+    describe('createWavHeader', () => {
+        it('should create a 44-byte WAV header', () => {
+            const header = createWavHeader(1, 44100, 1000);
+
+            expect(header.byteLength).toBe(44);
+        });
+
+        it('should contain valid RIFF/WAVE markers', () => {
+            const header = createWavHeader(1, 44100, 1000);
+            const view = new DataView(header);
+
+            // RIFF
+            expect(String.fromCharCode(view.getUint8(0), view.getUint8(1), view.getUint8(2), view.getUint8(3))).toBe('RIFF');
+            // WAVE
+            expect(String.fromCharCode(view.getUint8(8), view.getUint8(9), view.getUint8(10), view.getUint8(11))).toBe('WAVE');
+            // fmt
+            expect(String.fromCharCode(view.getUint8(12), view.getUint8(13), view.getUint8(14), view.getUint8(15))).toBe('fmt ');
+            // data
+            expect(String.fromCharCode(view.getUint8(36), view.getUint8(37), view.getUint8(38), view.getUint8(39))).toBe('data');
+        });
+
+        it('should set correct file size in RIFF header', () => {
+            const pcmDataLength = 5000;
+            const header = createWavHeader(1, 44100, pcmDataLength);
+            const view = new DataView(header);
+
+            // RIFF chunk size = file size - 8
+            expect(view.getUint32(4, true)).toBe(44 - 8 + pcmDataLength);
+        });
+
+        it('should set correct audio format fields for mono', () => {
+            const header = createWavHeader(1, 44100, 1000);
+            const view = new DataView(header);
+
+            expect(view.getUint16(20, true)).toBe(1); // PCM format
+            expect(view.getUint16(22, true)).toBe(1); // 1 channel
+            expect(view.getUint32(24, true)).toBe(44100); // sample rate
+            expect(view.getUint32(28, true)).toBe(88200); // byte rate: 44100 * 1 * 2
+            expect(view.getUint16(32, true)).toBe(2); // block align: 1 * 2
+            expect(view.getUint16(34, true)).toBe(16); // bits per sample
+        });
+
+        it('should set correct audio format fields for stereo', () => {
+            const header = createWavHeader(2, 48000, 2000);
+            const view = new DataView(header);
+
+            expect(view.getUint16(22, true)).toBe(2); // 2 channels
+            expect(view.getUint32(24, true)).toBe(48000); // sample rate
+            expect(view.getUint32(28, true)).toBe(192000); // byte rate: 48000 * 2 * 2
+            expect(view.getUint16(32, true)).toBe(4); // block align: 2 * 2
+        });
+
+        it('should set correct data subchunk size', () => {
+            const pcmDataLength = 8800;
+            const header = createWavHeader(1, 44100, pcmDataLength);
+            const view = new DataView(header);
+
+            expect(view.getUint32(40, true)).toBe(pcmDataLength);
+        });
+    });
+
+    describe('assembleWavFromPcmSegments', () => {
+        it('should assemble WAV from single segment', () => {
+            const pcmData = new Int16Array([100, -100, 200, -200]).buffer;
+            const result = assembleWavFromPcmSegments([pcmData], 1, 44100);
+
+            expect(result.byteLength).toBe(44 + pcmData.byteLength);
+        });
+
+        it('should assemble WAV from multiple segments', () => {
+            const seg1 = new Int16Array([100, -100]).buffer;
+            const seg2 = new Int16Array([200, -200]).buffer;
+            const seg3 = new Int16Array([300, -300]).buffer;
+
+            const result = assembleWavFromPcmSegments([seg1, seg2, seg3], 1, 44100);
+
+            const totalPcm = seg1.byteLength + seg2.byteLength + seg3.byteLength;
+            expect(result.byteLength).toBe(44 + totalPcm);
+        });
+
+        it('should preserve PCM data in correct order', () => {
+            const seg1 = new Int16Array([1000, 2000]).buffer;
+            const seg2 = new Int16Array([3000, 4000]).buffer;
+
+            const result = assembleWavFromPcmSegments([seg1, seg2], 1, 44100);
+
+            const int16View = new Int16Array(result, 44);
+            expect(int16View[0]).toBe(1000);
+            expect(int16View[1]).toBe(2000);
+            expect(int16View[2]).toBe(3000);
+            expect(int16View[3]).toBe(4000);
+        });
+
+        it('should write correct WAV header for assembled data', () => {
+            const pcmData = new Int16Array(100).buffer;
+            const result = assembleWavFromPcmSegments([pcmData], 2, 48000);
+
+            const view = new DataView(result);
+            // Verify RIFF marker
+            expect(String.fromCharCode(view.getUint8(0), view.getUint8(1), view.getUint8(2), view.getUint8(3))).toBe('RIFF');
+            // Verify channels
+            expect(view.getUint16(22, true)).toBe(2);
+            // Verify sample rate
+            expect(view.getUint32(24, true)).toBe(48000);
+            // Verify data size
+            expect(view.getUint32(40, true)).toBe(pcmData.byteLength);
+        });
+
+        it('should handle empty segments array', () => {
+            const result = assembleWavFromPcmSegments([], 1, 44100);
+
+            // Header only, no data
+            expect(result.byteLength).toBe(44);
+            const view = new DataView(result);
+            expect(view.getUint32(40, true)).toBe(0);
+        });
+    });
 
 /**
  * Creates a mock AudioBuffer for testing.


### PR DESCRIPTION
The WAV recording pipeline previously recorded in compressed format (webm/ogg) via MediaRecorder, then decoded the entire file at once using AudioContext.decodeAudioData() and converted to WAV in memory. For recordings >~30 min, this caused ~1.5 GB peak memory usage (float32 AudioBuffer + int16 WAV output), exceeding V8/Chromium limits. Additionally, the chunk append logic used O(n^2) read-modify- write on the temp file, copying ~11.7 GB of data over 45 minutes.

Functional changes:
- Add PcmStreamRecorder class that captures raw int16 PCM audio in real-time via ScriptProcessorNode, bypassing compressed recording entirely for WAV output on desktop
- Add segment-based PCM storage with configurable flush threshold (50 MB), eliminating O(n^2) temp file appending
- Add createWavHeader() and assembleWavFromPcmSegments() to WavEncoder for building WAV files from raw PCM segments
- Update AudioCapabilityDetector to mark WAV as available when AudioContext is present (no longer requires compressed intermediate)
- Preserve existing MediaRecorder path for non-WAV formats and mobile WAV recording unchanged

Test changes:
- Add PcmStreamRecorder unit tests (13 tests): audio graph setup, float32-to-int16 conversion, sample clamping, pause/resume, cleanup
- Add WavEncoder tests (9 tests): header structure, RIFF markers, segment assembly, data preservation, edge cases
- Update RecordingManager WAV test for new PCM capture path

Closes #20