### PR TITLE
feat(ui): add recording controls to status bar, fix context menu dupl…

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,7 +20,7 @@ export default tseslint.config(
                 ...globals.es2021,
             },
             parserOptions: {
-                project: './tsconfig.json',
+                project: './tsconfig.eslint.json',
             },
         },
         rules: {
@@ -57,16 +57,29 @@ export default tseslint.config(
             '**/*.config.mjs',
             '.agent/**',
             'eslint.config.mjs',
-            'tests/**',
             'scripts/**',
             '*.js',
             '*.mjs',
         ],
     },
     {
-        files: ['**/*.spec.ts', '**/*.test.ts'],
+        files: ['tests/**/*.ts'],
         rules: {
+            // Test files need unbound methods for jest mocks
             '@typescript-eslint/unbound-method': 'off',
+            // Test mocks may require type assertions and flexible typing
+            '@typescript-eslint/no-explicit-any': 'warn',
+            '@typescript-eslint/no-unsafe-function-type': 'off',
+            // Test files may use require for jest.mock
+            '@typescript-eslint/no-require-imports': 'off',
+            // Mock files use _prefixed params to indicate intentionally unused args
+            '@typescript-eslint/no-unused-vars': [
+                'error',
+                {
+                    argsIgnorePattern: '^_',
+                    varsIgnorePattern: '^_',
+                },
+            ],
         },
     },
 );

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@
 
 import { Plugin } from 'obsidian';
 import { RecordingStatus } from './types';
-import type { SaveProgress } from './types';
+import type { SaveProgress, RecordingControls } from './types';
 import {
 	AudioRecorderSettings,
 	mergeSettingsAsync,
@@ -38,7 +38,13 @@ export default class AudioRecorderPlugin extends Plugin {
 			this.app,
 			this.settings,
 			(status: RecordingStatus, saveProgress?: SaveProgress) => {
-				updateStatusBar(this.statusBarItem, status, saveProgress);
+				const controls = this.buildRecordingControls(status);
+				updateStatusBar(
+					this.statusBarItem,
+					status,
+					saveProgress,
+					controls,
+				);
 				updateRibbonIcon(this.ribbonIconEl, status);
 			},
 		);
@@ -117,6 +123,33 @@ export default class AudioRecorderPlugin extends Plugin {
 				);
 			},
 		});
+	}
+
+	/**
+	 * Builds recording control callbacks for the status bar buttons.
+	 * Returns controls only when recording is active or paused.
+	 * @param status - Current recording status
+	 * @returns RecordingControls or undefined if not in a recording state
+	 */
+	private buildRecordingControls(
+		status: RecordingStatus,
+	): RecordingControls | undefined {
+		if (
+			status !== RecordingStatus.Recording &&
+			status !== RecordingStatus.Paused
+		) {
+			return undefined;
+		}
+
+		return {
+			onPauseResume: () => {
+				this.recordingManager.togglePauseResume();
+			},
+			onStop: () => {
+				void this.recordingManager.stopRecording();
+			},
+			isPaused: status === RecordingStatus.Paused,
+		};
 	}
 
 	/**

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,3 +20,12 @@ export type SaveProgress = {
 	percent: number;
 	description: string;
 };
+
+/**
+ * Callbacks for recording control buttons in the status bar.
+ */
+export type RecordingControls = {
+	onPauseResume: () => void;
+	onStop: () => void;
+	isPaused: boolean;
+};

--- a/src/ui/ContextMenu.ts
+++ b/src/ui/ContextMenu.ts
@@ -28,10 +28,16 @@ interface EditorWithCM extends Editor {
 	cm?: EditorCodeMirrorView;
 }
 
+/** Menu section identifier for all AAR plugin items. */
+const AAR_MENU_SECTION = 'aar';
+
 /**
  * Manages context menu items for audio files.
  */
 export class ContextMenu {
+	/** Tracks menus that already have the "Audio file info" item to prevent duplicates. */
+	private readonly menusWithInfoItem = new WeakSet<Menu>();
+
 	/**
 	 * Creates a new ContextMenu instance.
 	 * @param app - The Obsidian App instance.
@@ -306,7 +312,7 @@ export class ContextMenu {
 		menu.addItem((item: MenuItem) => {
 			item.setTitle('Delete recording')
 				.setIcon('trash')
-				.setSection('danger')
+				.setSection(AAR_MENU_SECTION)
 				.onClick(async () => {
 					try {
 						await this.app.fileManager.trashFile(file);
@@ -337,7 +343,7 @@ export class ContextMenu {
 		menu.addItem((item: MenuItem) => {
 			item.setTitle('Delete recording & link to file')
 				.setIcon('trash')
-				.setSection('danger')
+				.setSection(AAR_MENU_SECTION)
 				.onClick(() =>
 					this.deleteRecordingAndLink(file, editor, line, linkMatch),
 				);
@@ -350,10 +356,15 @@ export class ContextMenu {
 	 * @param file - The audio file.
 	 */
 	private addAudioFileInfoMenuItem(menu: Menu, file: TFile): void {
+		if (this.menusWithInfoItem.has(menu)) {
+			return;
+		}
+		this.menusWithInfoItem.add(menu);
+
 		menu.addItem((item: MenuItem) => {
 			item.setTitle('Audio file info')
 				.setIcon('info')
-				.setSection('default')
+				.setSection(AAR_MENU_SECTION)
 				.onClick(async () => {
 					const info = await getAudioFileInfo(this.app, file);
 					if (info) {

--- a/src/ui/StatusBar.ts
+++ b/src/ui/StatusBar.ts
@@ -1,10 +1,11 @@
 /**
- * Status bar component for displaying recording status.
+ * Status bar component for displaying recording status and controls.
  * @module ui/StatusBar
  */
 
+import { setIcon } from 'obsidian';
 import { RecordingStatus } from '../types';
-import type { SaveProgress } from '../types';
+import type { SaveProgress, RecordingControls } from '../types';
 
 /**
  * Updates the status bar element based on recording status.
@@ -12,11 +13,13 @@ import type { SaveProgress } from '../types';
  * @param statusBarItem - The status bar HTML element
  * @param status - Current recording status
  * @param saveProgress - Optional save progress info for Saving state
+ * @param controls - Optional recording control callbacks for interactive buttons
  */
 export function updateStatusBar(
 	statusBarItem: HTMLElement | null,
 	status: RecordingStatus,
 	saveProgress?: SaveProgress,
+	controls?: RecordingControls,
 ): void {
 	if (!statusBarItem) {
 		return;
@@ -24,45 +27,117 @@ export function updateStatusBar(
 
 	switch (status) {
 		case RecordingStatus.Recording:
-			statusBarItem.empty();
-			statusBarItem.textContent = 'Recording...';
-			statusBarItem.classList.add('is-recording');
-			statusBarItem.classList.remove('is-saving');
+			renderRecordingState(statusBarItem, 'Recording...', controls);
 			break;
 		case RecordingStatus.Paused:
-			statusBarItem.empty();
-			statusBarItem.textContent = 'Recording paused';
-			statusBarItem.classList.add('is-recording');
-			statusBarItem.classList.remove('is-saving');
+			renderRecordingState(statusBarItem, 'Recording paused', controls);
 			break;
-		case RecordingStatus.Saving: {
-			statusBarItem.empty();
-			statusBarItem.classList.remove('is-recording');
-			statusBarItem.classList.add('is-saving');
-
-			const text = statusBarItem.createSpan();
-			text.textContent = saveProgress?.description ?? 'Saving...';
-
-			const progressContainer = statusBarItem.createDiv({
-				cls: 'aar-save-progress',
-			});
-			const progressBar = progressContainer.createDiv({
-				cls: 'aar-save-progress-bar',
-			});
-			const percent = saveProgress?.percent ?? 0;
-			progressBar.setCssProps({
-				'--save-progress': `${String(percent)}%`,
-			});
+		case RecordingStatus.Saving:
+			renderSavingState(statusBarItem, saveProgress);
 			break;
-		}
 		case RecordingStatus.Idle:
 		default:
-			statusBarItem.empty();
-			statusBarItem.textContent = '';
-			statusBarItem.classList.remove('is-recording');
-			statusBarItem.classList.remove('is-saving');
+			renderIdleState(statusBarItem);
 			break;
 	}
+}
+
+/**
+ * Renders the recording or paused state with control buttons.
+ * @param el - The status bar HTML element
+ * @param label - Display text for the current state
+ * @param controls - Optional recording control callbacks
+ */
+function renderRecordingState(
+	el: HTMLElement,
+	label: string,
+	controls?: RecordingControls,
+): void {
+	el.empty();
+	el.classList.add('is-recording');
+	el.classList.remove('is-saving');
+
+	const container = el.createDiv({ cls: 'aar-recording-controls' });
+	const text = container.createSpan({ cls: 'aar-recording-label' });
+	text.textContent = label;
+
+	if (controls) {
+		const buttons = container.createSpan({
+			cls: 'aar-recording-buttons',
+		});
+		createControlButton(
+			buttons,
+			controls.isPaused ? 'play' : 'pause',
+			controls.isPaused ? 'Resume recording' : 'Pause recording',
+			controls.onPauseResume,
+		);
+		createControlButton(
+			buttons,
+			'square',
+			'Stop recording',
+			controls.onStop,
+		);
+	}
+}
+
+/**
+ * Creates a clickable control button with an icon in the status bar.
+ * @param parent - Parent element to append the button to
+ * @param icon - Obsidian icon name
+ * @param ariaLabel - Accessible label for the button
+ * @param onClick - Click handler
+ */
+function createControlButton(
+	parent: HTMLElement,
+	icon: string,
+	ariaLabel: string,
+	onClick: () => void,
+): void {
+	const button = parent.createSpan({ cls: 'aar-control-btn' });
+	button.setAttribute('aria-label', ariaLabel);
+	button.setAttribute('role', 'button');
+	button.tabIndex = 0;
+	setIcon(button, icon);
+	button.addEventListener('click', (e: MouseEvent) => {
+		e.stopPropagation();
+		onClick();
+	});
+}
+
+/**
+ * Renders the saving state with progress bar.
+ * @param el - The status bar HTML element
+ * @param saveProgress - Optional save progress info
+ */
+function renderSavingState(el: HTMLElement, saveProgress?: SaveProgress): void {
+	el.empty();
+	el.classList.remove('is-recording');
+	el.classList.add('is-saving');
+
+	const text = el.createSpan();
+	text.textContent = saveProgress?.description ?? 'Saving...';
+
+	const progressContainer = el.createDiv({
+		cls: 'aar-save-progress',
+	});
+	const progressBar = progressContainer.createDiv({
+		cls: 'aar-save-progress-bar',
+	});
+	const percent = saveProgress?.percent ?? 0;
+	progressBar.setCssProps({
+		'--save-progress': `${String(percent)}%`,
+	});
+}
+
+/**
+ * Renders the idle state (empty status bar).
+ * @param el - The status bar HTML element
+ */
+function renderIdleState(el: HTMLElement): void {
+	el.empty();
+	el.textContent = '';
+	el.classList.remove('is-recording');
+	el.classList.remove('is-saving');
 }
 
 /**

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -35,7 +35,6 @@ If your plugin does not need CSS, delete this file.
     color: var(--color-accent);
     font-weight: bold;
     white-space: nowrap;
-    min-width: 150px;
 }
 
 .side-dock-ribbon-action.is-saving svg {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -34,6 +34,8 @@ If your plugin does not need CSS, delete this file.
 .is-saving {
     color: var(--color-accent);
     font-weight: bold;
+    white-space: nowrap;
+    min-width: 150px;
 }
 
 .side-dock-ribbon-action.is-saving svg {
@@ -41,6 +43,47 @@ If your plugin does not need CSS, delete this file.
     animation: pulse-saving 1.5s ease-in-out infinite;
 }
 
+/* Recording controls in status bar */
+.aar-recording-controls {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    white-space: nowrap;
+}
+
+.aar-recording-label {
+    margin-right: 2px;
+}
+
+.aar-recording-buttons {
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+}
+
+.aar-control-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    border-radius: 4px;
+    cursor: pointer;
+    opacity: 0.8;
+    transition: opacity 0.15s ease, background-color 0.15s ease;
+}
+
+.aar-control-btn:hover {
+    opacity: 1;
+    background-color: var(--background-modifier-hover);
+}
+
+.aar-control-btn svg {
+    width: 14px;
+    height: 14px;
+}
+
+/* Save progress */
 .aar-save-progress {
     height: 3px;
     width: 100%;

--- a/tests/RecordingManager.fallback.test.ts
+++ b/tests/RecordingManager.fallback.test.ts
@@ -8,8 +8,8 @@
 import { RecordingManager } from '../src/recording/RecordingManager';
 import { RecordingStatus } from '../src/types';
 import {
-    DEFAULT_SETTINGS,
-    AudioRecorderSettings,
+	DEFAULT_SETTINGS,
+	AudioRecorderSettings,
 } from '../src/settings/Settings';
 import { AudioStreamError } from '../src/errors';
 import { PLUGIN_LOG_PREFIX } from '../src/constants';
@@ -18,280 +18,290 @@ import type { App } from 'obsidian';
 // Mock AudioContext and OfflineAudioContext
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (global as any).AudioContext = jest.fn().mockImplementation(() => ({
-    decodeAudioData: jest.fn().mockResolvedValue({
-        duration: 1,
-        length: 44100,
-        sampleRate: 44100,
-        numberOfChannels: 1,
-        getChannelData: jest.fn().mockReturnValue(new Float32Array(44100)),
-    }),
-    createBufferSource: jest.fn().mockImplementation(() => ({
-        connect: jest.fn(),
-        start: jest.fn(),
-        buffer: null,
-    })),
-    destination: {},
-    close: jest.fn().mockResolvedValue(undefined),
-    sampleRate: 44100,
+	decodeAudioData: jest.fn().mockResolvedValue({
+		duration: 1,
+		length: 44100,
+		sampleRate: 44100,
+		numberOfChannels: 1,
+		getChannelData: jest.fn().mockReturnValue(new Float32Array(44100)),
+	}),
+	createBufferSource: jest.fn().mockImplementation(() => ({
+		connect: jest.fn(),
+		start: jest.fn(),
+		buffer: null,
+	})),
+	destination: {},
+	close: jest.fn().mockResolvedValue(undefined),
+	sampleRate: 44100,
 }));
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (global as any).OfflineAudioContext = jest.fn().mockImplementation(() => ({
-    createBufferSource: jest.fn().mockImplementation(() => ({
-        connect: jest.fn(),
-        start: jest.fn(),
-        buffer: null,
-    })),
-    startRendering: jest.fn().mockResolvedValue({
-        length: 44100,
-        sampleRate: 44100,
-        getChannelData: jest.fn().mockReturnValue(new Float32Array(44100)),
-    }),
-    destination: {},
+	createBufferSource: jest.fn().mockImplementation(() => ({
+		connect: jest.fn(),
+		start: jest.fn(),
+		buffer: null,
+	})),
+	startRendering: jest.fn().mockResolvedValue({
+		length: 44100,
+		sampleRate: 44100,
+		getChannelData: jest.fn().mockReturnValue(new Float32Array(44100)),
+	}),
+	destination: {},
 }));
 
 // Mock AudioBuffer
 (global as any).AudioBuffer = jest.fn().mockImplementation(() => ({
-    getChannelData: jest.fn().mockReturnValue(new Float32Array(44100)),
+	getChannelData: jest.fn().mockReturnValue(new Float32Array(44100)),
 }));
 
 // Mock OverconstrainedError if not present in JSDOM
 class OverconstrainedError extends Error {
-    constraint: string;
-    constructor(constraint: string, message?: string) {
-        super(message || 'OverconstrainedError');
-        this.name = 'OverconstrainedError';
-        this.constraint = constraint;
-    }
+	constraint: string;
+	constructor(constraint: string, message?: string) {
+		super(message || 'OverconstrainedError');
+		this.name = 'OverconstrainedError';
+		this.constraint = constraint;
+	}
 }
 (global as unknown as Record<string, unknown>).OverconstrainedError =
-    OverconstrainedError;
+	OverconstrainedError;
 
 // Mock obsidian module
 const mockNotice = jest.fn();
 jest.mock('obsidian', () => ({
-    Notice: jest.fn().mockImplementation((msg: string) => mockNotice(msg)),
-    MarkdownView: jest.fn(),
-    normalizePath: (path: string) => path.replace(/\\/g, '/'),
-    Platform: {
-        isMobile: false,
-        isMobileApp: false,
-    },
+	Notice: jest.fn().mockImplementation((msg: string) => mockNotice(msg)),
+	MarkdownView: jest.fn(),
+	normalizePath: (path: string) => path.replace(/\\/g, '/'),
+	Platform: {
+		isMobile: false,
+		isMobileApp: false,
+	},
 }));
 
 // Mock WavEncoder
 jest.mock('../src/recording/WavEncoder', () => ({
-    bufferToWave: jest
-        .fn()
-        .mockReturnValue(new Blob(['test'], { type: 'audio/wav' })),
+	bufferToWave: jest
+		.fn()
+		.mockReturnValue(new Blob(['test'], { type: 'audio/wav' })),
 }));
 
 describe('AudioStreamHandler: Error Handling', () => {
-    let manager: RecordingManager;
-    let mockApp: App;
-    let mockSettings: AudioRecorderSettings;
-    let statusChangeCallback: jest.Mock;
-    let consoleErrorSpy: jest.SpyInstance;
+	let manager: RecordingManager;
+	let mockApp: App;
+	let mockSettings: AudioRecorderSettings;
+	let statusChangeCallback: jest.Mock;
+	let consoleErrorSpy: jest.SpyInstance;
 
-    beforeEach(() => {
-        jest.clearAllMocks();
-        consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+	beforeEach(() => {
+		jest.clearAllMocks();
+		consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
 
-        mockApp = {
-            vault: {
-                adapter: {
-                    exists: jest.fn().mockResolvedValue(false),
-                    writeBinary: jest.fn().mockResolvedValue(undefined),
-                    rename: jest.fn().mockResolvedValue(undefined),
-                    readBinary: jest.fn().mockResolvedValue(new ArrayBuffer(0)),
-                    remove: jest.fn().mockResolvedValue(undefined),
-                },
-                createBinary: jest.fn().mockResolvedValue(undefined),
-                createFolder: jest.fn().mockResolvedValue(undefined),
-            },
-            workspace: {
-                getActiveViewOfType: jest.fn().mockReturnValue(null),
-                getActiveFile: jest.fn().mockReturnValue(null),
-            },
-        } as unknown as App;
+		mockApp = {
+			vault: {
+				adapter: {
+					exists: jest.fn().mockResolvedValue(false),
+					writeBinary: jest.fn().mockResolvedValue(undefined),
+					rename: jest.fn().mockResolvedValue(undefined),
+					readBinary: jest.fn().mockResolvedValue(new ArrayBuffer(0)),
+					remove: jest.fn().mockResolvedValue(undefined),
+				},
+				createBinary: jest.fn().mockResolvedValue(undefined),
+				createFolder: jest.fn().mockResolvedValue(undefined),
+			},
+			workspace: {
+				getActiveViewOfType: jest.fn().mockReturnValue(null),
+				getActiveFile: jest.fn().mockReturnValue(null),
+			},
+		} as unknown as App;
 
-        mockSettings = { ...DEFAULT_SETTINGS, audioDeviceId: 'test-device-id' };
-        statusChangeCallback = jest.fn();
-        manager = new RecordingManager(mockApp, mockSettings, statusChangeCallback);
+		mockSettings = { ...DEFAULT_SETTINGS, audioDeviceId: 'test-device-id' };
+		statusChangeCallback = jest.fn();
+		manager = new RecordingManager(
+			mockApp,
+			mockSettings,
+			statusChangeCallback,
+		);
 
-        // Mock MediaRecorder
-        const mockMediaRecorder = {
-            start: jest.fn(),
-            stop: jest.fn(),
-            ondataavailable: null,
-            onerror: null,
-        };
-        (global as unknown as Record<string, unknown>).MediaRecorder = jest.fn(
-            () => mockMediaRecorder,
-        );
-        (
-            (global as unknown as Record<string, unknown>)
-                .MediaRecorder as unknown as Record<string, unknown>
-        ).isTypeSupported = jest.fn().mockReturnValue(true);
-    });
+		// Mock MediaRecorder
+		const mockMediaRecorder = {
+			start: jest.fn(),
+			stop: jest.fn(),
+			ondataavailable: null,
+			onerror: null,
+		};
+		(global as unknown as Record<string, unknown>).MediaRecorder = jest.fn(
+			() => mockMediaRecorder,
+		);
+		(
+			(global as unknown as Record<string, unknown>)
+				.MediaRecorder as Record<string, unknown>
+		).isTypeSupported = jest.fn().mockReturnValue(true);
+	});
 
-    afterEach(() => {
-        consoleErrorSpy.mockRestore();
-    });
+	afterEach(() => {
+		consoleErrorSpy.mockRestore();
+	});
 
-    it('should log AudioStreamError when OverconstrainedError occurs', async () => {
-        const getUserMediaMock = jest
-            .fn()
-            .mockRejectedValueOnce(
-                new OverconstrainedError('deviceId', 'Constraint not satisfied'),
-            );
+	it('should log AudioStreamError when OverconstrainedError occurs', async () => {
+		const getUserMediaMock = jest
+			.fn()
+			.mockRejectedValueOnce(
+				new OverconstrainedError(
+					'deviceId',
+					'Constraint not satisfied',
+				),
+			);
 
-        Object.defineProperty(navigator, 'mediaDevices', {
-            value: {
-                getUserMedia: getUserMediaMock,
-                enumerateDevices: jest.fn().mockResolvedValue([
-                    {
-                        deviceId: 'test-device-id',
-                        kind: 'audioinput',
-                        label: 'Test Device',
-                    },
-                ]),
-            },
-            writable: true,
-        });
+		Object.defineProperty(navigator, 'mediaDevices', {
+			value: {
+				getUserMedia: getUserMediaMock,
+				enumerateDevices: jest.fn().mockResolvedValue([
+					{
+						deviceId: 'test-device-id',
+						kind: 'audioinput',
+						label: 'Test Device',
+					},
+				]),
+			},
+			writable: true,
+		});
 
-        await manager.startRecording();
+		await manager.startRecording();
 
-        expect(consoleErrorSpy).toHaveBeenCalledWith(
-            `${PLUGIN_LOG_PREFIX} Error in startRecording:`,
-            expect.any(AudioStreamError),
-        );
-    });
+		expect(consoleErrorSpy).toHaveBeenCalledWith(
+			`${PLUGIN_LOG_PREFIX} Error in startRecording:`,
+			expect.any(AudioStreamError),
+		);
+	});
 
-    it('should show Notice with error message containing device ID', async () => {
-        const getUserMediaMock = jest
-            .fn()
-            .mockRejectedValueOnce(
-                new OverconstrainedError('deviceId', 'Device not found'),
-            );
+	it('should show Notice with error message containing device ID', async () => {
+		const getUserMediaMock = jest
+			.fn()
+			.mockRejectedValueOnce(
+				new OverconstrainedError('deviceId', 'Device not found'),
+			);
 
-        Object.defineProperty(navigator, 'mediaDevices', {
-            value: {
-                getUserMedia: getUserMediaMock,
-                enumerateDevices: jest.fn().mockResolvedValue([
-                    {
-                        deviceId: 'test-device-id',
-                        kind: 'audioinput',
-                        label: 'Test Device',
-                    },
-                ]),
-            },
-            writable: true,
-        });
+		Object.defineProperty(navigator, 'mediaDevices', {
+			value: {
+				getUserMedia: getUserMediaMock,
+				enumerateDevices: jest.fn().mockResolvedValue([
+					{
+						deviceId: 'test-device-id',
+						kind: 'audioinput',
+						label: 'Test Device',
+					},
+				]),
+			},
+			writable: true,
+		});
 
-        await manager.startRecording();
+		await manager.startRecording();
 
-        expect(mockNotice).toHaveBeenCalledWith(
-            expect.stringContaining('test-device-id'),
-        );
-    });
+		expect(mockNotice).toHaveBeenCalledWith(
+			expect.stringContaining('test-device-id'),
+		);
+	});
 
-    it('should suggest checking plugin settings in Notice', async () => {
-        const getUserMediaMock = jest
-            .fn()
-            .mockRejectedValueOnce(new Error('NotFoundError'));
+	it('should suggest checking plugin settings in Notice', async () => {
+		const getUserMediaMock = jest
+			.fn()
+			.mockRejectedValueOnce(new Error('NotFoundError'));
 
-        Object.defineProperty(navigator, 'mediaDevices', {
-            value: {
-                getUserMedia: getUserMediaMock,
-                enumerateDevices: jest.fn().mockResolvedValue([
-                    {
-                        deviceId: 'test-device-id',
-                        kind: 'audioinput',
-                        label: 'Test Device',
-                    },
-                ]),
-            },
-            writable: true,
-        });
+		Object.defineProperty(navigator, 'mediaDevices', {
+			value: {
+				getUserMedia: getUserMediaMock,
+				enumerateDevices: jest.fn().mockResolvedValue([
+					{
+						deviceId: 'test-device-id',
+						kind: 'audioinput',
+						label: 'Test Device',
+					},
+				]),
+			},
+			writable: true,
+		});
 
-        await manager.startRecording();
+		await manager.startRecording();
 
-        expect(mockNotice).toHaveBeenCalledWith(
-            expect.stringContaining('verify the device in plugin settings'),
-        );
-    });
+		expect(mockNotice).toHaveBeenCalledWith(
+			expect.stringContaining('verify the device in plugin settings'),
+		);
+	});
 
-    it('should not fallback to default device', async () => {
-        const getUserMediaMock = jest
-            .fn()
-            .mockRejectedValueOnce(
-                new OverconstrainedError('deviceId', 'Constraint not satisfied'),
-            );
+	it('should not fallback to default device', async () => {
+		const getUserMediaMock = jest
+			.fn()
+			.mockRejectedValueOnce(
+				new OverconstrainedError(
+					'deviceId',
+					'Constraint not satisfied',
+				),
+			);
 
-        Object.defineProperty(navigator, 'mediaDevices', {
-            value: {
-                getUserMedia: getUserMediaMock,
-                enumerateDevices: jest.fn().mockResolvedValue([
-                    {
-                        deviceId: 'test-device-id',
-                        kind: 'audioinput',
-                        label: 'Test Device',
-                    },
-                ]),
-            },
-            writable: true,
-        });
+		Object.defineProperty(navigator, 'mediaDevices', {
+			value: {
+				getUserMedia: getUserMediaMock,
+				enumerateDevices: jest.fn().mockResolvedValue([
+					{
+						deviceId: 'test-device-id',
+						kind: 'audioinput',
+						label: 'Test Device',
+					},
+				]),
+			},
+			writable: true,
+		});
 
-        await manager.startRecording();
+		await manager.startRecording();
 
-        // getUserMedia should only be called once (no fallback attempt)
-        expect(getUserMediaMock).toHaveBeenCalledTimes(1);
-    });
+		// getUserMedia should only be called once (no fallback attempt)
+		expect(getUserMediaMock).toHaveBeenCalledTimes(1);
+	});
 
-    it('should remain in Idle status on error', async () => {
-        const getUserMediaMock = jest
-            .fn()
-            .mockRejectedValueOnce(new Error('Access denied'));
+	it('should remain in Idle status on error', async () => {
+		const getUserMediaMock = jest
+			.fn()
+			.mockRejectedValueOnce(new Error('Access denied'));
 
-        Object.defineProperty(navigator, 'mediaDevices', {
-            value: {
-                getUserMedia: getUserMediaMock,
-                enumerateDevices: jest.fn().mockResolvedValue([
-                    {
-                        deviceId: 'test-device-id',
-                        kind: 'audioinput',
-                        label: 'Test Device',
-                    },
-                ]),
-            },
-            writable: true,
-        });
+		Object.defineProperty(navigator, 'mediaDevices', {
+			value: {
+				getUserMedia: getUserMediaMock,
+				enumerateDevices: jest.fn().mockResolvedValue([
+					{
+						deviceId: 'test-device-id',
+						kind: 'audioinput',
+						label: 'Test Device',
+					},
+				]),
+			},
+			writable: true,
+		});
 
-        await manager.startRecording();
+		await manager.startRecording();
 
-        expect(manager.getStatus()).toBe(RecordingStatus.Idle);
-    });
+		expect(manager.getStatus()).toBe(RecordingStatus.Idle);
+	});
 });
 
 describe('AudioStreamError', () => {
-    it('should create error with device ID', () => {
-        const original = new Error('Original error');
-        const error = new AudioStreamError(original, 'my-device-id');
+	it('should create error with device ID', () => {
+		const original = new Error('Original error');
+		const error = new AudioStreamError(original, 'my-device-id');
 
-        expect(error.name).toBe('AudioStreamError');
-        expect(error.message).toContain('my-device-id');
-        expect(error.originalError).toBe(original);
-        expect(error.deviceId).toBe('my-device-id');
-    });
+		expect(error.name).toBe('AudioStreamError');
+		expect(error.message).toContain('my-device-id');
+		expect(error.originalError).toBe(original);
+		expect(error.deviceId).toBe('my-device-id');
+	});
 
-    it('should create error without device ID', () => {
-        const original = new Error('Original error');
-        const error = new AudioStreamError(original);
+	it('should create error without device ID', () => {
+		const original = new Error('Original error');
+		const error = new AudioStreamError(original);
 
-        expect(error.name).toBe('AudioStreamError');
-        expect(error.message).toContain('Failed to access audio device');
-        expect(error.message).toContain('Original error');
-        expect(error.deviceId).toBeUndefined();
-    });
+		expect(error.name).toBe('AudioStreamError');
+		expect(error.message).toContain('Failed to access audio device');
+		expect(error.message).toContain('Original error');
+		expect(error.deviceId).toBeUndefined();
+	});
 });

--- a/tests/mocks/obsidian.ts
+++ b/tests/mocks/obsidian.ts
@@ -7,101 +7,108 @@
  * Mock Plugin class.
  */
 export class Plugin {
-    app: App;
-    manifest: PluginManifest | null = null;
+	app: App;
+	manifest: PluginManifest | null = null;
 
-    constructor(app: App, manifest: PluginManifest) {
-        this.app = app;
-        this.manifest = manifest;
-    }
+	constructor(app: App, manifest: PluginManifest) {
+		this.app = app;
+		this.manifest = manifest;
+	}
 
-    addCommand(_command: Command): Command {
-        return _command;
-    }
+	addCommand(_command: Command): Command {
+		return _command;
+	}
 
-    addRibbonIcon(_icon: string, _title: string, _callback: () => void): HTMLElement {
-        return document.createElement('div');
-    }
+	addRibbonIcon(
+		_icon: string,
+		_title: string,
+		_callback: () => void,
+	): HTMLElement {
+		return document.createElement('div');
+	}
 
-    addSettingTab(_settingTab: PluginSettingTab): void {
-        // Mock implementation
-    }
+	addSettingTab(_settingTab: PluginSettingTab): void {
+		// Mock implementation
+	}
 
-    addStatusBarItem(): HTMLElement {
-        return document.createElement('div');
-    }
+	addStatusBarItem(): HTMLElement {
+		return document.createElement('div');
+	}
 
-    async loadData(): Promise<unknown> {
-        return {};
-    }
+	async loadData(): Promise<unknown> {
+		return {};
+	}
 
-    async saveData(_data: unknown): Promise<void> {
-        // Mock implementation
-    }
+	async saveData(_data: unknown): Promise<void> {
+		// Mock implementation
+	}
 }
 
 /**
  * Mock App class.
  */
 export class App {
-    vault: Vault = new Vault();
-    workspace: Workspace = new Workspace();
+	vault: Vault = new Vault();
+	workspace: Workspace = new Workspace();
 }
 
 /**
  * Mock Vault class.
  */
 export class Vault {
-    adapter = {
-        exists: async (_path: string): Promise<boolean> => false,
-        append: async (_path: string, _data: ArrayBuffer): Promise<void> => {
-            // Mock implementation
-        },
-        rename: async (_oldPath: string, _newPath: string): Promise<void> => {
-            // Mock implementation
-        },
-        readBinary: async (_path: string): Promise<ArrayBuffer> =>
-            new ArrayBuffer(0),
-        writeBinary: async (
-            _path: string,
-            _data: ArrayBuffer,
-        ): Promise<void> => {
-            // Mock implementation
-        },
-        remove: async (_path: string): Promise<void> => {
-            // Mock implementation
-        },
-    };
+	adapter = {
+		exists: async (_path: string): Promise<boolean> => false,
+		append: async (_path: string, _data: ArrayBuffer): Promise<void> => {
+			// Mock implementation
+		},
+		rename: async (_oldPath: string, _newPath: string): Promise<void> => {
+			// Mock implementation
+		},
+		readBinary: async (_path: string): Promise<ArrayBuffer> =>
+			new ArrayBuffer(0),
+		writeBinary: async (
+			_path: string,
+			_data: ArrayBuffer,
+		): Promise<void> => {
+			// Mock implementation
+		},
+		remove: async (_path: string): Promise<void> => {
+			// Mock implementation
+		},
+	};
 
-    async createBinary(_path: string, _data: ArrayBuffer): Promise<void> {
-        // Mock implementation
-    }
+	async createBinary(_path: string, _data: ArrayBuffer): Promise<void> {
+		// Mock implementation
+	}
 
-    getRoot(): TFolder {
-        return new TFolder('');
-    }
+	getRoot(): TFolder {
+		return new TFolder('');
+	}
 
-    static recurseChildren(_root: TFolder, _callback: (file: TAbstractFile) => void): void {
-        // Mock implementation
-    }
+	static recurseChildren(
+		_root: TFolder,
+		_callback: (file: TAbstractFile) => void,
+	): void {
+		// Mock implementation
+	}
 }
 
 /**
  * Mock Workspace class.
  */
 export class Workspace {
-    getActiveViewOfType<T>(_type: new (...args: unknown[]) => T): T | null {
-        return null;
-    }
+	getActiveViewOfType<T>(_type: new (...args: unknown[]) => T): T | null {
+		return null;
+	}
 }
 
 /**
  * Mock Notice class.
  */
 export class Notice {
-    constructor(_message: string, _timeout?: number) {
-        // Mock implementation
-    }
+	constructor(_message: string, _timeout?: number) {
+		// Mock implementation
+	}
 }
 
 /**
@@ -109,304 +116,320 @@ export class Notice {
  * Obsidian extends HTMLElement with helper methods like createEl, setText, etc.
  */
 function addObsidianDomExtensions(el: HTMLElement): HTMLElement {
-    // Use unknown cast to avoid TypeScript's overloaded HTMLElement extension conflicts
-    const extended = el as unknown as Record<string, unknown>;
+	// Use unknown cast to avoid TypeScript's overloaded HTMLElement extension conflicts
+	const extended = el as unknown as Record<string, unknown>;
 
-    extended['createEl'] = (tag: string, opts?: { text?: string; cls?: string | string[]; attr?: Record<string, string> }): HTMLElement => {
-        const child = document.createElement(tag);
-        addObsidianDomExtensions(child);
-        if (opts?.text) child.textContent = opts.text;
-        if (opts?.cls) {
-            const classes = Array.isArray(opts.cls) ? opts.cls : opts.cls.split(' ');
-            classes.forEach((c) => child.classList.add(c));
-        }
-        if (opts?.attr) {
-            Object.entries(opts.attr).forEach(([k, v]) => child.setAttribute(k, v));
-        }
-        el.appendChild(child);
-        return child;
-    };
+	extended['createEl'] = (
+		tag: string,
+		opts?: {
+			text?: string;
+			cls?: string | string[];
+			attr?: Record<string, string>;
+		},
+	): HTMLElement => {
+		const child = document.createElement(tag);
+		addObsidianDomExtensions(child);
+		if (opts?.text) child.textContent = opts.text;
+		if (opts?.cls) {
+			const classes = Array.isArray(opts.cls)
+				? opts.cls
+				: opts.cls.split(' ');
+			classes.forEach((c) => child.classList.add(c));
+		}
+		if (opts?.attr) {
+			Object.entries(opts.attr).forEach(([k, v]) =>
+				child.setAttribute(k, v),
+			);
+		}
+		el.appendChild(child);
+		return child;
+	};
 
-    extended['createDiv'] = (opts?: { cls?: string }): HTMLElement => {
-        const createEl = extended['createEl'] as (tag: string, opts?: { cls?: string }) => HTMLElement;
-        return createEl('div', opts ? { cls: opts.cls } : undefined);
-    };
+	extended['createDiv'] = (opts?: { cls?: string }): HTMLElement => {
+		const createEl = extended['createEl'] as (
+			tag: string,
+			opts?: { cls?: string },
+		) => HTMLElement;
+		return createEl('div', opts ? { cls: opts.cls } : undefined);
+	};
 
-    extended['setText'] = (text: string): void => {
-        el.textContent = text;
-    };
+	extended['setText'] = (text: string): void => {
+		el.textContent = text;
+	};
 
-    extended['addClass'] = (...classes: string[]): void => {
-        classes.forEach((c) => el.classList.add(c));
-    };
+	extended['addClass'] = (...classes: string[]): void => {
+		classes.forEach((c) => el.classList.add(c));
+	};
 
-    extended['removeClass'] = (...classes: string[]): void => {
-        classes.forEach((c) => el.classList.remove(c));
-    };
+	extended['removeClass'] = (...classes: string[]): void => {
+		classes.forEach((c) => el.classList.remove(c));
+	};
 
-    extended['empty'] = (): void => {
-        while (el.firstChild) {
-            el.removeChild(el.firstChild);
-        }
-    };
+	extended['empty'] = (): void => {
+		while (el.firstChild) {
+			el.removeChild(el.firstChild);
+		}
+	};
 
-    return el;
+	return el;
 }
 
 /**
  * Mock Modal class.
  */
 export class Modal {
-    app: App;
-    contentEl: HTMLElement;
+	app: App;
+	contentEl: HTMLElement;
 
-    constructor(app: App) {
-        this.app = app;
-        this.contentEl = addObsidianDomExtensions(document.createElement('div'));
-    }
+	constructor(app: App) {
+		this.app = app;
+		this.contentEl = addObsidianDomExtensions(
+			document.createElement('div'),
+		);
+	}
 
-    open(): void {
-        // Mock implementation
-    }
+	open(): void {
+		// Mock implementation
+	}
 
-    close(): void {
-        // Mock implementation
-    }
+	close(): void {
+		// Mock implementation
+	}
 
-    onOpen(): void {
-        // Mock implementation
-    }
+	onOpen(): void {
+		// Mock implementation
+	}
 
-    onClose(): void {
-        // Mock implementation
-    }
+	onClose(): void {
+		// Mock implementation
+	}
 }
 
 /**
  * Mock Setting class.
  */
 export class Setting {
-    settingEl: HTMLElement;
-    nameEl: HTMLElement;
-    descEl: HTMLElement;
+	settingEl: HTMLElement;
+	nameEl: HTMLElement;
+	descEl: HTMLElement;
 
-    constructor(_containerEl: HTMLElement) {
-        this.settingEl = document.createElement('div');
-        this.nameEl = document.createElement('div');
-        this.descEl = document.createElement('div');
-    }
+	constructor(_containerEl: HTMLElement) {
+		this.settingEl = document.createElement('div');
+		this.nameEl = document.createElement('div');
+		this.descEl = document.createElement('div');
+	}
 
-    setName(_name: string): this {
-        return this;
-    }
+	setName(_name: string): this {
+		return this;
+	}
 
-    setDesc(_desc: string): this {
-        return this;
-    }
+	setDesc(_desc: string): this {
+		return this;
+	}
 
-    setHeading(): this {
-        return this;
-    }
+	setHeading(): this {
+		return this;
+	}
 
-    addText(_callback: (text: TextComponent) => void): this {
-        return this;
-    }
+	addText(_callback: (text: TextComponent) => void): this {
+		return this;
+	}
 
-    addToggle(_callback: (toggle: ToggleComponent) => void): this {
-        return this;
-    }
+	addToggle(_callback: (toggle: ToggleComponent) => void): this {
+		return this;
+	}
 
-    addDropdown(_callback: (dropdown: DropdownComponent) => void): this {
-        return this;
-    }
+	addDropdown(_callback: (dropdown: DropdownComponent) => void): this {
+		return this;
+	}
 
-    addSlider(_callback: (slider: SliderComponent) => void): this {
-        return this;
-    }
+	addSlider(_callback: (slider: SliderComponent) => void): this {
+		return this;
+	}
 }
 
 /**
  * Mock PluginSettingTab class.
  */
 export class PluginSettingTab {
-    app: App;
-    containerEl: HTMLElement = document.createElement('div');
-    plugin: Plugin;
+	app: App;
+	containerEl: HTMLElement = document.createElement('div');
+	plugin: Plugin;
 
-    constructor(app: App, plugin: Plugin) {
-        this.app = app;
-        this.plugin = plugin;
-    }
+	constructor(app: App, plugin: Plugin) {
+		this.app = app;
+		this.plugin = plugin;
+	}
 
-    display(): void {
-        // Mock implementation
-    }
+	display(): void {
+		// Mock implementation
+	}
 
-    hide(): void {
-        // Mock implementation
-    }
+	hide(): void {
+		// Mock implementation
+	}
 }
 
 /**
  * Mock MarkdownView class.
  */
 export class MarkdownView {
-    editor: Editor | null = null;
+	editor: Editor | null = null;
 }
 
 /**
  * Mock Editor class.
  */
 export class Editor {
-    replaceSelection(_text: string): void {
-        // Mock implementation
-    }
+	replaceSelection(_text: string): void {
+		// Mock implementation
+	}
 }
 
 /**
  * Mock TAbstractFile class.
  */
 export class TAbstractFile {
-    path: string;
+	path: string;
 
-    constructor(path: string) {
-        this.path = path;
-    }
+	constructor(path: string) {
+		this.path = path;
+	}
 }
 
 /**
  * Mock TFolder class.
  */
 export class TFolder extends TAbstractFile {
-    children: TAbstractFile[] = [];
+	children: TAbstractFile[] = [];
 }
 
 /**
  * Mock TFile class.
  */
 export class TFile extends TAbstractFile {
-    basename: string;
-    extension: string;
+	basename: string;
+	extension: string;
 
-    constructor(path: string) {
-        super(path);
-        const parts = path.split('/');
-        const filename = parts[parts.length - 1];
-        const nameParts = filename.split('.');
-        this.extension = nameParts.pop() ?? '';
-        this.basename = nameParts.join('.');
-    }
+	constructor(path: string) {
+		super(path);
+		const parts = path.split('/');
+		const filename = parts[parts.length - 1];
+		const nameParts = filename.split('.');
+		this.extension = nameParts.pop() ?? '';
+		this.basename = nameParts.join('.');
+	}
 }
 
 /**
  * Mock DropdownComponent class.
  */
 export class DropdownComponent {
-    value = '';
+	value = '';
 
-    addOption(_value: string, _display: string): this {
-        return this;
-    }
+	addOption(_value: string, _display: string): this {
+		return this;
+	}
 
-    setValue(value: string): this {
-        this.value = value;
-        return this;
-    }
+	setValue(value: string): this {
+		this.value = value;
+		return this;
+	}
 
-    onChange(_callback: (value: string) => void): this {
-        return this;
-    }
+	onChange(_callback: (value: string) => void): this {
+		return this;
+	}
 }
 
 /**
  * Mock TextComponent class.
  */
 export class TextComponent {
-    inputEl: HTMLInputElement = document.createElement('input');
-    value = '';
+	inputEl: HTMLInputElement = document.createElement('input');
+	value = '';
 
-    setPlaceholder(_placeholder: string): this {
-        return this;
-    }
+	setPlaceholder(_placeholder: string): this {
+		return this;
+	}
 
-    setValue(value: string): this {
-        this.value = value;
-        return this;
-    }
+	setValue(value: string): this {
+		this.value = value;
+		return this;
+	}
 
-    onChange(_callback: (value: string) => void): this {
-        return this;
-    }
+	onChange(_callback: (value: string) => void): this {
+		return this;
+	}
 }
 
 /**
  * Mock ToggleComponent class.
  */
 export class ToggleComponent {
-    value = false;
+	value = false;
 
-    setValue(value: boolean): this {
-        this.value = value;
-        return this;
-    }
+	setValue(value: boolean): this {
+		this.value = value;
+		return this;
+	}
 
-    onChange(_callback: (value: boolean) => void): this {
-        return this;
-    }
+	onChange(_callback: (value: boolean) => void): this {
+		return this;
+	}
 }
 
 /**
  * Mock SliderComponent class.
  */
 export class SliderComponent {
-    value = 0;
+	value = 0;
 
-    setLimits(_min: number, _max: number, _step: number): this {
-        return this;
-    }
+	setLimits(_min: number, _max: number, _step: number): this {
+		return this;
+	}
 
-    setValue(value: number): this {
-        this.value = value;
-        return this;
-    }
+	setValue(value: number): this {
+		this.value = value;
+		return this;
+	}
 
-    setDynamicTooltip(): this {
-        return this;
-    }
+	setDynamicTooltip(): this {
+		return this;
+	}
 
-    onChange(_callback: (value: number) => void): this {
-        return this;
-    }
+	onChange(_callback: (value: number) => void): this {
+		return this;
+	}
 }
 
 /**
  * Mock normalizePath function.
  */
 export function normalizePath(path: string): string {
-    return path.replace(/\\/g, '/').replace(/\/+/g, '/');
+	return path.replace(/\\/g, '/').replace(/\/+/g, '/');
 }
 
 /**
  * Mock setIcon function.
  */
 export function setIcon(_el: HTMLElement, _iconId: string): void {
-    // Mock implementation
+	// Mock implementation
 }
 
 export const Platform = {
-    isMobile: false,
-    isMobileApp: false,
+	isMobile: false,
+	isMobileApp: false,
 };
 
 // Type definitions
 export interface PluginManifest {
-    id: string;
-    name: string;
-    version: string;
+	id: string;
+	name: string;
+	version: string;
 }
 
 export interface Command {
-    id: string;
-    name: string;
-    callback?: () => void;
+	id: string;
+	name: string;
+	callback?: () => void;
 }

--- a/tests/mocks/obsidian.ts
+++ b/tests/mocks/obsidian.ts
@@ -386,6 +386,13 @@ export function normalizePath(path: string): string {
     return path.replace(/\\/g, '/').replace(/\/+/g, '/');
 }
 
+/**
+ * Mock setIcon function.
+ */
+export function setIcon(_el: HTMLElement, _iconId: string): void {
+    // Mock implementation
+}
+
 export const Platform = {
     isMobile: false,
     isMobileApp: false,

--- a/tests/unit/AudioCapabilityDetector.test.ts
+++ b/tests/unit/AudioCapabilityDetector.test.ts
@@ -6,271 +6,279 @@
 /** @jest-environment jsdom */
 
 import {
-    buildMimeType,
-    detectSupportedFormats,
-    getSupportedSampleRates,
-    getSupportedBitrates,
-    validateRecordingCapability,
-    detectCapabilities,
-    detectCodecSupport,
-    FORMAT_FLAC,
+	buildMimeType,
+	detectSupportedFormats,
+	getSupportedSampleRates,
+	getSupportedBitrates,
+	validateRecordingCapability,
+	detectCapabilities,
+	detectCodecSupport,
+	FORMAT_FLAC,
 } from '../../src/recording/AudioCapabilityDetector';
 
 describe('AudioCapabilityDetector', () => {
-    beforeEach(() => {
-        jest.clearAllMocks();
-    });
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
 
-    describe('buildMimeType', () => {
-        it('should return plain audio/webm without codecs suffix', () => {
-            expect(buildMimeType('webm')).toBe('audio/webm');
-        });
+	describe('buildMimeType', () => {
+		it('should return plain audio/webm without codecs suffix', () => {
+			expect(buildMimeType('webm')).toBe('audio/webm');
+		});
 
-        it('should return plain audio/ogg without codecs suffix', () => {
-            expect(buildMimeType('ogg')).toBe('audio/ogg');
-        });
+		it('should return plain audio/ogg without codecs suffix', () => {
+			expect(buildMimeType('ogg')).toBe('audio/ogg');
+		});
 
-        it('should return plain audio/mp3', () => {
-            expect(buildMimeType('mp3')).toBe('audio/mp3');
-        });
+		it('should return plain audio/mp3', () => {
+			expect(buildMimeType('mp3')).toBe('audio/mp3');
+		});
 
-        it('should return plain audio/m4a', () => {
-            expect(buildMimeType('m4a')).toBe('audio/m4a');
-        });
+		it('should return plain audio/m4a', () => {
+			expect(buildMimeType('m4a')).toBe('audio/m4a');
+		});
 
-        it('should handle arbitrary format strings', () => {
-            expect(buildMimeType(FORMAT_FLAC)).toBe(`audio/${FORMAT_FLAC}`);
-        });
-    });
+		it('should handle arbitrary format strings', () => {
+			expect(buildMimeType(FORMAT_FLAC)).toBe(`audio/${FORMAT_FLAC}`);
+		});
+	});
 
-    describe('detectSupportedFormats', () => {
-        it('should return only formats supported by MediaRecorder', () => {
-            (global as Record<string, unknown>).MediaRecorder = {
-                isTypeSupported: jest.fn((type: string) => {
-                    return type === 'audio/webm' || type === 'audio/ogg';
-                }),
-            };
+	describe('detectSupportedFormats', () => {
+		it('should return only formats supported by MediaRecorder', () => {
+			(global as Record<string, unknown>).MediaRecorder = {
+				isTypeSupported: jest.fn((type: string) => {
+					return type === 'audio/webm' || type === 'audio/ogg';
+				}),
+			};
 
-            const formats = detectSupportedFormats();
+			const formats = detectSupportedFormats();
 
-            expect(formats).toContain('webm');
-            expect(formats).toContain('ogg');
-            expect(formats).not.toContain('mp3');
-            expect(formats).not.toContain('m4a');
-        });
+			expect(formats).toContain('webm');
+			expect(formats).toContain('ogg');
+			expect(formats).not.toContain('mp3');
+			expect(formats).not.toContain('m4a');
+		});
 
-        it('should include wav when a compressed intermediate is supported', () => {
-            (global as Record<string, unknown>).MediaRecorder = {
-                isTypeSupported: jest.fn((type: string) => {
-                    return type === 'audio/webm';
-                }),
-            };
+		it('should include wav when a compressed intermediate is supported', () => {
+			(global as Record<string, unknown>).MediaRecorder = {
+				isTypeSupported: jest.fn((type: string) => {
+					return type === 'audio/webm';
+				}),
+			};
 
-            const formats = detectSupportedFormats();
+			const formats = detectSupportedFormats();
 
-            expect(formats).toContain('wav');
-            expect(formats).toContain('webm');
-        });
+			expect(formats).toContain('wav');
+			expect(formats).toContain('webm');
+		});
 
-        it('should exclude wav when no compressed intermediate is supported', () => {
-            (global as Record<string, unknown>).MediaRecorder = {
-                isTypeSupported: jest.fn((type: string) => {
-                    return type === 'audio/mp3';
-                }),
-            };
+		it('should exclude wav when no compressed intermediate is supported', () => {
+			(global as Record<string, unknown>).MediaRecorder = {
+				isTypeSupported: jest.fn((type: string) => {
+					return type === 'audio/mp3';
+				}),
+			};
 
-            const formats = detectSupportedFormats();
+			const formats = detectSupportedFormats();
 
-            expect(formats).toContain('mp3');
-            expect(formats).not.toContain('wav');
-        });
+			expect(formats).toContain('mp3');
+			expect(formats).not.toContain('wav');
+		});
 
-        it('should return empty array when nothing is supported', () => {
-            (global as Record<string, unknown>).MediaRecorder = {
-                isTypeSupported: jest.fn().mockReturnValue(false),
-            };
+		it('should return empty array when nothing is supported', () => {
+			(global as Record<string, unknown>).MediaRecorder = {
+				isTypeSupported: jest.fn().mockReturnValue(false),
+			};
 
-            const formats = detectSupportedFormats();
+			const formats = detectSupportedFormats();
 
-            expect(formats).toEqual([]);
-        });
-    });
+			expect(formats).toEqual([]);
+		});
+	});
 
-    describe('getSupportedSampleRates', () => {
-        it('should return all candidate sample rates', () => {
-            const rates = getSupportedSampleRates();
+	describe('getSupportedSampleRates', () => {
+		it('should return all candidate sample rates', () => {
+			const rates = getSupportedSampleRates();
 
-            expect(rates).toEqual([8000, 16000, 22050, 44100, 48000]);
-        });
+			expect(rates).toEqual([8000, 16000, 22050, 44100, 48000]);
+		});
 
-        it('should return a new array each time', () => {
-            const rates1 = getSupportedSampleRates();
-            const rates2 = getSupportedSampleRates();
+		it('should return a new array each time', () => {
+			const rates1 = getSupportedSampleRates();
+			const rates2 = getSupportedSampleRates();
 
-            expect(rates1).not.toBe(rates2);
-            expect(rates1).toEqual(rates2);
-        });
-    });
+			expect(rates1).not.toBe(rates2);
+			expect(rates1).toEqual(rates2);
+		});
+	});
 
-    describe('getSupportedBitrates', () => {
-        it('should return all candidate bitrates in bps', () => {
-            const bitrates = getSupportedBitrates();
+	describe('getSupportedBitrates', () => {
+		it('should return all candidate bitrates in bps', () => {
+			const bitrates = getSupportedBitrates();
 
-            expect(bitrates).toEqual([
-                64000, 96000, 128000, 160000, 192000, 256000, 320000,
-            ]);
-        });
+			expect(bitrates).toEqual([
+				64000, 96000, 128000, 160000, 192000, 256000, 320000,
+			]);
+		});
 
-        it('should return a new array each time', () => {
-            const b1 = getSupportedBitrates();
-            const b2 = getSupportedBitrates();
+		it('should return a new array each time', () => {
+			const b1 = getSupportedBitrates();
+			const b2 = getSupportedBitrates();
 
-            expect(b1).not.toBe(b2);
-            expect(b1).toEqual(b2);
-        });
-    });
+			expect(b1).not.toBe(b2);
+			expect(b1).toEqual(b2);
+		});
+	});
 
-    describe('validateRecordingCapability', () => {
-        beforeEach(() => {
-            (global as Record<string, unknown>).MediaRecorder = {
-                isTypeSupported: jest.fn((type: string) => {
-                    return type === 'audio/webm' || type === 'audio/ogg';
-                }),
-            };
-        });
+	describe('validateRecordingCapability', () => {
+		beforeEach(() => {
+			(global as Record<string, unknown>).MediaRecorder = {
+				isTypeSupported: jest.fn((type: string) => {
+					return type === 'audio/webm' || type === 'audio/ogg';
+				}),
+			};
+		});
 
-        it('should return valid for supported format', () => {
-            const result = validateRecordingCapability('webm');
+		it('should return valid for supported format', () => {
+			const result = validateRecordingCapability('webm');
 
-            expect(result.valid).toBe(true);
-            expect(result.reason).toBe('');
-        });
+			expect(result.valid).toBe(true);
+			expect(result.reason).toBe('');
+		});
 
-        it('should return invalid for unsupported format', () => {
-            const result = validateRecordingCapability('mp3');
+		it('should return invalid for unsupported format', () => {
+			const result = validateRecordingCapability('mp3');
 
-            expect(result.valid).toBe(false);
-            expect(result.reason).toContain('mp3');
-            expect(result.reason).toContain('not supported');
-        });
+			expect(result.valid).toBe(false);
+			expect(result.reason).toContain('mp3');
+			expect(result.reason).toContain('not supported');
+		});
 
-        it('should return valid for wav when compressed intermediate is available', () => {
-            const result = validateRecordingCapability('wav');
+		it('should return valid for wav when compressed intermediate is available', () => {
+			const result = validateRecordingCapability('wav');
 
-            expect(result.valid).toBe(true);
-        });
+			expect(result.valid).toBe(true);
+		});
 
-        it('should return invalid for wav when no compressed intermediate is available', () => {
-            (global as Record<string, unknown>).MediaRecorder = {
-                isTypeSupported: jest.fn().mockReturnValue(false),
-            };
+		it('should return invalid for wav when no compressed intermediate is available', () => {
+			(global as Record<string, unknown>).MediaRecorder = {
+				isTypeSupported: jest.fn().mockReturnValue(false),
+			};
 
-            const result = validateRecordingCapability('wav');
+			const result = validateRecordingCapability('wav');
 
-            expect(result.valid).toBe(false);
-            expect(result.reason).toContain('WAV output requires');
-        });
-    });
+			expect(result.valid).toBe(false);
+			expect(result.reason).toContain('WAV output requires');
+		});
+	});
 
-    describe('detectCapabilities', () => {
-        it('should aggregate all detection results', () => {
-            (global as Record<string, unknown>).MediaRecorder = {
-                isTypeSupported: jest.fn((type: string) => {
-                    return type === 'audio/webm';
-                }),
-            };
+	describe('detectCapabilities', () => {
+		it('should aggregate all detection results', () => {
+			(global as Record<string, unknown>).MediaRecorder = {
+				isTypeSupported: jest.fn((type: string) => {
+					return type === 'audio/webm';
+				}),
+			};
 
-            const caps = detectCapabilities();
+			const caps = detectCapabilities();
 
-            expect(caps.supportedFormats).toContain('webm');
-            expect(caps.supportedFormats).toContain('wav');
-            expect(caps.supportedSampleRates).toEqual([
-                8000, 16000, 22050, 44100, 48000,
-            ]);
-            expect(caps.supportedBitrates.length).toBeGreaterThan(0);
-            expect(caps.defaultFormat).toBe('webm');
-            expect(caps.defaultSampleRate).toBe(44100);
-            expect(caps.defaultBitrate).toBe(128000);
-        });
+			expect(caps.supportedFormats).toContain('webm');
+			expect(caps.supportedFormats).toContain('wav');
+			expect(caps.supportedSampleRates).toEqual([
+				8000, 16000, 22050, 44100, 48000,
+			]);
+			expect(caps.supportedBitrates.length).toBeGreaterThan(0);
+			expect(caps.defaultFormat).toBe('webm');
+			expect(caps.defaultSampleRate).toBe(44100);
+			expect(caps.defaultBitrate).toBe(128000);
+		});
 
-        it('should default to first supported format when webm is unavailable', () => {
-            (global as Record<string, unknown>).MediaRecorder = {
-                isTypeSupported: jest.fn((type: string) => {
-                    return type === 'audio/ogg';
-                }),
-            };
+		it('should default to first supported format when webm is unavailable', () => {
+			(global as Record<string, unknown>).MediaRecorder = {
+				isTypeSupported: jest.fn((type: string) => {
+					return type === 'audio/ogg';
+				}),
+			};
 
-            const caps = detectCapabilities();
+			const caps = detectCapabilities();
 
-            expect(caps.defaultFormat).toBe('ogg');
-        });
+			expect(caps.defaultFormat).toBe('ogg');
+		});
 
-        it('should default to webm when nothing is supported', () => {
-            (global as Record<string, unknown>).MediaRecorder = {
-                isTypeSupported: jest.fn().mockReturnValue(false),
-            };
+		it('should default to webm when nothing is supported', () => {
+			(global as Record<string, unknown>).MediaRecorder = {
+				isTypeSupported: jest.fn().mockReturnValue(false),
+			};
 
-            const caps = detectCapabilities();
+			const caps = detectCapabilities();
 
-            expect(caps.defaultFormat).toBe('webm');
-        });
-    });
+			expect(caps.defaultFormat).toBe('webm');
+		});
+	});
 
-    describe('detectCodecSupport', () => {
-        it('returns an entry for each candidate format', () => {
-            (global as Record<string, unknown>).MediaRecorder = {
-                isTypeSupported: jest.fn((type: string) => type === 'audio/webm'),
-            };
+	describe('detectCodecSupport', () => {
+		it('returns an entry for each candidate format', () => {
+			(global as Record<string, unknown>).MediaRecorder = {
+				isTypeSupported: jest.fn(
+					(type: string) => type === 'audio/webm',
+				),
+			};
 
-            const entries = detectCodecSupport();
+			const entries = detectCodecSupport();
 
-            // CANDIDATE_FORMATS = ['webm', 'ogg', 'mp3', 'm4a', 'mp4']
-            expect(entries).toHaveLength(5);
-        });
+			// CANDIDATE_FORMATS = ['webm', 'ogg', 'mp3', 'm4a', 'mp4']
+			expect(entries).toHaveLength(5);
+		});
 
-        it('sets supported=true only for the MIME type that matches', () => {
-            (global as Record<string, unknown>).MediaRecorder = {
-                isTypeSupported: jest.fn((type: string) => type === 'audio/webm'),
-            };
+		it('sets supported=true only for the MIME type that matches', () => {
+			(global as Record<string, unknown>).MediaRecorder = {
+				isTypeSupported: jest.fn(
+					(type: string) => type === 'audio/webm',
+				),
+			};
 
-            const entries = detectCodecSupport();
-            const webm = entries.find((e) => e.mimeType === 'audio/webm');
-            const ogg = entries.find((e) => e.mimeType === 'audio/ogg');
+			const entries = detectCodecSupport();
+			const webm = entries.find((e) => e.mimeType === 'audio/webm');
+			const ogg = entries.find((e) => e.mimeType === 'audio/ogg');
 
-            expect(webm?.supported).toBe(true);
-            expect(ogg?.supported).toBe(false);
-        });
+			expect(webm?.supported).toBe(true);
+			expect(ogg?.supported).toBe(false);
+		});
 
-        it('populates withCodecs with correct mimeType strings', () => {
-            (global as Record<string, unknown>).MediaRecorder = {
-                isTypeSupported: jest.fn((type: string) =>
-                    type === 'audio/webm' || type === 'audio/webm;codecs=opus',
-                ),
-            };
+		it('populates withCodecs with correct mimeType strings', () => {
+			(global as Record<string, unknown>).MediaRecorder = {
+				isTypeSupported: jest.fn(
+					(type: string) =>
+						type === 'audio/webm' ||
+						type === 'audio/webm;codecs=opus',
+				),
+			};
 
-            const entries = detectCodecSupport();
-            const webm = entries.find((e) => e.mimeType === 'audio/webm');
+			const entries = detectCodecSupport();
+			const webm = entries.find((e) => e.mimeType === 'audio/webm');
 
-            expect(webm).toBeDefined();
-            const opusEntry = webm?.withCodecs.find((c) => c.codec === 'opus');
-            expect(opusEntry?.mimeType).toBe('audio/webm;codecs=opus');
-            expect(opusEntry?.supported).toBe(true);
+			expect(webm).toBeDefined();
+			const opusEntry = webm?.withCodecs.find((c) => c.codec === 'opus');
+			expect(opusEntry?.mimeType).toBe('audio/webm;codecs=opus');
+			expect(opusEntry?.supported).toBe(true);
 
-            const vorbisEntry = webm?.withCodecs.find((c) => c.codec === 'vorbis');
-            expect(vorbisEntry?.supported).toBe(false);
-        });
+			const vorbisEntry = webm?.withCodecs.find(
+				(c) => c.codec === 'vorbis',
+			);
+			expect(vorbisEntry?.supported).toBe(false);
+		});
 
-        it('returns supported=false for all when MediaRecorder is unavailable', () => {
-            (global as Record<string, unknown>).MediaRecorder = undefined;
+		it('returns supported=false for all when MediaRecorder is unavailable', () => {
+			(global as Record<string, unknown>).MediaRecorder = undefined;
 
-            const entries = detectCodecSupport();
+			const entries = detectCodecSupport();
 
-            entries.forEach((entry) => {
-                expect(entry.supported).toBe(false);
-                entry.withCodecs.forEach((v) => {
-                    expect(v.supported).toBe(false);
-                });
-            });
-        });
-    });
+			entries.forEach((entry) => {
+				expect(entry.supported).toBe(false);
+				entry.withCodecs.forEach((v) => {
+					expect(v.supported).toBe(false);
+				});
+			});
+		});
+	});
 });

--- a/tests/unit/AudioFileAnalyzer.test.ts
+++ b/tests/unit/AudioFileAnalyzer.test.ts
@@ -9,20 +9,20 @@ import { App, Notice, TFile } from 'obsidian';
 
 // Mock Notice
 jest.mock('obsidian', () => ({
-    App: jest.fn().mockImplementation(() => ({
-        vault: {
-            readBinary: jest.fn(),
-        },
-    })),
-    Notice: jest.fn(),
-    TFile: jest.fn().mockImplementation(() => ({
-        extension: 'webm',
-        name: 'test.webm',
-        path: 'test.webm',
-        stat: {
-            size: 1572864, // 1.5 MB
-        },
-    })),
+	App: jest.fn().mockImplementation(() => ({
+		vault: {
+			readBinary: jest.fn(),
+		},
+	})),
+	Notice: jest.fn(),
+	TFile: jest.fn().mockImplementation(() => ({
+		extension: 'webm',
+		name: 'test.webm',
+		path: 'test.webm',
+		stat: {
+			size: 1572864, // 1.5 MB
+		},
+	})),
 }));
 
 // Setup mock AudioContext
@@ -30,136 +30,152 @@ const mockDecodeAudioData = jest.fn();
 const mockClose = jest.fn();
 
 class MockAudioContext {
-    state = 'running';
-    decodeAudioData = mockDecodeAudioData;
-    close = mockClose;
+	state = 'running';
+	decodeAudioData = mockDecodeAudioData;
+	close = mockClose;
 }
 
 describe('getAudioFileInfo', () => {
-    let app: App;
-    let file: TFile;
+	let app: App;
+	let file: TFile;
 
-    beforeEach(() => {
-        jest.clearAllMocks();
-        app = new App();
-        file = new TFile();
+	beforeEach(() => {
+		jest.clearAllMocks();
+		app = new App();
+		file = new TFile();
 
-        // Set default mocked behaviors
-        (app.vault.readBinary as jest.Mock).mockResolvedValue(new ArrayBuffer(8));
+		// Set default mocked behaviors
+		(app.vault.readBinary as jest.Mock).mockResolvedValue(
+			new ArrayBuffer(8),
+		);
 
-        // Reset AudioContext mocks
-        mockDecodeAudioData.mockResolvedValue({
-            duration: 90, // 1.5 minutes
-            sampleRate: 48000,
-            numberOfChannels: 2,
-        });
-        mockClose.mockResolvedValue(undefined);
+		// Reset AudioContext mocks
+		mockDecodeAudioData.mockResolvedValue({
+			duration: 90, // 1.5 minutes
+			sampleRate: 48000,
+			numberOfChannels: 2,
+		});
+		mockClose.mockResolvedValue(undefined);
 
-        Object.defineProperty(window, 'AudioContext', {
-            writable: true,
-            value: MockAudioContext,
-        });
-    });
+		Object.defineProperty(window, 'AudioContext', {
+			writable: true,
+			value: MockAudioContext,
+		});
+	});
 
-    it('should accurately extract and format audio metadata', async () => {
-        const result = await getAudioFileInfo(app, file);
+	it('should accurately extract and format audio metadata', async () => {
+		const result = await getAudioFileInfo(app, file);
 
-        expect(result).not.toBeNull();
-        expect(result).toEqual({
-            fileName: 'test.webm',
-            fileSize: '1.5 MB',
-            duration: '00:01:30',
-            containerFormat: 'audio/webm',
-            audioCodec: 'opus',
-            bitrate: '140 kbps', // (1572864 * 8) / 90 / 1000 = ~139.8 -> 140
-            sampleRate: '48000 Hz',
-            channels: '2 (Stereo)',
-        });
-    });
+		expect(result).not.toBeNull();
+		expect(result).toEqual({
+			fileName: 'test.webm',
+			fileSize: '1.5 MB',
+			duration: '00:01:30',
+			containerFormat: 'audio/webm',
+			audioCodec: 'opus',
+			bitrate: '140 kbps', // (1572864 * 8) / 90 / 1000 = ~139.8 -> 140
+			sampleRate: '48000 Hz',
+			channels: '2 (Stereo)',
+		});
+	});
 
-    it('should handle mono channels', async () => {
-        mockDecodeAudioData.mockResolvedValue({
-            duration: 60,
-            sampleRate: 44100,
-            numberOfChannels: 1,
-        });
-        const result = await getAudioFileInfo(app, file);
-        expect(result?.channels).toBe('1 (Mono)');
-    });
+	it('should handle mono channels', async () => {
+		mockDecodeAudioData.mockResolvedValue({
+			duration: 60,
+			sampleRate: 44100,
+			numberOfChannels: 1,
+		});
+		const result = await getAudioFileInfo(app, file);
+		expect(result?.channels).toBe('1 (Mono)');
+	});
 
-    it('should handle > 2 channels', async () => {
-        mockDecodeAudioData.mockResolvedValue({
-            duration: 60,
-            sampleRate: 44100,
-            numberOfChannels: 6,
-        });
-        const result = await getAudioFileInfo(app, file);
-        expect(result?.channels).toBe('6 channels');
-    });
+	it('should handle > 2 channels', async () => {
+		mockDecodeAudioData.mockResolvedValue({
+			duration: 60,
+			sampleRate: 44100,
+			numberOfChannels: 6,
+		});
+		const result = await getAudioFileInfo(app, file);
+		expect(result?.channels).toBe('6 channels');
+	});
 
-    it('should correctly infer codecs from extensions', async () => {
-        (file as any).extension = 'mp4';
-        let result = await getAudioFileInfo(app, file);
-        expect(result?.containerFormat).toBe('audio/mp4');
-        expect(result?.audioCodec).toBe('aac');
+	it('should correctly infer codecs from extensions', async () => {
+		(file as any).extension = 'mp4';
+		let result = await getAudioFileInfo(app, file);
+		expect(result?.containerFormat).toBe('audio/mp4');
+		expect(result?.audioCodec).toBe('aac');
 
-        (file as any).extension = 'ogg';
-        result = await getAudioFileInfo(app, file);
-        expect(result?.containerFormat).toBe('audio/ogg');
-        expect(result?.audioCodec).toBe('opus/vorbis');
-    });
+		(file as any).extension = 'ogg';
+		result = await getAudioFileInfo(app, file);
+		expect(result?.containerFormat).toBe('audio/ogg');
+		expect(result?.audioCodec).toBe('opus/vorbis');
+	});
 
-    it('should format very small files correctly', async () => {
-        (file as any).stat.size = 500;
-        mockDecodeAudioData.mockResolvedValue({ duration: 1, sampleRate: 44100, numberOfChannels: 1 });
-        const result = await getAudioFileInfo(app, file);
-        expect(result?.fileSize).toBe('500 Bytes');
-        expect(result?.bitrate).toBe('4 kbps'); // 500 * 8 / 1000 = 4k
-    });
+	it('should format very small files correctly', async () => {
+		(file as any).stat.size = 500;
+		mockDecodeAudioData.mockResolvedValue({
+			duration: 1,
+			sampleRate: 44100,
+			numberOfChannels: 1,
+		});
+		const result = await getAudioFileInfo(app, file);
+		expect(result?.fileSize).toBe('500 Bytes');
+		expect(result?.bitrate).toBe('4 kbps'); // 500 * 8 / 1000 = 4k
+	});
 
-    it('should format zero duration correctly without Infinity bitrate', async () => {
-        mockDecodeAudioData.mockResolvedValue({ duration: 0, sampleRate: 44100, numberOfChannels: 1 });
-        const result = await getAudioFileInfo(app, file);
-        expect(result?.duration).toBe('00:00:00');
-        expect(result?.bitrate).toBe('0 kbps');
-    });
+	it('should format zero duration correctly without Infinity bitrate', async () => {
+		mockDecodeAudioData.mockResolvedValue({
+			duration: 0,
+			sampleRate: 44100,
+			numberOfChannels: 1,
+		});
+		const result = await getAudioFileInfo(app, file);
+		expect(result?.duration).toBe('00:00:00');
+		expect(result?.bitrate).toBe('0 kbps');
+	});
 
-    it('should return null and show Notice if decoding throws', async () => {
-        mockDecodeAudioData.mockRejectedValue(new Error('Invalid audio data'));
+	it('should return null and show Notice if decoding throws', async () => {
+		mockDecodeAudioData.mockRejectedValue(new Error('Invalid audio data'));
 
-        const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => { });
+		const consoleSpy = jest
+			.spyOn(console, 'error')
+			.mockImplementation(() => {});
 
-        const result = await getAudioFileInfo(app, file);
+		const result = await getAudioFileInfo(app, file);
 
-        expect(result).toBeNull();
-        expect(Notice).toHaveBeenCalledWith('Failed to decode audio file data.');
-        expect(consoleSpy).toHaveBeenCalled();
+		expect(result).toBeNull();
+		expect(Notice).toHaveBeenCalledWith(
+			'Failed to decode audio file data.',
+		);
+		expect(consoleSpy).toHaveBeenCalled();
 
-        consoleSpy.mockRestore();
-    });
+		consoleSpy.mockRestore();
+	});
 
-    it('should close AudioContext in finally block', async () => {
-        await getAudioFileInfo(app, file);
-        expect(mockClose).toHaveBeenCalled();
-    });
+	it('should close AudioContext in finally block', async () => {
+		await getAudioFileInfo(app, file);
+		expect(mockClose).toHaveBeenCalled();
+	});
 
-    it('should return null if AudioContext is not supported', async () => {
-        const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => { });
-        Object.defineProperty(window, 'AudioContext', {
-            writable: true,
-            value: undefined,
-        });
-        Object.defineProperty(window, 'webkitAudioContext', {
-            writable: true,
-            value: undefined,
-        });
+	it('should return null if AudioContext is not supported', async () => {
+		const consoleSpy = jest
+			.spyOn(console, 'error')
+			.mockImplementation(() => {});
+		Object.defineProperty(window, 'AudioContext', {
+			writable: true,
+			value: undefined,
+		});
+		Object.defineProperty(window, 'webkitAudioContext', {
+			writable: true,
+			value: undefined,
+		});
 
-        const result = await getAudioFileInfo(app, file);
-        expect(result).toBeNull();
-        expect(Notice).toHaveBeenCalledWith(
-            'Audio context is not supported. Cannot extract audio metadata.',
-        );
+		const result = await getAudioFileInfo(app, file);
+		expect(result).toBeNull();
+		expect(Notice).toHaveBeenCalledWith(
+			'Audio context is not supported. Cannot extract audio metadata.',
+		);
 
-        consoleSpy.mockRestore();
-    });
+		consoleSpy.mockRestore();
+	});
 });

--- a/tests/unit/AudioFileInfoModal.test.ts
+++ b/tests/unit/AudioFileInfoModal.test.ts
@@ -13,24 +13,24 @@ import { App } from 'obsidian';
 // ---------------------------------------------------------------------------
 
 function makeData(overrides: Partial<AudioFileInfo> = {}): AudioFileInfo {
-    return {
-        fileName: 'test.webm',
-        fileSize: '1.5 MB',
-        duration: '00:01:30',
-        containerFormat: 'audio/webm',
-        audioCodec: 'opus',
-        bitrate: '128 kbps',
-        sampleRate: '48000 Hz',
-        channels: '2 (Stereo)',
-        ...overrides,
-    };
+	return {
+		fileName: 'test.webm',
+		fileSize: '1.5 MB',
+		duration: '00:01:30',
+		containerFormat: 'audio/webm',
+		audioCodec: 'opus',
+		bitrate: '128 kbps',
+		sampleRate: '48000 Hz',
+		channels: '2 (Stereo)',
+		...overrides,
+	};
 }
 
 function makeModal(info: AudioFileInfo = makeData()) {
-    const app = new App();
-    const modal = new AudioFileInfoModal(app, info);
-    modal.onOpen();
-    return modal;
+	const app = new App();
+	const modal = new AudioFileInfoModal(app, info);
+	modal.onOpen();
+	return modal;
 }
 
 // ---------------------------------------------------------------------------
@@ -38,36 +38,36 @@ function makeModal(info: AudioFileInfo = makeData()) {
 // ---------------------------------------------------------------------------
 
 describe('AudioFileInfoModal.onOpen', () => {
-    it('renders a "Copy as Markdown" button', () => {
-        const modal = makeModal();
+	it('renders a "Copy as Markdown" button', () => {
+		const modal = makeModal();
 
-        const btn = modal.contentEl.querySelector('button');
-        expect(btn).not.toBeNull();
-        expect(btn?.textContent).toBe('Copy as Markdown');
-    });
+		const btn = modal.contentEl.querySelector('button');
+		expect(btn).not.toBeNull();
+		expect(btn?.textContent).toBe('Copy as Markdown');
+	});
 
-    it('renders an unordered list with expected file info', () => {
-        const modal = makeModal(makeData());
+	it('renders an unordered list with expected file info', () => {
+		const modal = makeModal(makeData());
 
-        const listItems = modal.contentEl.querySelectorAll('li');
-        expect(listItems.length).toBe(8);
+		const listItems = modal.contentEl.querySelectorAll('li');
+		expect(listItems.length).toBe(8);
 
-        expect(listItems[0].textContent).toBe('File Name: test.webm');
-        expect(listItems[1].textContent).toBe('File Size: 1.5 MB');
-        expect(listItems[2].textContent).toBe('Duration: 00:01:30');
-        expect(listItems[3].textContent).toBe('Container Format: audio/webm');
-        expect(listItems[4].textContent).toBe('Audio Codec: opus');
-        expect(listItems[5].textContent).toBe('Bitrate: 128 kbps');
-        expect(listItems[6].textContent).toBe('Sample Rate: 48000 Hz');
-        expect(listItems[7].textContent).toBe('Channels: 2 (Stereo)');
-    });
+		expect(listItems[0].textContent).toBe('File Name: test.webm');
+		expect(listItems[1].textContent).toBe('File Size: 1.5 MB');
+		expect(listItems[2].textContent).toBe('Duration: 00:01:30');
+		expect(listItems[3].textContent).toBe('Container Format: audio/webm');
+		expect(listItems[4].textContent).toBe('Audio Codec: opus');
+		expect(listItems[5].textContent).toBe('Bitrate: 128 kbps');
+		expect(listItems[6].textContent).toBe('Sample Rate: 48000 Hz');
+		expect(listItems[7].textContent).toBe('Channels: 2 (Stereo)');
+	});
 
-    it('list element has the aar-audio-info-list CSS class', () => {
-        const modal = makeModal();
+	it('list element has the aar-audio-info-list CSS class', () => {
+		const modal = makeModal();
 
-        const ul = modal.contentEl.querySelector('ul');
-        expect(ul?.classList.contains('aar-audio-info-list')).toBe(true);
-    });
+		const ul = modal.contentEl.querySelector('ul');
+		expect(ul?.classList.contains('aar-audio-info-list')).toBe(true);
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -75,83 +75,95 @@ describe('AudioFileInfoModal.onOpen', () => {
 // ---------------------------------------------------------------------------
 
 describe('AudioFileInfoModal copy button', () => {
-    beforeEach(() => {
-        jest.useFakeTimers();
-        Object.defineProperty(global.navigator, 'clipboard', {
-            value: { writeText: jest.fn().mockResolvedValue(undefined) },
-            configurable: true,
-        });
-    });
+	beforeEach(() => {
+		jest.useFakeTimers();
+		Object.defineProperty(global.navigator, 'clipboard', {
+			value: { writeText: jest.fn().mockResolvedValue(undefined) },
+			configurable: true,
+		});
+	});
 
-    afterEach(() => {
-        jest.useRealTimers();
-    });
+	afterEach(() => {
+		jest.useRealTimers();
+	});
 
-    it('calls clipboard.writeText with formatted Markdown on click', async () => {
-        const data = makeData();
-        const modal = makeModal(data);
+	it('calls clipboard.writeText with formatted Markdown on click', async () => {
+		const data = makeData();
+		const modal = makeModal(data);
 
-        const expectedMarkdown = [
-            `- **File Name:** \`${data.fileName}\``,
-            `- **File Size:** \`${data.fileSize}\``,
-            `- **Duration:** \`${data.duration}\``,
-            `- **Container Format:** \`${data.containerFormat}\``,
-            `- **Audio Codec:** \`${data.audioCodec}\``,
-            `- **Bitrate:** \`${data.bitrate}\``,
-            `- **Sample Rate:** \`${data.sampleRate}\``,
-            `- **Channels:** \`${data.channels}\``,
-        ].join('\n');
+		const expectedMarkdown = [
+			`- **File Name:** \`${data.fileName}\``,
+			`- **File Size:** \`${data.fileSize}\``,
+			`- **Duration:** \`${data.duration}\``,
+			`- **Container Format:** \`${data.containerFormat}\``,
+			`- **Audio Codec:** \`${data.audioCodec}\``,
+			`- **Bitrate:** \`${data.bitrate}\``,
+			`- **Sample Rate:** \`${data.sampleRate}\``,
+			`- **Channels:** \`${data.channels}\``,
+		].join('\n');
 
-        const btn = modal.contentEl.querySelector('button') as HTMLButtonElement;
-        btn.click();
-        await Promise.resolve();
+		const btn = modal.contentEl.querySelector(
+			'button',
+		) as HTMLButtonElement;
+		btn.click();
+		await Promise.resolve();
 
-        expect(navigator.clipboard.writeText).toHaveBeenCalledWith(expectedMarkdown);
-    });
+		expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+			expectedMarkdown,
+		);
+	});
 
-    it('changes button text to "Copied!" after click', async () => {
-        const modal = makeModal();
+	it('changes button text to "Copied!" after click', async () => {
+		const modal = makeModal();
 
-        const btn = modal.contentEl.querySelector('button') as HTMLButtonElement;
-        btn.click();
-        await Promise.resolve();
+		const btn = modal.contentEl.querySelector(
+			'button',
+		) as HTMLButtonElement;
+		btn.click();
+		await Promise.resolve();
 
-        expect(btn.textContent).toBe('Copied!');
-    });
+		expect(btn.textContent).toBe('Copied!');
+	});
 
-    it('adds aar-audio-info-copied CSS class after click', async () => {
-        const modal = makeModal();
+	it('adds aar-audio-info-copied CSS class after click', async () => {
+		const modal = makeModal();
 
-        const btn = modal.contentEl.querySelector('button') as HTMLButtonElement;
-        btn.click();
-        await Promise.resolve();
+		const btn = modal.contentEl.querySelector(
+			'button',
+		) as HTMLButtonElement;
+		btn.click();
+		await Promise.resolve();
 
-        expect(btn.classList.contains('aar-audio-info-copied')).toBe(true);
-    });
+		expect(btn.classList.contains('aar-audio-info-copied')).toBe(true);
+	});
 
-    it('reverts button text back to "Copy as Markdown" after 2 seconds', async () => {
-        const modal = makeModal();
+	it('reverts button text back to "Copy as Markdown" after 2 seconds', async () => {
+		const modal = makeModal();
 
-        const btn = modal.contentEl.querySelector('button') as HTMLButtonElement;
-        btn.click();
-        await Promise.resolve();
+		const btn = modal.contentEl.querySelector(
+			'button',
+		) as HTMLButtonElement;
+		btn.click();
+		await Promise.resolve();
 
-        jest.advanceTimersByTime(2000);
+		jest.advanceTimersByTime(2000);
 
-        expect(btn.textContent).toBe('Copy as Markdown');
-    });
+		expect(btn.textContent).toBe('Copy as Markdown');
+	});
 
-    it('removes aar-audio-info-copied CSS class after 2 seconds', async () => {
-        const modal = makeModal();
+	it('removes aar-audio-info-copied CSS class after 2 seconds', async () => {
+		const modal = makeModal();
 
-        const btn = modal.contentEl.querySelector('button') as HTMLButtonElement;
-        btn.click();
-        await Promise.resolve();
+		const btn = modal.contentEl.querySelector(
+			'button',
+		) as HTMLButtonElement;
+		btn.click();
+		await Promise.resolve();
 
-        jest.advanceTimersByTime(2000);
+		jest.advanceTimersByTime(2000);
 
-        expect(btn.classList.contains('aar-audio-info-copied')).toBe(false);
-    });
+		expect(btn.classList.contains('aar-audio-info-copied')).toBe(false);
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -159,13 +171,13 @@ describe('AudioFileInfoModal copy button', () => {
 // ---------------------------------------------------------------------------
 
 describe('AudioFileInfoModal.onClose', () => {
-    it('empties contentEl on close', () => {
-        const modal = makeModal();
+	it('empties contentEl on close', () => {
+		const modal = makeModal();
 
-        expect(modal.contentEl.children.length).toBeGreaterThan(0);
+		expect(modal.contentEl.children.length).toBeGreaterThan(0);
 
-        modal.onClose();
+		modal.onClose();
 
-        expect(modal.contentEl.children.length).toBe(0);
-    });
+		expect(modal.contentEl.children.length).toBe(0);
+	});
 });

--- a/tests/unit/AudioStreamHandler.test.ts
+++ b/tests/unit/AudioStreamHandler.test.ts
@@ -7,43 +7,45 @@ import { getOrderedTrackSources } from '../../src/recording/AudioStreamHandler';
 import { DEFAULT_SETTINGS } from '../../src/settings/Settings';
 
 describe('AudioStreamHandler', () => {
-    describe('getOrderedTrackSources', () => {
-        it('should return sources in track order regardless of Map insertion order', () => {
-            const settings = {
-                ...DEFAULT_SETTINGS,
-                enableMultiTrack: true,
-                maxTracks: 3,
-                trackAudioSources: new Map([
-                    [2, { deviceId: 'device-2' }],
-                    [1, { deviceId: 'device-1' }],
-                    [3, { deviceId: 'device-3' }],
-                ]),
-            };
+	describe('getOrderedTrackSources', () => {
+		it('should return sources in track order regardless of Map insertion order', () => {
+			const settings = {
+				...DEFAULT_SETTINGS,
+				enableMultiTrack: true,
+				maxTracks: 3,
+				trackAudioSources: new Map([
+					[2, { deviceId: 'device-2' }],
+					[1, { deviceId: 'device-1' }],
+					[3, { deviceId: 'device-3' }],
+				]),
+			};
 
-            const ordered = getOrderedTrackSources(settings);
+			const ordered = getOrderedTrackSources(settings);
 
-            expect(ordered.map((source) => source.trackNumber)).toEqual([1, 2, 3]);
-            expect(ordered.map((source) => source.deviceId)).toEqual([
-                'device-1',
-                'device-2',
-                'device-3',
-            ]);
-        });
+			expect(ordered.map((source) => source.trackNumber)).toEqual([
+				1, 2, 3,
+			]);
+			expect(ordered.map((source) => source.deviceId)).toEqual([
+				'device-1',
+				'device-2',
+				'device-3',
+			]);
+		});
 
-        it('should skip tracks without selected devices', () => {
-            const settings = {
-                ...DEFAULT_SETTINGS,
-                enableMultiTrack: true,
-                maxTracks: 3,
-                trackAudioSources: new Map([
-                    [1, { deviceId: 'device-1' }],
-                    [3, { deviceId: '' }],
-                ]),
-            };
+		it('should skip tracks without selected devices', () => {
+			const settings = {
+				...DEFAULT_SETTINGS,
+				enableMultiTrack: true,
+				maxTracks: 3,
+				trackAudioSources: new Map([
+					[1, { deviceId: 'device-1' }],
+					[3, { deviceId: '' }],
+				]),
+			};
 
-            const ordered = getOrderedTrackSources(settings);
+			const ordered = getOrderedTrackSources(settings);
 
-            expect(ordered.map((source) => source.trackNumber)).toEqual([1]);
-        });
-    });
+			expect(ordered.map((source) => source.trackNumber)).toEqual([1]);
+		});
+	});
 });

--- a/tests/unit/ContextMenu.test.ts
+++ b/tests/unit/ContextMenu.test.ts
@@ -38,6 +38,12 @@ jest.mock('obsidian', () => ({
     FileManager: jest.fn(),
 }));
 
+jest.mock('../../src/ui/AudioFileInfoModal', () => ({
+    AudioFileInfoModal: jest.fn().mockImplementation(() => ({
+        open: jest.fn(),
+    })),
+}));
+
 describe('ContextMenu', () => {
     let contextMenu: ContextMenu;
     let mockApp: App;
@@ -166,7 +172,7 @@ describe('ContextMenu', () => {
 
             expect(mockItem.setTitle).toHaveBeenCalledWith('Delete recording');
             expect(mockItem.setIcon).toHaveBeenCalledWith('trash');
-            expect(mockItem.setSection).toHaveBeenCalledWith('danger');
+            expect(mockItem.setSection).toHaveBeenCalledWith('aar');
         });
 
         it('should add "Audio file info" item for audio files', () => {
@@ -191,7 +197,83 @@ describe('ContextMenu', () => {
 
             expect(mockItem.setTitle).toHaveBeenCalledWith('Audio file info');
             expect(mockItem.setIcon).toHaveBeenCalledWith('info');
-            expect(mockItem.setSection).toHaveBeenCalledWith('default');
+            expect(mockItem.setSection).toHaveBeenCalledWith('aar');
+        });
+
+        it('should open AudioFileInfoModal on "Audio file info" click', async () => {
+            const mockMenu = new Menu();
+            const mockFile = new TFile();
+            Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
+
+            const mockInfo = { name: 'audio.mp3', size: 1024 };
+            jest.spyOn(AudioFileAnalyzer, 'getAudioFileInfo').mockResolvedValue(mockInfo);
+
+            fileMenuCallback(mockMenu, mockFile);
+
+            const addItemCallback = (mockMenu.addItem as jest.Mock).mock.calls[0][0];
+            const mockItem = {
+                setTitle: jest.fn().mockReturnThis(),
+                setIcon: jest.fn().mockReturnThis(),
+                setSection: jest.fn().mockReturnThis(),
+                onClick: jest.fn(),
+            };
+            addItemCallback(mockItem);
+
+            const clickHandler = mockItem.onClick.mock.calls[0][0];
+            await clickHandler();
+
+            expect(AudioFileAnalyzer.getAudioFileInfo).toHaveBeenCalledWith(mockApp, mockFile);
+        });
+
+        it('should not open modal if getAudioFileInfo returns null', async () => {
+            const mockMenu = new Menu();
+            const mockFile = new TFile();
+            Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
+
+            jest.spyOn(AudioFileAnalyzer, 'getAudioFileInfo').mockResolvedValue(null);
+
+            fileMenuCallback(mockMenu, mockFile);
+
+            const addItemCallback = (mockMenu.addItem as jest.Mock).mock.calls[0][0];
+            const mockItem = {
+                setTitle: jest.fn().mockReturnThis(),
+                setIcon: jest.fn().mockReturnThis(),
+                setSection: jest.fn().mockReturnThis(),
+                onClick: jest.fn(),
+            };
+            addItemCallback(mockItem);
+
+            const clickHandler = mockItem.onClick.mock.calls[0][0];
+            await clickHandler();
+
+            expect(AudioFileAnalyzer.getAudioFileInfo).toHaveBeenCalledWith(mockApp, mockFile);
+        });
+
+        it('should not duplicate "Audio file info" when called twice on the same menu', () => {
+            const mockMenu = new Menu();
+            const mockFile = new TFile();
+            Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
+
+            // Simulate both editor-menu and file-menu firing for the same Menu instance
+            fileMenuCallback(mockMenu, mockFile);
+            fileMenuCallback(mockMenu, mockFile);
+
+            // "Audio file info" should be added only once, but "Delete recording" is added each time
+            const calls = (mockMenu.addItem as jest.Mock).mock.calls;
+            const titles: string[] = [];
+            for (const call of calls) {
+                const mockItem = {
+                    setTitle: jest.fn().mockReturnThis(),
+                    setIcon: jest.fn().mockReturnThis(),
+                    setSection: jest.fn().mockReturnThis(),
+                    onClick: jest.fn(),
+                };
+                call[0](mockItem);
+                titles.push(mockItem.setTitle.mock.calls[0][0] as string);
+            }
+
+            const infoCount = titles.filter((t) => t === 'Audio file info').length;
+            expect(infoCount).toBe(1);
         });
 
         it('should NOT add item for non-audio files', () => {

--- a/tests/unit/ContextMenu.test.ts
+++ b/tests/unit/ContextMenu.test.ts
@@ -9,850 +9,948 @@ import { AUDIO_EXTENSIONS } from '../../src/constants';
 import { FORMAT_MP4 } from '../../src/recording/AudioCapabilityDetector';
 import * as AudioFileAnalyzer from '../../src/utils/AudioFileAnalyzer';
 import {
-    App,
-    Menu,
-    TFile,
-    Plugin,
-    Editor,
-    Notice,
-    MarkdownView,
-    Workspace,
-    MetadataCache,
-    Vault,
-    FileManager,
+	App,
+	Menu,
+	TFile,
+	Plugin,
+	Editor,
+	Notice,
+	Workspace,
+	MetadataCache,
+	Vault,
+	FileManager,
 } from 'obsidian';
 
 // Mock obsidian module
 jest.mock('obsidian', () => ({
-    App: jest.fn(),
-    Menu: class {
-        addItem = jest.fn();
-        showAtPosition = jest.fn();
-    },
-    Modal: class { },
-    TFile: jest.fn(),
-    Plugin: jest.fn(),
-    Editor: jest.fn(),
-    Notice: jest.fn(),
-    MarkdownView: jest.fn(),
-    FileManager: jest.fn(),
+	App: jest.fn(),
+	Menu: class {
+		addItem = jest.fn();
+		showAtPosition = jest.fn();
+	},
+	Modal: class {},
+	TFile: jest.fn(),
+	Plugin: jest.fn(),
+	Editor: jest.fn(),
+	Notice: jest.fn(),
+	MarkdownView: jest.fn(),
+	FileManager: jest.fn(),
 }));
 
 jest.mock('../../src/ui/AudioFileInfoModal', () => ({
-    AudioFileInfoModal: jest.fn().mockImplementation(() => ({
-        open: jest.fn(),
-    })),
+	AudioFileInfoModal: jest.fn().mockImplementation(() => ({
+		open: jest.fn(),
+	})),
 }));
 
 describe('ContextMenu', () => {
-    let contextMenu: ContextMenu;
-    let mockApp: App;
-    let mockPlugin: Plugin;
-    let mockWorkspace: Workspace;
-    let mockMetadataCache: MetadataCache;
-    let mockVault: Vault;
-    let mockFileManager: FileManager;
-
-    beforeEach(() => {
-        jest.clearAllMocks();
-
-        // Mock App and its components
-        mockWorkspace = {
-            on: jest.fn(),
-            trigger: jest.fn(),
-            getActiveFile: jest.fn(),
-            getActiveViewOfType: jest.fn(),
-        } as unknown as Workspace;
-
-        mockMetadataCache = {
-            getFirstLinkpathDest: jest.fn(),
-        } as unknown as MetadataCache;
-
-        mockVault = {
-            delete: jest.fn(),
-        } as unknown as Vault;
-
-        mockFileManager = {
-            trashFile: jest.fn(),
-        } as unknown as FileManager;
-
-        mockApp = {
-            workspace: mockWorkspace,
-            metadataCache: mockMetadataCache,
-            vault: mockVault,
-            fileManager: mockFileManager,
-        } as unknown as App;
-
-        // Mock Plugin
-        mockPlugin = {
-            registerEvent: jest.fn(),
-            registerDomEvent: jest.fn(),
-        } as unknown as Plugin;
-
-        contextMenu = new ContextMenu(mockApp, mockPlugin);
-    });
-
-    describe('register', () => {
-        it('should register file, editor, and player menus', () => {
-            // We can't easily spy on private methods, so we verify side effects (calls to plugin.register*)
-            contextMenu.register();
-
-            // registerFileMenu calls workspace.on('file-menu') and plugin.registerEvent
-            expect(mockWorkspace.on).toHaveBeenCalledWith(
-                'file-menu',
-                expect.any(Function),
-            );
-            expect(mockPlugin.registerEvent).toHaveBeenCalled();
-
-            // registerEditorMenu calls workspace.on('editor-menu') and plugin.registerEvent
-            expect(mockWorkspace.on).toHaveBeenCalledWith(
-                'editor-menu',
-                expect.any(Function),
-            );
-
-            // registerPlayerMenu calls plugin.registerDomEvent
-            expect(mockPlugin.registerDomEvent).toHaveBeenCalledWith(
-                document,
-                'contextmenu',
-                expect.any(Function),
-                { capture: true },
-            );
-        });
-    });
-
-    describe('registerFileMenu', () => {
-        let fileMenuCallback: (menu: Menu, file: TFile) => void;
-
-        beforeEach(() => {
-            contextMenu.register();
-            // Extract the callback passed to workspace.on('file-menu', ...)
-            const call = (mockWorkspace.on as jest.Mock).mock.calls.find(
-                (c) => c[0] === 'file-menu',
-            );
-            fileMenuCallback = call[1];
-        });
-
-        it('should include mp4 in AUDIO_EXTENSIONS', () => {
-            expect(AUDIO_EXTENSIONS).toContain(FORMAT_MP4);
-        });
-
-        test.each(AUDIO_EXTENSIONS)(
-            'should add "Delete recording" item for %s files',
-            (extension) => {
-                const mockMenu = new Menu();
-                const mockFile = new TFile();
-                Object.defineProperty(mockFile, 'extension', { value: extension });
-
-                fileMenuCallback(mockMenu, mockFile);
-
-                expect(mockMenu.addItem).toHaveBeenCalled();
-            },
-        );
-
-        it('should add "Delete recording" item for audio files', () => {
-            const mockMenu = new Menu();
-            const mockFile = new TFile();
-            // Mock TFile properties setup
-            Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
-
-            fileMenuCallback(mockMenu, mockFile);
-
-            expect(mockMenu.addItem).toHaveBeenCalledTimes(2);
-
-            // Verify the delete item configuration
-            const addItemCallback = (mockMenu.addItem as jest.Mock).mock
-                .calls[1][0];
-            const mockItem = {
-                setTitle: jest.fn().mockReturnThis(),
-                setIcon: jest.fn().mockReturnThis(),
-                setSection: jest.fn().mockReturnThis(),
-                onClick: jest.fn(),
-            };
-            addItemCallback(mockItem);
-
-            expect(mockItem.setTitle).toHaveBeenCalledWith('Delete recording');
-            expect(mockItem.setIcon).toHaveBeenCalledWith('trash');
-            expect(mockItem.setSection).toHaveBeenCalledWith('aar');
-        });
-
-        it('should add "Audio file info" item for audio files', () => {
-            const mockMenu = new Menu();
-            const mockFile = new TFile();
-            Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
-
-            fileMenuCallback(mockMenu, mockFile);
-
-            expect(mockMenu.addItem).toHaveBeenCalledTimes(2);
-
-            // Verify the audio info item configuration
-            const addItemCallback = (mockMenu.addItem as jest.Mock).mock
-                .calls[0][0];
-            const mockItem = {
-                setTitle: jest.fn().mockReturnThis(),
-                setIcon: jest.fn().mockReturnThis(),
-                setSection: jest.fn().mockReturnThis(),
-                onClick: jest.fn(),
-            };
-            addItemCallback(mockItem);
-
-            expect(mockItem.setTitle).toHaveBeenCalledWith('Audio file info');
-            expect(mockItem.setIcon).toHaveBeenCalledWith('info');
-            expect(mockItem.setSection).toHaveBeenCalledWith('aar');
-        });
-
-        it('should open AudioFileInfoModal on "Audio file info" click', async () => {
-            const mockMenu = new Menu();
-            const mockFile = new TFile();
-            Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
-
-            const mockInfo = { name: 'audio.mp3', size: 1024 };
-            jest.spyOn(AudioFileAnalyzer, 'getAudioFileInfo').mockResolvedValue(mockInfo);
-
-            fileMenuCallback(mockMenu, mockFile);
-
-            const addItemCallback = (mockMenu.addItem as jest.Mock).mock.calls[0][0];
-            const mockItem = {
-                setTitle: jest.fn().mockReturnThis(),
-                setIcon: jest.fn().mockReturnThis(),
-                setSection: jest.fn().mockReturnThis(),
-                onClick: jest.fn(),
-            };
-            addItemCallback(mockItem);
-
-            const clickHandler = mockItem.onClick.mock.calls[0][0];
-            await clickHandler();
-
-            expect(AudioFileAnalyzer.getAudioFileInfo).toHaveBeenCalledWith(mockApp, mockFile);
-        });
-
-        it('should not open modal if getAudioFileInfo returns null', async () => {
-            const mockMenu = new Menu();
-            const mockFile = new TFile();
-            Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
-
-            jest.spyOn(AudioFileAnalyzer, 'getAudioFileInfo').mockResolvedValue(null);
-
-            fileMenuCallback(mockMenu, mockFile);
-
-            const addItemCallback = (mockMenu.addItem as jest.Mock).mock.calls[0][0];
-            const mockItem = {
-                setTitle: jest.fn().mockReturnThis(),
-                setIcon: jest.fn().mockReturnThis(),
-                setSection: jest.fn().mockReturnThis(),
-                onClick: jest.fn(),
-            };
-            addItemCallback(mockItem);
-
-            const clickHandler = mockItem.onClick.mock.calls[0][0];
-            await clickHandler();
-
-            expect(AudioFileAnalyzer.getAudioFileInfo).toHaveBeenCalledWith(mockApp, mockFile);
-        });
-
-        it('should not duplicate "Audio file info" when called twice on the same menu', () => {
-            const mockMenu = new Menu();
-            const mockFile = new TFile();
-            Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
-
-            // Simulate both editor-menu and file-menu firing for the same Menu instance
-            fileMenuCallback(mockMenu, mockFile);
-            fileMenuCallback(mockMenu, mockFile);
-
-            // "Audio file info" should be added only once, but "Delete recording" is added each time
-            const calls = (mockMenu.addItem as jest.Mock).mock.calls;
-            const titles: string[] = [];
-            for (const call of calls) {
-                const mockItem = {
-                    setTitle: jest.fn().mockReturnThis(),
-                    setIcon: jest.fn().mockReturnThis(),
-                    setSection: jest.fn().mockReturnThis(),
-                    onClick: jest.fn(),
-                };
-                call[0](mockItem);
-                titles.push(mockItem.setTitle.mock.calls[0][0] as string);
-            }
-
-            const infoCount = titles.filter((t) => t === 'Audio file info').length;
-            expect(infoCount).toBe(1);
-        });
-
-        it('should NOT add item for non-audio files', () => {
-            const mockMenu = new Menu();
-            const mockFile = new TFile();
-            Object.defineProperty(mockFile, 'extension', { value: 'md' });
-
-            fileMenuCallback(mockMenu, mockFile);
-
-            expect(mockMenu.addItem).not.toHaveBeenCalled();
-        });
-
-        it('should delete file on click', async () => {
-            const mockMenu = new Menu();
-            const mockFile = new TFile();
-            Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
-
-            fileMenuCallback(mockMenu, mockFile);
-
-            const addItemCallback = (mockMenu.addItem as jest.Mock).mock
-                .calls[1][0];
-            const mockItem = {
-                setTitle: jest.fn().mockReturnThis(),
-                setIcon: jest.fn().mockReturnThis(),
-                setSection: jest.fn().mockReturnThis(),
-                onClick: jest.fn(),
-            };
-            addItemCallback(mockItem);
-
-            // Trigger click
-            const clickHandler = mockItem.onClick.mock.calls[0][0];
-            await clickHandler();
-
-            expect(mockFileManager.trashFile).toHaveBeenCalledWith(mockFile);
-            expect(Notice).toHaveBeenCalledWith('Recording deleted');
-        });
-
-        it('should handle deletion error', async () => {
-            const mockMenu = new Menu();
-            const mockFile = new TFile();
-            Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
-            (mockFileManager.trashFile as jest.Mock).mockRejectedValue(
-                new Error('Delete failed'),
-            );
-            const consoleSpy = jest
-                .spyOn(console, 'error')
-                .mockImplementation(() => { });
-
-            fileMenuCallback(mockMenu, mockFile);
-
-            const addItemCallback = (mockMenu.addItem as jest.Mock).mock
-                .calls[1][0];
-            const mockItem = {
-                setTitle: jest.fn().mockReturnThis(),
-                setIcon: jest.fn().mockReturnThis(),
-                setSection: jest.fn().mockReturnThis(),
-                onClick: jest.fn(),
-            };
-            addItemCallback(mockItem);
-
-            const clickHandler = mockItem.onClick.mock.calls[0][0];
-            await clickHandler();
-
-            expect(Notice).toHaveBeenCalledWith('Failed to delete recording');
-            expect(consoleSpy).toHaveBeenCalled();
-            consoleSpy.mockRestore();
-        });
-    });
-
-    describe('registerEditorMenu', () => {
-        let editorMenuCallback: (
-            menu: Menu,
-            editor: Editor,
-            view: any,
-        ) => void;
-        let mockEditor: Editor;
-
-        beforeEach(() => {
-            contextMenu.register();
-            const call = (mockWorkspace.on as jest.Mock).mock.calls.find(
-                (c) => c[0] === 'editor-menu',
-            );
-            editorMenuCallback = call[1];
-
-            mockEditor = {
-                getCursor: jest.fn().mockReturnValue({ line: 0, ch: 0 }),
-                getLine: jest.fn(),
-                replaceRange: jest.fn(),
-                offsetToPos: jest.fn(),
-            } as unknown as Editor;
-        });
-
-        test.each(AUDIO_EXTENSIONS)(
-            'should add "Delete recording & link" item for %s files',
-            (extension) => {
-                const mockMenu = new Menu();
-                (mockEditor.getLine as jest.Mock).mockReturnValue(`[[audio.${extension}]]`);
-                (mockEditor.getCursor as jest.Mock).mockReturnValue({ line: 0, ch: 2 });
-
-                const mockFile = new TFile();
-                Object.defineProperty(mockFile, 'extension', { value: extension });
-                (mockMetadataCache.getFirstLinkpathDest as jest.Mock).mockReturnValue(mockFile);
-
-                editorMenuCallback(mockMenu, mockEditor, {});
-
-                expect(mockMenu.addItem).toHaveBeenCalled();
-            },
-        );
-
-        it('should do nothing if no link at cursor', () => {
-            const mockMenu = new Menu();
-            (mockEditor.getLine as jest.Mock).mockReturnValue('Just text');
-
-            editorMenuCallback(mockMenu, mockEditor, {});
-
-            expect(mockMenu.addItem).not.toHaveBeenCalled();
-        });
-
-        it('should do nothing if link resolves to non-audio file', () => {
-            const mockMenu = new Menu();
-            (mockEditor.getLine as jest.Mock).mockReturnValue('[[note]]');
-            (mockEditor.getCursor as jest.Mock).mockReturnValue({
-                line: 0,
-                ch: 2,
-            }); // Inside link
-            (mockMetadataCache.getFirstLinkpathDest as jest.Mock).mockReturnValue(
-                new TFile(),
-            ); // Default check fails mostly on extension mock? Or default TFile mock
-
-            const mockFile = new TFile();
-            Object.defineProperty(mockFile, 'extension', { value: 'md' });
-            (mockMetadataCache.getFirstLinkpathDest as jest.Mock).mockReturnValue(
-                mockFile,
-            );
-
-            editorMenuCallback(mockMenu, mockEditor, {});
-
-            expect(mockMenu.addItem).not.toHaveBeenCalled();
-        });
-
-        it('should add "Delete recording & link" if valid audio link', () => {
-            const mockMenu = new Menu();
-            (mockEditor.getLine as jest.Mock).mockReturnValue('[[audio.mp3]]');
-            (mockEditor.getCursor as jest.Mock).mockReturnValue({
-                line: 0,
-                ch: 2,
-            });
-
-            const mockFile = new TFile();
-            Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
-            (mockMetadataCache.getFirstLinkpathDest as jest.Mock).mockReturnValue(
-                mockFile,
-            );
-
-            editorMenuCallback(mockMenu, mockEditor, {});
-
-            expect(mockMenu.addItem).toHaveBeenCalledTimes(2);
-            const addItemCallback = (mockMenu.addItem as jest.Mock).mock
-                .calls[1][0]; // Delete recording & link is the second item added
-            const mockItem = {
-                setTitle: jest.fn().mockReturnThis(),
-                setIcon: jest.fn().mockReturnThis(),
-                setSection: jest.fn().mockReturnThis(),
-                onClick: jest.fn(),
-            };
-            addItemCallback(mockItem);
-
-            expect(mockItem.setTitle).toHaveBeenCalledWith(
-                'Delete recording & link to file',
-            );
-        });
-
-        it('should delete file and remove link text on click', async () => {
-            const mockMenu = new Menu();
-            (mockEditor.getLine as jest.Mock).mockReturnValue('Text [[audio.mp3]] Text');
-            // Cursor at link
-            (mockEditor.getCursor as jest.Mock).mockReturnValue({ line: 0, ch: 7 });
-
-            const mockFile = new TFile();
-            Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
-            (mockMetadataCache.getFirstLinkpathDest as jest.Mock).mockReturnValue(mockFile);
-
-            editorMenuCallback(mockMenu, mockEditor, {});
-
-            const addItemCallback = (mockMenu.addItem as jest.Mock).mock.calls[1][0];
-            const mockItem = {
-                setTitle: jest.fn().mockReturnThis(),
-                setIcon: jest.fn().mockReturnThis(),
-                setSection: jest.fn().mockReturnThis(),
-                onClick: jest.fn(),
-            };
-            addItemCallback(mockItem);
-
-            const clickHandler = mockItem.onClick.mock.calls[0][0];
-            await clickHandler();
-
-            expect(mockFileManager.trashFile).toHaveBeenCalledWith(mockFile);
-            // Verify editor.replaceRange was called with correct range for [[audio.mp3]]
-            // "Text [[audio.mp3]] Text" -> Link is at index 5 to 18 (13 chars)
-            // But strict regex might handle it differently.
-            // Let's rely on the fact that existing logic finds it.
-            // Regex !?\[\[(.*?)(?:\|.*?)?\]\]
-            // For 'Text [[audio.mp3]] Text', match index is 5.
-            expect(mockEditor.replaceRange).toHaveBeenCalledWith(
-                '',
-                { line: 0, ch: 5 },
-                { line: 0, ch: 18 }
-            );
-            expect(Notice).toHaveBeenCalledWith('Recording and link deleted');
-        });
-
-        it('should handle deletion error in editor menu', async () => {
-            const mockMenu = new Menu();
-            (mockEditor.getLine as jest.Mock).mockReturnValue('[[audio.mp3]]');
-            (mockEditor.getCursor as jest.Mock).mockReturnValue({ line: 0, ch: 2 });
-
-            const mockFile = new TFile();
-            Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
-            (mockMetadataCache.getFirstLinkpathDest as jest.Mock).mockReturnValue(mockFile);
-
-            // Mock delete failure
-            (mockFileManager.trashFile as jest.Mock).mockRejectedValue(new Error('Delete failed'));
-            const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
-
-            editorMenuCallback(mockMenu, mockEditor, {});
-
-            const addItemCallback = (mockMenu.addItem as jest.Mock).mock.calls[1][0];
-            const mockItem = {
-                setTitle: jest.fn().mockReturnThis(),
-                setIcon: jest.fn().mockReturnThis(),
-                setSection: jest.fn().mockReturnThis(),
-                onClick: jest.fn(),
-            };
-            addItemCallback(mockItem);
-
-            const clickHandler = mockItem.onClick.mock.calls[0][0];
-            await clickHandler();
-
-            expect(Notice).toHaveBeenCalledWith('Failed to delete recording');
-            expect(consoleSpy).toHaveBeenCalled();
-            consoleSpy.mockRestore();
-        });
-
-        it('should work with markdown links', () => {
-            const mockMenu = new Menu();
-            (mockEditor.getLine as jest.Mock).mockReturnValue('[link](audio.mp3)');
-            // [link](audio.mp3) -> cursor at 5 (inside link text) or 10 (inside path)
-            // Regex: !?\[(.*?)\]\((.*?)\)
-            // Group 1: link, Group 2: audio.mp3
-            // Match index 0. Length: [link](audio.mp3) = 17 chars.
-            (mockEditor.getCursor as jest.Mock).mockReturnValue({ line: 0, ch: 10 });
-
-            const mockFile = new TFile();
-            Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
-            (mockMetadataCache.getFirstLinkpathDest as jest.Mock).mockReturnValue(mockFile);
-
-            editorMenuCallback(mockMenu, mockEditor, {});
-
-            expect(mockMenu.addItem).toHaveBeenCalled();
-        });
-
-        it('should handle view with no file', () => {
-            const mockMenu = new Menu();
-            (mockEditor.getLine as jest.Mock).mockReturnValue('[[audio.mp3]]');
-            (mockEditor.getCursor as jest.Mock).mockReturnValue({ line: 0, ch: 2 });
-
-            // view has no file property or it is null
-            const mockView = {};
-
-            const mockFile = new TFile();
-            Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
-            // Should call getFirstLinkpathDest with sourcePath = ''
-            (mockMetadataCache.getFirstLinkpathDest as jest.Mock).mockReturnValue(mockFile);
-
-            editorMenuCallback(mockMenu, mockEditor, mockView);
-
-            expect(mockMetadataCache.getFirstLinkpathDest).toHaveBeenCalledWith('audio.mp3', '');
-            expect(mockMenu.addItem).toHaveBeenCalled();
-        });
-
-        it('should handle view with file', () => {
-            const mockMenu = new Menu();
-            (mockEditor.getLine as jest.Mock).mockReturnValue('[[audio.mp3]]');
-            (mockEditor.getCursor as jest.Mock).mockReturnValue({ line: 0, ch: 2 });
-
-            const mockView = { file: { path: 'view.md' } };
-
-            const mockFile = new TFile();
-            Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
-            (mockMetadataCache.getFirstLinkpathDest as jest.Mock).mockReturnValue(mockFile);
-
-            editorMenuCallback(mockMenu, mockEditor, mockView);
-
-            expect(mockMetadataCache.getFirstLinkpathDest).toHaveBeenCalledWith('audio.mp3', 'view.md');
-            expect(mockMenu.addItem).toHaveBeenCalled();
-        });
-    });
-
-    describe('registerPlayerMenu', () => {
-        let playerMenuCallback: (event: MouseEvent) => void;
-
-        beforeEach(() => {
-            contextMenu.register();
-            const call = (mockPlugin.registerDomEvent as jest.Mock).mock.calls.find(
-                (c) => c[1] === 'contextmenu',
-            );
-            playerMenuCallback = call[2];
-        });
-
-        test.each(AUDIO_EXTENSIONS)(
-            'should resolve %s file and show context menu',
-            (extension) => {
-                const embed = document.createElement('div');
-                embed.className = 'internal-embed';
-                embed.setAttribute('src', `audio.${extension}`);
-                const target = document.createElement('span');
-                embed.appendChild(target);
-
-                const mockEvent = {
-                    target: target,
-                    pageX: 100,
-                    pageY: 200,
-                    preventDefault: jest.fn(),
-                    stopPropagation: jest.fn(),
-                } as unknown as MouseEvent;
-
-                const mockFile = new TFile();
-                Object.defineProperty(mockFile, 'extension', { value: extension });
-                (mockMetadataCache.getFirstLinkpathDest as jest.Mock).mockReturnValue(mockFile);
-                (mockWorkspace.getActiveFile as jest.Mock).mockReturnValue(null);
-
-                playerMenuCallback(mockEvent);
-
-                expect(mockEvent.preventDefault).toHaveBeenCalled();
-                expect(mockWorkspace.trigger).toHaveBeenCalledWith(
-                    'file-menu',
-                    expect.any(Menu),
-                    mockFile,
-                    'audio-recorder-player-context-menu',
-                );
-            },
-        );
-
-        it('should do nothing if target is not part of internal-embed', () => {
-            const mockEvent = {
-                target: document.createElement('div'),
-            } as unknown as MouseEvent;
-
-            playerMenuCallback(mockEvent);
-
-            expect(mockMetadataCache.getFirstLinkpathDest).not.toHaveBeenCalled();
-        });
-
-        it('should do nothing if embed has no src', () => {
-            const embed = document.createElement('div');
-            embed.className = 'internal-embed';
-            // No src attribute
-
-            const target = document.createElement('span');
-            embed.appendChild(target);
-
-            const mockEvent = {
-                target: target,
-            } as unknown as MouseEvent;
-
-            playerMenuCallback(mockEvent);
-
-            expect(mockMetadataCache.getFirstLinkpathDest).not.toHaveBeenCalled();
-        });
-
-        it('should resolve file and show menu if valid audio', () => {
-            const embed = document.createElement('div');
-            embed.className = 'internal-embed';
-            embed.setAttribute('src', 'audio.mp3');
-
-            const target = document.createElement('span');
-            embed.appendChild(target);
-
-            const mockEvent = {
-                target: target,
-                pageX: 100,
-                pageY: 200,
-                preventDefault: jest.fn(),
-                stopPropagation: jest.fn(),
-            } as unknown as MouseEvent;
-
-            const mockFile = new TFile();
-            Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
-            (mockMetadataCache.getFirstLinkpathDest as jest.Mock).mockReturnValue(
-                mockFile,
-            );
-
-            // Cover truthy activeFile branch
-            const mockActiveFile = new TFile();
-            mockActiveFile.path = 'active.md';
-            (mockWorkspace.getActiveFile as jest.Mock).mockReturnValue(mockActiveFile);
-
-            playerMenuCallback(mockEvent);
-
-            expect(mockEvent.preventDefault).toHaveBeenCalled();
-            expect(mockEvent.stopPropagation).toHaveBeenCalled();
-            expect(mockWorkspace.trigger).toHaveBeenCalledWith(
-                'file-menu',
-                expect.any(Menu),
-                mockFile,
-                'audio-recorder-player-context-menu'
-            );
-            expect(mockMetadataCache.getFirstLinkpathDest).toHaveBeenCalledWith('audio.mp3', 'active.md');
-        });
-
-        it('should do nothing if file resolution fails', () => {
-            const embed = document.createElement('div');
-            embed.className = 'internal-embed';
-            embed.setAttribute('src', 'audio.mp3');
-            const target = document.createElement('span');
-            embed.appendChild(target);
-
-            const mockEvent = {
-                target: target,
-            } as unknown as MouseEvent;
-
-            (mockMetadataCache.getFirstLinkpathDest as jest.Mock).mockReturnValue(null);
-
-            playerMenuCallback(mockEvent);
-
-            expect(mockEvent.preventDefault).not.toBeDefined(); // Event not passed to callback in this test setup actually, wait. 
-            // The callback receives event. If we don't mock preventDefault it might be undefined properly.
-            // But we want to ensure we returned early.
-            // Check if triggers were called.
-            expect(mockWorkspace.trigger).not.toHaveBeenCalled();
-        });
-
-        it('should handle no active file in player menu', () => {
-            const embed = document.createElement('div');
-            embed.className = 'internal-embed';
-            embed.setAttribute('src', 'audio.mp3');
-            const target = document.createElement('span');
-            embed.appendChild(target);
-
-            const mockEvent = {
-                target: target,
-                preventDefault: jest.fn(),
-                stopPropagation: jest.fn(),
-            } as unknown as MouseEvent;
-
-            (mockWorkspace.getActiveFile as jest.Mock).mockReturnValue(null);
-
-            // We expect getFirstLinkpathDest to be called with sourcePath = ''
-            // and if it finds file, proceed.
-            const mockFile = new TFile();
-            Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
-            (mockMetadataCache.getFirstLinkpathDest as jest.Mock).mockReturnValue(mockFile);
-
-            playerMenuCallback(mockEvent);
-
-            expect(mockMetadataCache.getFirstLinkpathDest).toHaveBeenCalledWith('audio.mp3', '');
-            expect(mockWorkspace.trigger).toHaveBeenCalled();
-        });
-
-        it('should attempt to find link in editor and add "Delete & Link" option', () => {
-            const embed = document.createElement('div');
-            embed.className = 'internal-embed';
-            embed.setAttribute('src', 'audio.mp3');
-            const target = document.createElement('span');
-            embed.appendChild(target);
-
-            const mockEvent = {
-                target: target,
-                pageX: 100,
-                pageY: 200,
-                preventDefault: jest.fn(),
-                stopPropagation: jest.fn(),
-            } as unknown as MouseEvent;
-
-            const mockFile = new TFile();
-            Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
-            (mockMetadataCache.getFirstLinkpathDest as jest.Mock).mockReturnValue(mockFile);
-
-            // Mock active view and editor
-            const mockEditor = {
-                offsetToPos: jest.fn().mockReturnValue({ line: 0, ch: 0 }),
-                getLine: jest.fn().mockReturnValue('[[audio.mp3]]'),
-                getCursor: jest.fn().mockReturnValue({ line: 10, ch: 10 }), // Should rely on offsetToPos result
-                replaceRange: jest.fn(),
-            } as unknown as Editor;
-
-            const editorViewOverride = {
-                posAtDOM: jest.fn().mockReturnValue(0)
-            };
-            // Mock casting editor to any to access cm/posAtDOM
-            Object.defineProperty(mockEditor, 'cm', {
-                get: () => editorViewOverride
-            });
-
-            (mockWorkspace.getActiveViewOfType as jest.Mock).mockReturnValue({
-                editor: mockEditor
-            });
-
-            playerMenuCallback(mockEvent);
-
-            // With findLinkAtCursor working (line is '[[audio.mp3]]', cursor 0), it matches
-            // We expect the menu to have items.
-            // Since we create 'new Menu()' inside using mock, we check its calls.
-            // The class creates one Menu instance.
-            // We can't easily access that exact instance unless we spy on Menu constructor or check args passed to workspace.trigger
-
-            const triggerCall = (mockWorkspace.trigger as jest.Mock).mock.calls[0];
-            const menuInstance = triggerCall[1];
-
-            expect(menuInstance.addItem).toHaveBeenCalled();
-
-            // Check if one of the items is "Delete recording & link"
-            // Since we manually add it inside registerPlayerMenu logic
-            // logic: if (linkMatch) { addDeleteRecordingAndLinkMenuItem(...) }
-
-            // We can check if addItem was called enough times or with specific title setup
-            const calls = (menuInstance.addItem as jest.Mock).mock.calls;
-            let foundDeleteLink = false;
-
-            for (const call of calls) {
-                const cb = call[0];
-                const mockItem = {
-                    setTitle: jest.fn().mockReturnThis(),
-                    setIcon: jest.fn().mockReturnThis(),
-                    setSection: jest.fn().mockReturnThis(),
-                    onClick: jest.fn(),
-                };
-                cb(mockItem);
-                if (mockItem.setTitle.mock.calls.length > 0 && mockItem.setTitle.mock.calls[0][0] === 'Delete recording & link to file') {
-                    foundDeleteLink = true;
-                    break;
-                }
-            }
-
-            expect(foundDeleteLink).toBe(true);
-        });
-
-        it('should handle errors in link resolution gracefully', () => {
-            const embed = document.createElement('div');
-            embed.className = 'internal-embed';
-            embed.setAttribute('src', 'audio.mp3');
-            const target = document.createElement('span');
-            embed.appendChild(target);
-
-            const mockEvent = {
-                target: target,
-                pageX: 100,
-                pageY: 200,
-                preventDefault: jest.fn(),
-                stopPropagation: jest.fn(),
-            } as unknown as MouseEvent;
-
-            const mockFile = new TFile();
-            Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
-            (mockMetadataCache.getFirstLinkpathDest as jest.Mock).mockReturnValue(mockFile);
-
-            const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
-
-            // Force error by returning an editor that throws inside posAtDOM
-            const mockEditor = {
-                get cm() {
-                    return {
-                        posAtDOM: jest.fn().mockImplementation(() => {
-                            throw new Error('Test Error');
-                        })
-                    };
-                }
-            } as unknown as Editor;
-            (mockWorkspace.getActiveViewOfType as jest.Mock).mockReturnValue({
-                editor: mockEditor
-            });
-
-            playerMenuCallback(mockEvent);
-
-            expect(consoleSpy).toHaveBeenCalledWith(
-                '[AudioRecorder] Failed to resolve link position in editor:',
-                expect.any(Error)
-            );
-            consoleSpy.mockRestore();
-        });
-    });
+	let contextMenu: ContextMenu;
+	let mockApp: App;
+	let mockPlugin: Plugin;
+	let mockWorkspace: Workspace;
+	let mockMetadataCache: MetadataCache;
+	let mockVault: Vault;
+	let mockFileManager: FileManager;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		// Mock App and its components
+		mockWorkspace = {
+			on: jest.fn(),
+			trigger: jest.fn(),
+			getActiveFile: jest.fn(),
+			getActiveViewOfType: jest.fn(),
+		} as unknown as Workspace;
+
+		mockMetadataCache = {
+			getFirstLinkpathDest: jest.fn(),
+		} as unknown as MetadataCache;
+
+		mockVault = {
+			delete: jest.fn(),
+		} as unknown as Vault;
+
+		mockFileManager = {
+			trashFile: jest.fn(),
+		} as unknown as FileManager;
+
+		mockApp = {
+			workspace: mockWorkspace,
+			metadataCache: mockMetadataCache,
+			vault: mockVault,
+			fileManager: mockFileManager,
+		} as unknown as App;
+
+		// Mock Plugin
+		mockPlugin = {
+			registerEvent: jest.fn(),
+			registerDomEvent: jest.fn(),
+		} as unknown as Plugin;
+
+		contextMenu = new ContextMenu(mockApp, mockPlugin);
+	});
+
+	describe('register', () => {
+		it('should register file, editor, and player menus', () => {
+			// We can't easily spy on private methods, so we verify side effects (calls to plugin.register*)
+			contextMenu.register();
+
+			// registerFileMenu calls workspace.on('file-menu') and plugin.registerEvent
+			expect(mockWorkspace.on).toHaveBeenCalledWith(
+				'file-menu',
+				expect.any(Function),
+			);
+			expect(mockPlugin.registerEvent).toHaveBeenCalled();
+
+			// registerEditorMenu calls workspace.on('editor-menu') and plugin.registerEvent
+			expect(mockWorkspace.on).toHaveBeenCalledWith(
+				'editor-menu',
+				expect.any(Function),
+			);
+
+			// registerPlayerMenu calls plugin.registerDomEvent
+			expect(mockPlugin.registerDomEvent).toHaveBeenCalledWith(
+				document,
+				'contextmenu',
+				expect.any(Function),
+				{ capture: true },
+			);
+		});
+	});
+
+	describe('registerFileMenu', () => {
+		let fileMenuCallback: (menu: Menu, file: TFile) => void;
+
+		beforeEach(() => {
+			contextMenu.register();
+			// Extract the callback passed to workspace.on('file-menu', ...)
+			const call = (mockWorkspace.on as jest.Mock).mock.calls.find(
+				(c) => c[0] === 'file-menu',
+			);
+			fileMenuCallback = call[1];
+		});
+
+		it('should include mp4 in AUDIO_EXTENSIONS', () => {
+			expect(AUDIO_EXTENSIONS).toContain(FORMAT_MP4);
+		});
+
+		test.each(AUDIO_EXTENSIONS)(
+			'should add "Delete recording" item for %s files',
+			(extension) => {
+				const mockMenu = new Menu();
+				const mockFile = new TFile();
+				Object.defineProperty(mockFile, 'extension', {
+					value: extension,
+				});
+
+				fileMenuCallback(mockMenu, mockFile);
+
+				expect(mockMenu.addItem).toHaveBeenCalled();
+			},
+		);
+
+		it('should add "Delete recording" item for audio files', () => {
+			const mockMenu = new Menu();
+			const mockFile = new TFile();
+			// Mock TFile properties setup
+			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
+
+			fileMenuCallback(mockMenu, mockFile);
+
+			expect(mockMenu.addItem).toHaveBeenCalledTimes(2);
+
+			// Verify the delete item configuration
+			const addItemCallback = (mockMenu.addItem as jest.Mock).mock
+				.calls[1][0];
+			const mockItem = {
+				setTitle: jest.fn().mockReturnThis(),
+				setIcon: jest.fn().mockReturnThis(),
+				setSection: jest.fn().mockReturnThis(),
+				onClick: jest.fn(),
+			};
+			addItemCallback(mockItem);
+
+			expect(mockItem.setTitle).toHaveBeenCalledWith('Delete recording');
+			expect(mockItem.setIcon).toHaveBeenCalledWith('trash');
+			expect(mockItem.setSection).toHaveBeenCalledWith('aar');
+		});
+
+		it('should add "Audio file info" item for audio files', () => {
+			const mockMenu = new Menu();
+			const mockFile = new TFile();
+			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
+
+			fileMenuCallback(mockMenu, mockFile);
+
+			expect(mockMenu.addItem).toHaveBeenCalledTimes(2);
+
+			// Verify the audio info item configuration
+			const addItemCallback = (mockMenu.addItem as jest.Mock).mock
+				.calls[0][0];
+			const mockItem = {
+				setTitle: jest.fn().mockReturnThis(),
+				setIcon: jest.fn().mockReturnThis(),
+				setSection: jest.fn().mockReturnThis(),
+				onClick: jest.fn(),
+			};
+			addItemCallback(mockItem);
+
+			expect(mockItem.setTitle).toHaveBeenCalledWith('Audio file info');
+			expect(mockItem.setIcon).toHaveBeenCalledWith('info');
+			expect(mockItem.setSection).toHaveBeenCalledWith('aar');
+		});
+
+		it('should open AudioFileInfoModal on "Audio file info" click', async () => {
+			const mockMenu = new Menu();
+			const mockFile = new TFile();
+			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
+
+			const mockInfo = { name: 'audio.mp3', size: 1024 };
+			jest.spyOn(AudioFileAnalyzer, 'getAudioFileInfo').mockResolvedValue(
+				mockInfo,
+			);
+
+			fileMenuCallback(mockMenu, mockFile);
+
+			const addItemCallback = (mockMenu.addItem as jest.Mock).mock
+				.calls[0][0];
+			const mockItem = {
+				setTitle: jest.fn().mockReturnThis(),
+				setIcon: jest.fn().mockReturnThis(),
+				setSection: jest.fn().mockReturnThis(),
+				onClick: jest.fn(),
+			};
+			addItemCallback(mockItem);
+
+			const clickHandler = mockItem.onClick.mock.calls[0][0];
+			await clickHandler();
+
+			expect(AudioFileAnalyzer.getAudioFileInfo).toHaveBeenCalledWith(
+				mockApp,
+				mockFile,
+			);
+		});
+
+		it('should not open modal if getAudioFileInfo returns null', async () => {
+			const mockMenu = new Menu();
+			const mockFile = new TFile();
+			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
+
+			jest.spyOn(AudioFileAnalyzer, 'getAudioFileInfo').mockResolvedValue(
+				null,
+			);
+
+			fileMenuCallback(mockMenu, mockFile);
+
+			const addItemCallback = (mockMenu.addItem as jest.Mock).mock
+				.calls[0][0];
+			const mockItem = {
+				setTitle: jest.fn().mockReturnThis(),
+				setIcon: jest.fn().mockReturnThis(),
+				setSection: jest.fn().mockReturnThis(),
+				onClick: jest.fn(),
+			};
+			addItemCallback(mockItem);
+
+			const clickHandler = mockItem.onClick.mock.calls[0][0];
+			await clickHandler();
+
+			expect(AudioFileAnalyzer.getAudioFileInfo).toHaveBeenCalledWith(
+				mockApp,
+				mockFile,
+			);
+		});
+
+		it('should not duplicate "Audio file info" when called twice on the same menu', () => {
+			const mockMenu = new Menu();
+			const mockFile = new TFile();
+			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
+
+			// Simulate both editor-menu and file-menu firing for the same Menu instance
+			fileMenuCallback(mockMenu, mockFile);
+			fileMenuCallback(mockMenu, mockFile);
+
+			// "Audio file info" should be added only once, but "Delete recording" is added each time
+			const calls = (mockMenu.addItem as jest.Mock).mock.calls;
+			const titles: string[] = [];
+			for (const call of calls) {
+				const mockItem = {
+					setTitle: jest.fn().mockReturnThis(),
+					setIcon: jest.fn().mockReturnThis(),
+					setSection: jest.fn().mockReturnThis(),
+					onClick: jest.fn(),
+				};
+				call[0](mockItem);
+				titles.push(mockItem.setTitle.mock.calls[0][0] as string);
+			}
+
+			const infoCount = titles.filter(
+				(t) => t === 'Audio file info',
+			).length;
+			expect(infoCount).toBe(1);
+		});
+
+		it('should NOT add item for non-audio files', () => {
+			const mockMenu = new Menu();
+			const mockFile = new TFile();
+			Object.defineProperty(mockFile, 'extension', { value: 'md' });
+
+			fileMenuCallback(mockMenu, mockFile);
+
+			expect(mockMenu.addItem).not.toHaveBeenCalled();
+		});
+
+		it('should delete file on click', async () => {
+			const mockMenu = new Menu();
+			const mockFile = new TFile();
+			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
+
+			fileMenuCallback(mockMenu, mockFile);
+
+			const addItemCallback = (mockMenu.addItem as jest.Mock).mock
+				.calls[1][0];
+			const mockItem = {
+				setTitle: jest.fn().mockReturnThis(),
+				setIcon: jest.fn().mockReturnThis(),
+				setSection: jest.fn().mockReturnThis(),
+				onClick: jest.fn(),
+			};
+			addItemCallback(mockItem);
+
+			// Trigger click
+			const clickHandler = mockItem.onClick.mock.calls[0][0];
+			await clickHandler();
+
+			expect(mockFileManager.trashFile).toHaveBeenCalledWith(mockFile);
+			expect(Notice).toHaveBeenCalledWith('Recording deleted');
+		});
+
+		it('should handle deletion error', async () => {
+			const mockMenu = new Menu();
+			const mockFile = new TFile();
+			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
+			(mockFileManager.trashFile as jest.Mock).mockRejectedValue(
+				new Error('Delete failed'),
+			);
+			const consoleSpy = jest
+				.spyOn(console, 'error')
+				.mockImplementation(() => {});
+
+			fileMenuCallback(mockMenu, mockFile);
+
+			const addItemCallback = (mockMenu.addItem as jest.Mock).mock
+				.calls[1][0];
+			const mockItem = {
+				setTitle: jest.fn().mockReturnThis(),
+				setIcon: jest.fn().mockReturnThis(),
+				setSection: jest.fn().mockReturnThis(),
+				onClick: jest.fn(),
+			};
+			addItemCallback(mockItem);
+
+			const clickHandler = mockItem.onClick.mock.calls[0][0];
+			await clickHandler();
+
+			expect(Notice).toHaveBeenCalledWith('Failed to delete recording');
+			expect(consoleSpy).toHaveBeenCalled();
+			consoleSpy.mockRestore();
+		});
+	});
+
+	describe('registerEditorMenu', () => {
+		let editorMenuCallback: (
+			menu: Menu,
+			editor: Editor,
+			view: unknown,
+		) => void;
+		let mockEditor: Editor;
+
+		beforeEach(() => {
+			contextMenu.register();
+			const call = (mockWorkspace.on as jest.Mock).mock.calls.find(
+				(c) => c[0] === 'editor-menu',
+			);
+			editorMenuCallback = call[1];
+
+			mockEditor = {
+				getCursor: jest.fn().mockReturnValue({ line: 0, ch: 0 }),
+				getLine: jest.fn(),
+				replaceRange: jest.fn(),
+				offsetToPos: jest.fn(),
+			} as unknown as Editor;
+		});
+
+		test.each(AUDIO_EXTENSIONS)(
+			'should add "Delete recording & link" item for %s files',
+			(extension) => {
+				const mockMenu = new Menu();
+				(mockEditor.getLine as jest.Mock).mockReturnValue(
+					`[[audio.${extension}]]`,
+				);
+				(mockEditor.getCursor as jest.Mock).mockReturnValue({
+					line: 0,
+					ch: 2,
+				});
+
+				const mockFile = new TFile();
+				Object.defineProperty(mockFile, 'extension', {
+					value: extension,
+				});
+				(
+					mockMetadataCache.getFirstLinkpathDest as jest.Mock
+				).mockReturnValue(mockFile);
+
+				editorMenuCallback(mockMenu, mockEditor, {});
+
+				expect(mockMenu.addItem).toHaveBeenCalled();
+			},
+		);
+
+		it('should do nothing if no link at cursor', () => {
+			const mockMenu = new Menu();
+			(mockEditor.getLine as jest.Mock).mockReturnValue('Just text');
+
+			editorMenuCallback(mockMenu, mockEditor, {});
+
+			expect(mockMenu.addItem).not.toHaveBeenCalled();
+		});
+
+		it('should do nothing if link resolves to non-audio file', () => {
+			const mockMenu = new Menu();
+			(mockEditor.getLine as jest.Mock).mockReturnValue('[[note]]');
+			(mockEditor.getCursor as jest.Mock).mockReturnValue({
+				line: 0,
+				ch: 2,
+			}); // Inside link
+			(
+				mockMetadataCache.getFirstLinkpathDest as jest.Mock
+			).mockReturnValue(new TFile()); // Default check fails mostly on extension mock? Or default TFile mock
+
+			const mockFile = new TFile();
+			Object.defineProperty(mockFile, 'extension', { value: 'md' });
+			(
+				mockMetadataCache.getFirstLinkpathDest as jest.Mock
+			).mockReturnValue(mockFile);
+
+			editorMenuCallback(mockMenu, mockEditor, {});
+
+			expect(mockMenu.addItem).not.toHaveBeenCalled();
+		});
+
+		it('should add "Delete recording & link" if valid audio link', () => {
+			const mockMenu = new Menu();
+			(mockEditor.getLine as jest.Mock).mockReturnValue('[[audio.mp3]]');
+			(mockEditor.getCursor as jest.Mock).mockReturnValue({
+				line: 0,
+				ch: 2,
+			});
+
+			const mockFile = new TFile();
+			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
+			(
+				mockMetadataCache.getFirstLinkpathDest as jest.Mock
+			).mockReturnValue(mockFile);
+
+			editorMenuCallback(mockMenu, mockEditor, {});
+
+			expect(mockMenu.addItem).toHaveBeenCalledTimes(2);
+			const addItemCallback = (mockMenu.addItem as jest.Mock).mock
+				.calls[1][0]; // Delete recording & link is the second item added
+			const mockItem = {
+				setTitle: jest.fn().mockReturnThis(),
+				setIcon: jest.fn().mockReturnThis(),
+				setSection: jest.fn().mockReturnThis(),
+				onClick: jest.fn(),
+			};
+			addItemCallback(mockItem);
+
+			expect(mockItem.setTitle).toHaveBeenCalledWith(
+				'Delete recording & link to file',
+			);
+		});
+
+		it('should delete file and remove link text on click', async () => {
+			const mockMenu = new Menu();
+			(mockEditor.getLine as jest.Mock).mockReturnValue(
+				'Text [[audio.mp3]] Text',
+			);
+			// Cursor at link
+			(mockEditor.getCursor as jest.Mock).mockReturnValue({
+				line: 0,
+				ch: 7,
+			});
+
+			const mockFile = new TFile();
+			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
+			(
+				mockMetadataCache.getFirstLinkpathDest as jest.Mock
+			).mockReturnValue(mockFile);
+
+			editorMenuCallback(mockMenu, mockEditor, {});
+
+			const addItemCallback = (mockMenu.addItem as jest.Mock).mock
+				.calls[1][0];
+			const mockItem = {
+				setTitle: jest.fn().mockReturnThis(),
+				setIcon: jest.fn().mockReturnThis(),
+				setSection: jest.fn().mockReturnThis(),
+				onClick: jest.fn(),
+			};
+			addItemCallback(mockItem);
+
+			const clickHandler = mockItem.onClick.mock.calls[0][0];
+			await clickHandler();
+
+			expect(mockFileManager.trashFile).toHaveBeenCalledWith(mockFile);
+			// Verify editor.replaceRange was called with correct range for [[audio.mp3]]
+			// "Text [[audio.mp3]] Text" -> Link is at index 5 to 18 (13 chars)
+			// But strict regex might handle it differently.
+			// Let's rely on the fact that existing logic finds it.
+			// Regex !?\[\[(.*?)(?:\|.*?)?\]\]
+			// For 'Text [[audio.mp3]] Text', match index is 5.
+			expect(mockEditor.replaceRange).toHaveBeenCalledWith(
+				'',
+				{ line: 0, ch: 5 },
+				{ line: 0, ch: 18 },
+			);
+			expect(Notice).toHaveBeenCalledWith('Recording and link deleted');
+		});
+
+		it('should handle deletion error in editor menu', async () => {
+			const mockMenu = new Menu();
+			(mockEditor.getLine as jest.Mock).mockReturnValue('[[audio.mp3]]');
+			(mockEditor.getCursor as jest.Mock).mockReturnValue({
+				line: 0,
+				ch: 2,
+			});
+
+			const mockFile = new TFile();
+			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
+			(
+				mockMetadataCache.getFirstLinkpathDest as jest.Mock
+			).mockReturnValue(mockFile);
+
+			// Mock delete failure
+			(mockFileManager.trashFile as jest.Mock).mockRejectedValue(
+				new Error('Delete failed'),
+			);
+			const consoleSpy = jest
+				.spyOn(console, 'error')
+				.mockImplementation();
+
+			editorMenuCallback(mockMenu, mockEditor, {});
+
+			const addItemCallback = (mockMenu.addItem as jest.Mock).mock
+				.calls[1][0];
+			const mockItem = {
+				setTitle: jest.fn().mockReturnThis(),
+				setIcon: jest.fn().mockReturnThis(),
+				setSection: jest.fn().mockReturnThis(),
+				onClick: jest.fn(),
+			};
+			addItemCallback(mockItem);
+
+			const clickHandler = mockItem.onClick.mock.calls[0][0];
+			await clickHandler();
+
+			expect(Notice).toHaveBeenCalledWith('Failed to delete recording');
+			expect(consoleSpy).toHaveBeenCalled();
+			consoleSpy.mockRestore();
+		});
+
+		it('should work with markdown links', () => {
+			const mockMenu = new Menu();
+			(mockEditor.getLine as jest.Mock).mockReturnValue(
+				'[link](audio.mp3)',
+			);
+			// [link](audio.mp3) -> cursor at 5 (inside link text) or 10 (inside path)
+			// Regex: !?\[(.*?)\]\((.*?)\)
+			// Group 1: link, Group 2: audio.mp3
+			// Match index 0. Length: [link](audio.mp3) = 17 chars.
+			(mockEditor.getCursor as jest.Mock).mockReturnValue({
+				line: 0,
+				ch: 10,
+			});
+
+			const mockFile = new TFile();
+			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
+			(
+				mockMetadataCache.getFirstLinkpathDest as jest.Mock
+			).mockReturnValue(mockFile);
+
+			editorMenuCallback(mockMenu, mockEditor, {});
+
+			expect(mockMenu.addItem).toHaveBeenCalled();
+		});
+
+		it('should handle view with no file', () => {
+			const mockMenu = new Menu();
+			(mockEditor.getLine as jest.Mock).mockReturnValue('[[audio.mp3]]');
+			(mockEditor.getCursor as jest.Mock).mockReturnValue({
+				line: 0,
+				ch: 2,
+			});
+
+			// view has no file property or it is null
+			const mockView = {};
+
+			const mockFile = new TFile();
+			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
+			// Should call getFirstLinkpathDest with sourcePath = ''
+			(
+				mockMetadataCache.getFirstLinkpathDest as jest.Mock
+			).mockReturnValue(mockFile);
+
+			editorMenuCallback(mockMenu, mockEditor, mockView);
+
+			expect(mockMetadataCache.getFirstLinkpathDest).toHaveBeenCalledWith(
+				'audio.mp3',
+				'',
+			);
+			expect(mockMenu.addItem).toHaveBeenCalled();
+		});
+
+		it('should handle view with file', () => {
+			const mockMenu = new Menu();
+			(mockEditor.getLine as jest.Mock).mockReturnValue('[[audio.mp3]]');
+			(mockEditor.getCursor as jest.Mock).mockReturnValue({
+				line: 0,
+				ch: 2,
+			});
+
+			const mockView = { file: { path: 'view.md' } };
+
+			const mockFile = new TFile();
+			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
+			(
+				mockMetadataCache.getFirstLinkpathDest as jest.Mock
+			).mockReturnValue(mockFile);
+
+			editorMenuCallback(mockMenu, mockEditor, mockView);
+
+			expect(mockMetadataCache.getFirstLinkpathDest).toHaveBeenCalledWith(
+				'audio.mp3',
+				'view.md',
+			);
+			expect(mockMenu.addItem).toHaveBeenCalled();
+		});
+	});
+
+	describe('registerPlayerMenu', () => {
+		let playerMenuCallback: (event: MouseEvent) => void;
+
+		beforeEach(() => {
+			contextMenu.register();
+			const call = (
+				mockPlugin.registerDomEvent as jest.Mock
+			).mock.calls.find((c) => c[1] === 'contextmenu');
+			playerMenuCallback = call[2];
+		});
+
+		test.each(AUDIO_EXTENSIONS)(
+			'should resolve %s file and show context menu',
+			(extension) => {
+				const embed = document.createElement('div');
+				embed.className = 'internal-embed';
+				embed.setAttribute('src', `audio.${extension}`);
+				const target = document.createElement('span');
+				embed.appendChild(target);
+
+				const mockEvent = {
+					target: target,
+					pageX: 100,
+					pageY: 200,
+					preventDefault: jest.fn(),
+					stopPropagation: jest.fn(),
+				} as unknown as MouseEvent;
+
+				const mockFile = new TFile();
+				Object.defineProperty(mockFile, 'extension', {
+					value: extension,
+				});
+				(
+					mockMetadataCache.getFirstLinkpathDest as jest.Mock
+				).mockReturnValue(mockFile);
+				(mockWorkspace.getActiveFile as jest.Mock).mockReturnValue(
+					null,
+				);
+
+				playerMenuCallback(mockEvent);
+
+				expect(mockEvent.preventDefault).toHaveBeenCalled();
+				expect(mockWorkspace.trigger).toHaveBeenCalledWith(
+					'file-menu',
+					expect.any(Menu),
+					mockFile,
+					'audio-recorder-player-context-menu',
+				);
+			},
+		);
+
+		it('should do nothing if target is not part of internal-embed', () => {
+			const mockEvent = {
+				target: document.createElement('div'),
+			} as unknown as MouseEvent;
+
+			playerMenuCallback(mockEvent);
+
+			expect(
+				mockMetadataCache.getFirstLinkpathDest,
+			).not.toHaveBeenCalled();
+		});
+
+		it('should do nothing if embed has no src', () => {
+			const embed = document.createElement('div');
+			embed.className = 'internal-embed';
+			// No src attribute
+
+			const target = document.createElement('span');
+			embed.appendChild(target);
+
+			const mockEvent = {
+				target: target,
+			} as unknown as MouseEvent;
+
+			playerMenuCallback(mockEvent);
+
+			expect(
+				mockMetadataCache.getFirstLinkpathDest,
+			).not.toHaveBeenCalled();
+		});
+
+		it('should resolve file and show menu if valid audio', () => {
+			const embed = document.createElement('div');
+			embed.className = 'internal-embed';
+			embed.setAttribute('src', 'audio.mp3');
+
+			const target = document.createElement('span');
+			embed.appendChild(target);
+
+			const mockEvent = {
+				target: target,
+				pageX: 100,
+				pageY: 200,
+				preventDefault: jest.fn(),
+				stopPropagation: jest.fn(),
+			} as unknown as MouseEvent;
+
+			const mockFile = new TFile();
+			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
+			(
+				mockMetadataCache.getFirstLinkpathDest as jest.Mock
+			).mockReturnValue(mockFile);
+
+			// Cover truthy activeFile branch
+			const mockActiveFile = new TFile();
+			mockActiveFile.path = 'active.md';
+			(mockWorkspace.getActiveFile as jest.Mock).mockReturnValue(
+				mockActiveFile,
+			);
+
+			playerMenuCallback(mockEvent);
+
+			expect(mockEvent.preventDefault).toHaveBeenCalled();
+			expect(mockEvent.stopPropagation).toHaveBeenCalled();
+			expect(mockWorkspace.trigger).toHaveBeenCalledWith(
+				'file-menu',
+				expect.any(Menu),
+				mockFile,
+				'audio-recorder-player-context-menu',
+			);
+			expect(mockMetadataCache.getFirstLinkpathDest).toHaveBeenCalledWith(
+				'audio.mp3',
+				'active.md',
+			);
+		});
+
+		it('should do nothing if file resolution fails', () => {
+			const embed = document.createElement('div');
+			embed.className = 'internal-embed';
+			embed.setAttribute('src', 'audio.mp3');
+			const target = document.createElement('span');
+			embed.appendChild(target);
+
+			const mockEvent = {
+				target: target,
+			} as unknown as MouseEvent;
+
+			(
+				mockMetadataCache.getFirstLinkpathDest as jest.Mock
+			).mockReturnValue(null);
+
+			playerMenuCallback(mockEvent);
+
+			expect(mockEvent.preventDefault).not.toBeDefined(); // Event not passed to callback in this test setup actually, wait.
+			// The callback receives event. If we don't mock preventDefault it might be undefined properly.
+			// But we want to ensure we returned early.
+			// Check if triggers were called.
+			expect(mockWorkspace.trigger).not.toHaveBeenCalled();
+		});
+
+		it('should handle no active file in player menu', () => {
+			const embed = document.createElement('div');
+			embed.className = 'internal-embed';
+			embed.setAttribute('src', 'audio.mp3');
+			const target = document.createElement('span');
+			embed.appendChild(target);
+
+			const mockEvent = {
+				target: target,
+				preventDefault: jest.fn(),
+				stopPropagation: jest.fn(),
+			} as unknown as MouseEvent;
+
+			(mockWorkspace.getActiveFile as jest.Mock).mockReturnValue(null);
+
+			// We expect getFirstLinkpathDest to be called with sourcePath = ''
+			// and if it finds file, proceed.
+			const mockFile = new TFile();
+			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
+			(
+				mockMetadataCache.getFirstLinkpathDest as jest.Mock
+			).mockReturnValue(mockFile);
+
+			playerMenuCallback(mockEvent);
+
+			expect(mockMetadataCache.getFirstLinkpathDest).toHaveBeenCalledWith(
+				'audio.mp3',
+				'',
+			);
+			expect(mockWorkspace.trigger).toHaveBeenCalled();
+		});
+
+		it('should attempt to find link in editor and add "Delete & Link" option', () => {
+			const embed = document.createElement('div');
+			embed.className = 'internal-embed';
+			embed.setAttribute('src', 'audio.mp3');
+			const target = document.createElement('span');
+			embed.appendChild(target);
+
+			const mockEvent = {
+				target: target,
+				pageX: 100,
+				pageY: 200,
+				preventDefault: jest.fn(),
+				stopPropagation: jest.fn(),
+			} as unknown as MouseEvent;
+
+			const mockFile = new TFile();
+			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
+			(
+				mockMetadataCache.getFirstLinkpathDest as jest.Mock
+			).mockReturnValue(mockFile);
+
+			// Mock active view and editor
+			const mockEditor = {
+				offsetToPos: jest.fn().mockReturnValue({ line: 0, ch: 0 }),
+				getLine: jest.fn().mockReturnValue('[[audio.mp3]]'),
+				getCursor: jest.fn().mockReturnValue({ line: 10, ch: 10 }), // Should rely on offsetToPos result
+				replaceRange: jest.fn(),
+			} as unknown as Editor;
+
+			const editorViewOverride = {
+				posAtDOM: jest.fn().mockReturnValue(0),
+			};
+			// Mock casting editor to any to access cm/posAtDOM
+			Object.defineProperty(mockEditor, 'cm', {
+				get: () => editorViewOverride,
+			});
+
+			(mockWorkspace.getActiveViewOfType as jest.Mock).mockReturnValue({
+				editor: mockEditor,
+			});
+
+			playerMenuCallback(mockEvent);
+
+			// With findLinkAtCursor working (line is '[[audio.mp3]]', cursor 0), it matches
+			// We expect the menu to have items.
+			// Since we create 'new Menu()' inside using mock, we check its calls.
+			// The class creates one Menu instance.
+			// We can't easily access that exact instance unless we spy on Menu constructor or check args passed to workspace.trigger
+
+			const triggerCall = (mockWorkspace.trigger as jest.Mock).mock
+				.calls[0];
+			const menuInstance = triggerCall[1];
+
+			expect(menuInstance.addItem).toHaveBeenCalled();
+
+			// Check if one of the items is "Delete recording & link"
+			// Since we manually add it inside registerPlayerMenu logic
+			// logic: if (linkMatch) { addDeleteRecordingAndLinkMenuItem(...) }
+
+			// We can check if addItem was called enough times or with specific title setup
+			const calls = (menuInstance.addItem as jest.Mock).mock.calls;
+			let foundDeleteLink = false;
+
+			for (const call of calls) {
+				const cb = call[0];
+				const mockItem = {
+					setTitle: jest.fn().mockReturnThis(),
+					setIcon: jest.fn().mockReturnThis(),
+					setSection: jest.fn().mockReturnThis(),
+					onClick: jest.fn(),
+				};
+				cb(mockItem);
+				if (
+					mockItem.setTitle.mock.calls.length > 0 &&
+					mockItem.setTitle.mock.calls[0][0] ===
+						'Delete recording & link to file'
+				) {
+					foundDeleteLink = true;
+					break;
+				}
+			}
+
+			expect(foundDeleteLink).toBe(true);
+		});
+
+		it('should handle errors in link resolution gracefully', () => {
+			const embed = document.createElement('div');
+			embed.className = 'internal-embed';
+			embed.setAttribute('src', 'audio.mp3');
+			const target = document.createElement('span');
+			embed.appendChild(target);
+
+			const mockEvent = {
+				target: target,
+				pageX: 100,
+				pageY: 200,
+				preventDefault: jest.fn(),
+				stopPropagation: jest.fn(),
+			} as unknown as MouseEvent;
+
+			const mockFile = new TFile();
+			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
+			(
+				mockMetadataCache.getFirstLinkpathDest as jest.Mock
+			).mockReturnValue(mockFile);
+
+			const consoleSpy = jest
+				.spyOn(console, 'error')
+				.mockImplementation();
+
+			// Force error by returning an editor that throws inside posAtDOM
+			const mockEditor = {
+				get cm() {
+					return {
+						posAtDOM: jest.fn().mockImplementation(() => {
+							throw new Error('Test Error');
+						}),
+					};
+				},
+			} as unknown as Editor;
+			(mockWorkspace.getActiveViewOfType as jest.Mock).mockReturnValue({
+				editor: mockEditor,
+			});
+
+			playerMenuCallback(mockEvent);
+
+			expect(consoleSpy).toHaveBeenCalledWith(
+				'[AudioRecorder] Failed to resolve link position in editor:',
+				expect.any(Error),
+			);
+			consoleSpy.mockRestore();
+		});
+	});
 });

--- a/tests/unit/DebugLogger.test.ts
+++ b/tests/unit/DebugLogger.test.ts
@@ -8,105 +8,126 @@ import type { AudioRecorderSettings } from '../../src/settings/Settings';
 import { DEFAULT_SETTINGS } from '../../src/settings/Settings';
 
 describe('DebugLogger', () => {
-    let consoleMock: jest.SpyInstance;
+	let consoleMock: jest.SpyInstance;
 
-    beforeEach(() => {
-        consoleMock = jest.spyOn(console, 'debug').mockImplementation();
-    });
+	beforeEach(() => {
+		consoleMock = jest.spyOn(console, 'debug').mockImplementation();
+	});
 
-    afterEach(() => {
-        consoleMock.mockRestore();
-    });
+	afterEach(() => {
+		consoleMock.mockRestore();
+	});
 
-    describe('when debug is disabled', () => {
-        it('should not log anything', () => {
-            const settings: AudioRecorderSettings = { ...DEFAULT_SETTINGS, debug: false };
-            const logger = new DebugLogger(settings);
+	describe('when debug is disabled', () => {
+		it('should not log anything', () => {
+			const settings: AudioRecorderSettings = {
+				...DEFAULT_SETTINGS,
+				debug: false,
+			};
+			const logger = new DebugLogger(settings);
 
-            logger.logMimeType('audio/webm');
-            logger.logDevices([]);
-            logger.logChunkSize(0, 1000);
-            logger.logRecordingStats(5000, 10);
-            logger.log('test message');
+			logger.logMimeType('audio/webm');
+			logger.logDevices([]);
+			logger.logChunkSize(0, 1000);
+			logger.logRecordingStats(5000, 10);
+			logger.log('test message');
 
-            expect(consoleMock).not.toHaveBeenCalled();
-        });
-    });
+			expect(consoleMock).not.toHaveBeenCalled();
+		});
+	});
 
-    describe('when debug is enabled', () => {
-        it('should log MIME type', () => {
-            const settings: AudioRecorderSettings = { ...DEFAULT_SETTINGS, debug: true };
-            const logger = new DebugLogger(settings);
+	describe('when debug is enabled', () => {
+		it('should log MIME type', () => {
+			const settings: AudioRecorderSettings = {
+				...DEFAULT_SETTINGS,
+				debug: true,
+			};
+			const logger = new DebugLogger(settings);
 
-            logger.logMimeType('audio/webm;codecs=opus');
+			logger.logMimeType('audio/webm;codecs=opus');
 
-            expect(consoleMock).toHaveBeenCalledWith(
-                '[AudioRecorder] Selected MIME type:',
-                'audio/webm;codecs=opus',
-            );
-        });
+			expect(consoleMock).toHaveBeenCalledWith(
+				'[AudioRecorder] Selected MIME type:',
+				'audio/webm;codecs=opus',
+			);
+		});
 
-        it('should log devices', () => {
-            const settings: AudioRecorderSettings = { ...DEFAULT_SETTINGS, debug: true };
-            const logger = new DebugLogger(settings);
-            const mockDevices = [
-                { deviceId: 'abc123', label: 'Built-in Microphone' },
-            ] as unknown as MediaDeviceInfo[];
+		it('should log devices', () => {
+			const settings: AudioRecorderSettings = {
+				...DEFAULT_SETTINGS,
+				debug: true,
+			};
+			const logger = new DebugLogger(settings);
+			const mockDevices = [
+				{ deviceId: 'abc123', label: 'Built-in Microphone' },
+			] as unknown as MediaDeviceInfo[];
 
-            logger.logDevices(mockDevices);
+			logger.logDevices(mockDevices);
 
-            expect(consoleMock).toHaveBeenCalledWith(
-                '[AudioRecorder] Available audio devices:',
-                [{ id: 'abc123', label: 'Built-in Microphone' }],
-            );
-        });
+			expect(consoleMock).toHaveBeenCalledWith(
+				'[AudioRecorder] Available audio devices:',
+				[{ id: 'abc123', label: 'Built-in Microphone' }],
+			);
+		});
 
-        it('should log chunk size', () => {
-            const settings: AudioRecorderSettings = { ...DEFAULT_SETTINGS, debug: true };
-            const logger = new DebugLogger(settings);
+		it('should log chunk size', () => {
+			const settings: AudioRecorderSettings = {
+				...DEFAULT_SETTINGS,
+				debug: true,
+			};
+			const logger = new DebugLogger(settings);
 
-            logger.logChunkSize(0, 4096);
+			logger.logChunkSize(0, 4096);
 
-            expect(consoleMock).toHaveBeenCalledWith(
-                '[AudioRecorder] Track 0 chunk size: 4096 bytes',
-            );
-        });
+			expect(consoleMock).toHaveBeenCalledWith(
+				'[AudioRecorder] Track 0 chunk size: 4096 bytes',
+			);
+		});
 
-        it('should log recording stats', () => {
-            const settings: AudioRecorderSettings = { ...DEFAULT_SETTINGS, debug: true };
-            const logger = new DebugLogger(settings);
+		it('should log recording stats', () => {
+			const settings: AudioRecorderSettings = {
+				...DEFAULT_SETTINGS,
+				debug: true,
+			};
+			const logger = new DebugLogger(settings);
 
-            logger.logRecordingStats(5500, 12);
+			logger.logRecordingStats(5500, 12);
 
-            expect(consoleMock).toHaveBeenCalledWith(
-                '[AudioRecorder] Recording stats: 5.5s, 12 chunks',
-            );
-        });
+			expect(consoleMock).toHaveBeenCalledWith(
+				'[AudioRecorder] Recording stats: 5.5s, 12 chunks',
+			);
+		});
 
-        it('should log generic messages', () => {
-            const settings: AudioRecorderSettings = { ...DEFAULT_SETTINGS, debug: true };
-            const logger = new DebugLogger(settings);
+		it('should log generic messages', () => {
+			const settings: AudioRecorderSettings = {
+				...DEFAULT_SETTINGS,
+				debug: true,
+			};
+			const logger = new DebugLogger(settings);
 
-            logger.log('Custom message', { key: 'value' });
+			logger.log('Custom message', { key: 'value' });
 
-            expect(consoleMock).toHaveBeenCalledWith(
-                '[AudioRecorder] Custom message',
-                { key: 'value' },
-            );
-        });
-    });
+			expect(consoleMock).toHaveBeenCalledWith(
+				'[AudioRecorder] Custom message',
+				{ key: 'value' },
+			);
+		});
+	});
 
-    describe('updateSettings', () => {
-        it('should toggle logging based on new settings', () => {
-            const settings: AudioRecorderSettings = { ...DEFAULT_SETTINGS, debug: false };
-            const logger = new DebugLogger(settings);
+	describe('updateSettings', () => {
+		it('should toggle logging based on new settings', () => {
+			const settings: AudioRecorderSettings = {
+				...DEFAULT_SETTINGS,
+				debug: false,
+			};
+			const logger = new DebugLogger(settings);
 
-            logger.logMimeType('test');
-            expect(consoleMock).not.toHaveBeenCalled();
+			logger.logMimeType('test');
+			expect(consoleMock).not.toHaveBeenCalled();
 
-            logger.updateSettings({ ...settings, debug: true });
-            logger.logMimeType('test');
-            expect(consoleMock).toHaveBeenCalled();
-        });
-    });
+			logger.updateSettings({ ...settings, debug: true });
+			logger.logMimeType('test');
+			expect(consoleMock).toHaveBeenCalled();
+		});
+	});
 });

--- a/tests/unit/PcmStreamRecorder.test.ts
+++ b/tests/unit/PcmStreamRecorder.test.ts
@@ -117,20 +117,18 @@ describe('PcmStreamRecorder', () => {
 
 		it('should connect audio graph: source → processor → gain(0) → destination', async () => {
 			const stream = createMockStream();
-			const recorder = new PcmStreamRecorder(
-				stream,
-				44100,
-				onChunkMock,
-			);
+			const recorder = new PcmStreamRecorder(stream, 44100, onChunkMock);
 
 			await recorder.start();
 
 			expect(
 				mockAudioContext.createMediaStreamSource,
 			).toHaveBeenCalledWith(stream);
-			expect(
-				mockAudioContext.createScriptProcessor,
-			).toHaveBeenCalledWith(4096, 1, 1);
+			expect(mockAudioContext.createScriptProcessor).toHaveBeenCalledWith(
+				4096,
+				1,
+				1,
+			);
 			expect(mockAudioContext.createGain).toHaveBeenCalled();
 			expect(mockGainNode.gain.value).toBe(0);
 		});
@@ -138,11 +136,7 @@ describe('PcmStreamRecorder', () => {
 		it('should expose actual channels and sampleRate from AudioContext', async () => {
 			mockSourceNode.channelCount = 2;
 			const stream = createMockStream(2);
-			const recorder = new PcmStreamRecorder(
-				stream,
-				44100,
-				onChunkMock,
-			);
+			const recorder = new PcmStreamRecorder(stream, 44100, onChunkMock);
 
 			await recorder.start();
 
@@ -154,11 +148,7 @@ describe('PcmStreamRecorder', () => {
 	describe('onaudioprocess callback', () => {
 		it('should deliver interleaved int16 PCM data via onChunk', async () => {
 			const stream = createMockStream();
-			const recorder = new PcmStreamRecorder(
-				stream,
-				44100,
-				onChunkMock,
-			);
+			const recorder = new PcmStreamRecorder(stream, 44100, onChunkMock);
 
 			await recorder.start();
 
@@ -174,11 +164,7 @@ describe('PcmStreamRecorder', () => {
 		it('should interleave stereo samples correctly', async () => {
 			mockSourceNode.channelCount = 2;
 			const stream = createMockStream(2);
-			const recorder = new PcmStreamRecorder(
-				stream,
-				44100,
-				onChunkMock,
-			);
+			const recorder = new PcmStreamRecorder(stream, 44100, onChunkMock);
 
 			await recorder.start();
 
@@ -193,11 +179,7 @@ describe('PcmStreamRecorder', () => {
 
 		it('should clamp sample values to [-1, 1] range', async () => {
 			const stream = createMockStream();
-			const recorder = new PcmStreamRecorder(
-				stream,
-				44100,
-				onChunkMock,
-			);
+			const recorder = new PcmStreamRecorder(stream, 44100, onChunkMock);
 
 			await recorder.start();
 
@@ -222,11 +204,7 @@ describe('PcmStreamRecorder', () => {
 
 		it('should not deliver chunks when paused', async () => {
 			const stream = createMockStream();
-			const recorder = new PcmStreamRecorder(
-				stream,
-				44100,
-				onChunkMock,
-			);
+			const recorder = new PcmStreamRecorder(stream, 44100, onChunkMock);
 
 			await recorder.start();
 			recorder.pause();
@@ -239,11 +217,7 @@ describe('PcmStreamRecorder', () => {
 
 		it('should resume delivering chunks after resume', async () => {
 			const stream = createMockStream();
-			const recorder = new PcmStreamRecorder(
-				stream,
-				44100,
-				onChunkMock,
-			);
+			const recorder = new PcmStreamRecorder(stream, 44100, onChunkMock);
 
 			await recorder.start();
 			recorder.pause();
@@ -259,11 +233,7 @@ describe('PcmStreamRecorder', () => {
 	describe('stop', () => {
 		it('should close AudioContext and disconnect nodes', async () => {
 			const stream = createMockStream();
-			const recorder = new PcmStreamRecorder(
-				stream,
-				44100,
-				onChunkMock,
-			);
+			const recorder = new PcmStreamRecorder(stream, 44100, onChunkMock);
 
 			await recorder.start();
 			await recorder.stop();
@@ -273,11 +243,7 @@ describe('PcmStreamRecorder', () => {
 
 		it('should nullify onaudioprocess callback', async () => {
 			const stream = createMockStream();
-			const recorder = new PcmStreamRecorder(
-				stream,
-				44100,
-				onChunkMock,
-			);
+			const recorder = new PcmStreamRecorder(stream, 44100, onChunkMock);
 
 			await recorder.start();
 			await recorder.stop();
@@ -287,11 +253,7 @@ describe('PcmStreamRecorder', () => {
 
 		it('should handle stop when not started', async () => {
 			const stream = createMockStream();
-			const recorder = new PcmStreamRecorder(
-				stream,
-				44100,
-				onChunkMock,
-			);
+			const recorder = new PcmStreamRecorder(stream, 44100, onChunkMock);
 
 			// Should not throw
 			await expect(recorder.stop()).resolves.toBeUndefined();

--- a/tests/unit/RecordingManager.test.ts
+++ b/tests/unit/RecordingManager.test.ts
@@ -7,1273 +7,1438 @@
 
 import { RecordingManager } from '../../src/recording/RecordingManager';
 import { RecordingStatus } from '../../src/types';
-import { DEFAULT_SETTINGS, AudioRecorderSettings } from '../../src/settings/Settings';
+import {
+	DEFAULT_SETTINGS,
+	AudioRecorderSettings,
+} from '../../src/settings/Settings';
 import type { App } from 'obsidian';
 
 // Mock obsidian module
 jest.mock('obsidian', () => ({
-    Notice: jest.fn(),
-    MarkdownView: jest.fn(),
-    normalizePath: (path: string) => path.replace(/\\/g, '/'),
-    Platform: {
-        isMobile: false,
-        isMobileApp: false,
-    },
+	Notice: jest.fn(),
+	MarkdownView: jest.fn(),
+	normalizePath: (path: string) => path.replace(/\\/g, '/'),
+	Platform: {
+		isMobile: false,
+		isMobileApp: false,
+	},
 }));
 
 // Mock AudioStreamHandler
 jest.mock('../../src/recording/AudioStreamHandler', () => ({
-    getAudioStreams: jest.fn(),
-    getAudioSourceName: jest.fn().mockResolvedValue('TestDevice'),
-    stopAllStreams: jest.fn(),
-    validateSelectedDevices: jest.fn(),
+	getAudioStreams: jest.fn(),
+	getAudioSourceName: jest.fn().mockResolvedValue('TestDevice'),
+	stopAllStreams: jest.fn(),
+	validateSelectedDevices: jest.fn(),
 }));
 
 // Mock WavEncoder
 jest.mock('../../src/recording/WavEncoder', () => ({
-    bufferToWave: jest.fn().mockReturnValue(new Blob(['test'], { type: 'audio/wav' })),
-    assembleWavFromPcmSegments: jest.fn().mockReturnValue(new ArrayBuffer(44)),
+	bufferToWave: jest
+		.fn()
+		.mockReturnValue(new Blob(['test'], { type: 'audio/wav' })),
+	assembleWavFromPcmSegments: jest.fn().mockReturnValue(new ArrayBuffer(44)),
 }));
 
 // Mock PcmStreamRecorder
 let capturedPcmChunkCallback: ((data: ArrayBuffer) => void) | null = null;
 jest.mock('../../src/recording/PcmStreamRecorder', () => ({
-    PcmStreamRecorder: jest.fn().mockImplementation(
-        (_stream: MediaStream, _sampleRate: number, onChunk: (data: ArrayBuffer) => void) => {
-            capturedPcmChunkCallback = onChunk;
-            return {
-                channels: 1,
-                sampleRate: 44100,
-                start: jest.fn().mockResolvedValue(undefined),
-                stop: jest.fn().mockResolvedValue(undefined),
-                pause: jest.fn(),
-                resume: jest.fn(),
-            };
-        },
-    ),
+	PcmStreamRecorder: jest
+		.fn()
+		.mockImplementation(
+			(
+				_stream: MediaStream,
+				_sampleRate: number,
+				onChunk: (data: ArrayBuffer) => void,
+			) => {
+				capturedPcmChunkCallback = onChunk;
+				return {
+					channels: 1,
+					sampleRate: 44100,
+					start: jest.fn().mockResolvedValue(undefined),
+					stop: jest.fn().mockResolvedValue(undefined),
+					pause: jest.fn(),
+					resume: jest.fn(),
+				};
+			},
+		),
 }));
 
 // Mock AudioContext and OfflineAudioContext
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (global as any).AudioContext = jest.fn().mockImplementation(() => ({
-    decodeAudioData: jest.fn().mockResolvedValue({
-        duration: 1,
-        length: 44100,
-        sampleRate: 44100,
-        numberOfChannels: 1,
-        getChannelData: jest.fn().mockReturnValue(new Float32Array(44100)),
-    }),
-    createBufferSource: jest.fn().mockImplementation(() => ({
-        connect: jest.fn(),
-        start: jest.fn(),
-        buffer: null,
-    })),
-    destination: {},
-    close: jest.fn().mockResolvedValue(undefined),
-    sampleRate: 44100,
+	decodeAudioData: jest.fn().mockResolvedValue({
+		duration: 1,
+		length: 44100,
+		sampleRate: 44100,
+		numberOfChannels: 1,
+		getChannelData: jest.fn().mockReturnValue(new Float32Array(44100)),
+	}),
+	createBufferSource: jest.fn().mockImplementation(() => ({
+		connect: jest.fn(),
+		start: jest.fn(),
+		buffer: null,
+	})),
+	destination: {},
+	close: jest.fn().mockResolvedValue(undefined),
+	sampleRate: 44100,
 }));
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (global as any).OfflineAudioContext = jest.fn().mockImplementation(() => ({
-    createBufferSource: jest.fn().mockImplementation(() => ({
-        connect: jest.fn(),
-        start: jest.fn(),
-        buffer: null,
-    })),
-    startRendering: jest.fn().mockResolvedValue({
-        length: 44100,
-        sampleRate: 44100,
-        getChannelData: jest.fn().mockReturnValue(new Float32Array(44100)),
-    }),
-    destination: {},
+	createBufferSource: jest.fn().mockImplementation(() => ({
+		connect: jest.fn(),
+		start: jest.fn(),
+		buffer: null,
+	})),
+	startRendering: jest.fn().mockResolvedValue({
+		length: 44100,
+		sampleRate: 44100,
+		getChannelData: jest.fn().mockReturnValue(new Float32Array(44100)),
+	}),
+	destination: {},
 }));
 
 // Mock AudioBuffer
 (global as any).AudioBuffer = jest.fn().mockImplementation(() => ({
-    getChannelData: jest.fn().mockReturnValue(new Float32Array(44100)),
+	getChannelData: jest.fn().mockReturnValue(new Float32Array(44100)),
 }));
 
 if (!Blob.prototype.arrayBuffer) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test polyfill
-    (Blob.prototype as any).arrayBuffer = function (): Promise<ArrayBuffer> {
-        return Promise.resolve(new ArrayBuffer(0));
-    };
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- test polyfill
+	(Blob.prototype as any).arrayBuffer = function (): Promise<ArrayBuffer> {
+		return Promise.resolve(new ArrayBuffer(0));
+	};
 }
 
 describe('RecordingManager', () => {
-    let manager: RecordingManager;
-    let mockApp: App;
-    let mockSettings: AudioRecorderSettings;
-    let statusChangeCallback: jest.Mock;
-    let consoleErrorSpy: jest.SpyInstance;
-
-    beforeEach(() => {
-        // Reset mocks
-        jest.clearAllMocks();
-        consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
-
-        // Create mock App
-        mockApp = {
-            vault: {
-                adapter: {
-                    exists: jest.fn().mockResolvedValue(false),
-                    rename: jest.fn().mockResolvedValue(undefined),
-                    readBinary: jest.fn().mockResolvedValue(new ArrayBuffer(0)),
-                    writeBinary: jest.fn().mockResolvedValue(undefined),
-                    remove: jest.fn().mockResolvedValue(undefined),
-                },
-                createBinary: jest.fn().mockResolvedValue(undefined),
-                createFolder: jest.fn().mockResolvedValue(undefined),
-            },
-            workspace: {
-                getActiveViewOfType: jest.fn().mockReturnValue(null),
-                getActiveFile: jest.fn().mockReturnValue(null),
-            },
-        } as unknown as App;
-
-        // Use default settings
-        mockSettings = { ...DEFAULT_SETTINGS };
-
-        // Status change callback
-        statusChangeCallback = jest.fn();
-
-        // Create manager instance
-        manager = new RecordingManager(mockApp, mockSettings, statusChangeCallback);
-    });
-
-    afterEach(() => {
-        consoleErrorSpy.mockRestore();
-    });
-
-    describe('constructor', () => {
-        it('should initialize with idle status', () => {
-            expect(manager.getStatus()).toBe(RecordingStatus.Idle);
-        });
-
-        it('should store the status change callback', () => {
-            expect(statusChangeCallback).not.toHaveBeenCalled();
-        });
-    });
-
-    describe('getStatus', () => {
-        it('should return Idle initially', () => {
-            expect(manager.getStatus()).toBe(RecordingStatus.Idle);
-        });
-    });
-
-    describe('updateSettings', () => {
-        it('should update settings reference', () => {
-            const newSettings: AudioRecorderSettings = {
-                ...DEFAULT_SETTINGS,
-                filePrefix: 'new-prefix',
-            };
-
-            manager.updateSettings(newSettings);
-
-            // Settings are private, but we can verify through behavior
-            expect(manager.getStatus()).toBe(RecordingStatus.Idle);
-        });
-    });
-
-    describe('toggleRecording', () => {
-        beforeEach(() => {
-            // Mock MediaRecorder
-            const mockMediaRecorder = {
-                start: jest.fn(),
-                stop: jest.fn(),
-                pause: jest.fn(),
-                resume: jest.fn(),
-                ondataavailable: null as ((event: BlobEvent) => void) | null,
-                onerror: null as ((event: Event) => void) | null,
-                addEventListener: jest.fn((event: string, handler: () => void) => {
-                    if (event === 'stop') {
-                        handler();
-                    }
-                }),
-            };
-
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- Mock global MediaRecorder
-            (global as Record<string, unknown>).MediaRecorder = jest.fn(() => mockMediaRecorder);
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- Mock isTypeSupported
-            (global as Record<string, unknown>).MediaRecorder.isTypeSupported = jest.fn().mockReturnValue(true);
-
-            // Mock getAudioStreams
-            const { getAudioStreams } = jest.requireMock('../../src/recording/AudioStreamHandler') as {
-                getAudioStreams: jest.Mock;
-            };
-            getAudioStreams.mockResolvedValue({
-                streams: [{
-                    getTracks: () => [{ stop: jest.fn() }],
-                }],
-                trackOrder: [],
-            });
-        });
-
-        it('should start recording when idle', async () => {
-            expect(manager.getStatus()).toBe(RecordingStatus.Idle);
-
-            await manager.toggleRecording();
-
-            expect(manager.getStatus()).toBe(RecordingStatus.Recording);
-            expect(statusChangeCallback).toHaveBeenCalledWith(RecordingStatus.Recording, undefined);
-        });
-
-        it('should stop recording when recording', async () => {
-            // First start
-            await manager.toggleRecording();
-            expect(manager.getStatus()).toBe(RecordingStatus.Recording);
-
-            // Then stop
-            await manager.toggleRecording();
-            expect(manager.getStatus()).toBe(RecordingStatus.Idle);
-        });
-    });
-
-    describe('togglePauseResume', () => {
-        let mockMediaRecorder: {
-            start: jest.Mock;
-            stop: jest.Mock;
-            pause: jest.Mock;
-            resume: jest.Mock;
-            ondataavailable: ((event: BlobEvent) => void) | null;
-            onerror: ((event: Event) => void) | null;
-            addEventListener: jest.Mock;
-        };
-
-        beforeEach(() => {
-            mockMediaRecorder = {
-                start: jest.fn(),
-                stop: jest.fn(),
-                pause: jest.fn(),
-                resume: jest.fn(),
-                ondataavailable: null,
-                onerror: null,
-                addEventListener: jest.fn((event: string, handler: () => void) => {
-                    if (event === 'stop') {
-                        handler();
-                    }
-                }),
-            };
-
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- Mock global MediaRecorder
-            (global as Record<string, unknown>).MediaRecorder = jest.fn(() => mockMediaRecorder);
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- Mock isTypeSupported
-            (global as Record<string, unknown>).MediaRecorder.isTypeSupported = jest.fn().mockReturnValue(true);
-
-            const { getAudioStreams } = jest.requireMock('../../src/recording/AudioStreamHandler') as {
-                getAudioStreams: jest.Mock;
-            };
-            getAudioStreams.mockResolvedValue({
-                streams: [{
-                    getTracks: () => [{ stop: jest.fn() }],
-                }],
-                trackOrder: [],
-            });
-        });
-
-        it('should do nothing when idle', () => {
-            manager.togglePauseResume();
-
-            expect(manager.getStatus()).toBe(RecordingStatus.Idle);
-            expect(mockMediaRecorder.pause).not.toHaveBeenCalled();
-        });
-
-        it('should pause when recording', async () => {
-            await manager.toggleRecording();
-            expect(manager.getStatus()).toBe(RecordingStatus.Recording);
-
-            manager.togglePauseResume();
-
-            expect(manager.getStatus()).toBe(RecordingStatus.Paused);
-            expect(statusChangeCallback).toHaveBeenCalledWith(RecordingStatus.Paused, undefined);
-        });
-
-        it('should resume when paused', async () => {
-            await manager.toggleRecording();
-            manager.togglePauseResume(); // Pause
-            expect(manager.getStatus()).toBe(RecordingStatus.Paused);
-
-            manager.togglePauseResume(); // Resume
-
-            expect(manager.getStatus()).toBe(RecordingStatus.Recording);
-            expect(statusChangeCallback).toHaveBeenCalledWith(RecordingStatus.Recording, undefined);
-        });
-    });
-
-    describe('streaming chunks', () => {
-        it('should write chunks as segment files on desktop', async () => {
-            const { Platform } = jest.requireMock('obsidian') as {
-                Platform: { isMobile: boolean; isMobileApp: boolean };
-            };
-            Platform.isMobile = false;
-            Platform.isMobileApp = false;
-
-            const mockMediaRecorder = {
-                start: jest.fn(),
-                stop: jest.fn(),
-                pause: jest.fn(),
-                resume: jest.fn(),
-                ondataavailable: null as ((event: BlobEvent) => void) | null,
-                onerror: null as ((event: Event) => void) | null,
-                addEventListener: jest.fn((event: string, handler: () => void) => {
-                    if (event === 'stop') {
-                        handler();
-                    }
-                }),
-            };
-
-            (global as Record<string, unknown>).MediaRecorder = jest.fn(
-                () => mockMediaRecorder,
-            );
-            (global as Record<string, unknown>).MediaRecorder.isTypeSupported = jest
-                .fn()
-                .mockReturnValue(true);
-
-            const { getAudioStreams } = jest.requireMock('../../src/recording/AudioStreamHandler') as {
-                getAudioStreams: jest.Mock;
-            };
-            getAudioStreams.mockResolvedValue({
-                streams: [{
-                    getTracks: () => [{ stop: jest.fn() }],
-                }],
-                trackOrder: [],
-            });
-
-            (mockApp.vault.adapter.readBinary as jest.Mock).mockResolvedValue(
-                new Uint8Array([1, 2, 3]).buffer,
-            );
-
-            await manager.startRecording();
-
-            const chunk = new Blob([new Uint8Array([1, 2, 3])], {
-                type: 'audio/webm',
-            });
-            mockMediaRecorder.ondataavailable?.({ data: chunk } as BlobEvent);
-
-            await manager.stopRecording();
-
-            expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
-                expect.stringMatching(/-part1\.webm\.tmp$/),
-                expect.any(ArrayBuffer),
-            );
-        });
-
-        it('should flush mobile buffer when limit reached', async () => {
-            const { Platform } = jest.requireMock('obsidian') as {
-                Platform: { isMobile: boolean; isMobileApp: boolean };
-            };
-            Platform.isMobile = true;
-            Platform.isMobileApp = true;
-
-            const mockMediaRecorder = {
-                start: jest.fn(),
-                stop: jest.fn(),
-                pause: jest.fn(),
-                resume: jest.fn(),
-                ondataavailable: null as ((event: BlobEvent) => void) | null,
-                onerror: null as ((event: Event) => void) | null,
-                addEventListener: jest.fn((event: string, handler: () => void) => {
-                    if (event === 'stop') {
-                        handler();
-                    }
-                }),
-            };
-
-            (global as Record<string, unknown>).MediaRecorder = jest.fn(
-                () => mockMediaRecorder,
-            );
-            (global as Record<string, unknown>).MediaRecorder.isTypeSupported = jest
-                .fn()
-                .mockReturnValue(true);
-
-            const { getAudioStreams } = jest.requireMock('../../src/recording/AudioStreamHandler') as {
-                getAudioStreams: jest.Mock;
-            };
-            getAudioStreams.mockResolvedValue({
-                streams: [{
-                    getTracks: () => [{ stop: jest.fn() }],
-                }],
-                trackOrder: [],
-            });
-
-            await manager.startRecording();
-
-            const target = (manager as unknown as { chunkTargets: Array<{ bufferedBytes: number }> }).chunkTargets[0];
-            target.bufferedBytes = 50 * 1024 * 1024 - 1;
-
-            const chunk = new Blob([new Uint8Array([1])], {
-                type: 'audio/webm',
-            });
-            mockMediaRecorder.ondataavailable?.({ data: chunk } as BlobEvent);
-
-            await manager.stopRecording();
-
-            expect(mockApp.vault.createBinary).toHaveBeenCalled();
-        });
-
-        it('should write multiple chunks as separate segment files and clean up after finalization', async () => {
-            const { Platform } = jest.requireMock('obsidian') as {
-                Platform: { isMobile: boolean; isMobileApp: boolean };
-            };
-            Platform.isMobile = false;
-            Platform.isMobileApp = false;
-
-            const mockMediaRecorder = {
-                start: jest.fn(),
-                stop: jest.fn(),
-                pause: jest.fn(),
-                resume: jest.fn(),
-                ondataavailable: null as ((event: BlobEvent) => void) | null,
-                onerror: null as ((event: Event) => void) | null,
-                addEventListener: jest.fn((event: string, handler: () => void) => {
-                    if (event === 'stop') {
-                        handler();
-                    }
-                }),
-            };
-
-            (global as Record<string, unknown>).MediaRecorder = jest.fn(
-                () => mockMediaRecorder,
-            );
-            (global as Record<string, unknown>).MediaRecorder.isTypeSupported = jest
-                .fn()
-                .mockReturnValue(true);
-
-            const { getAudioStreams } = jest.requireMock('../../src/recording/AudioStreamHandler') as {
-                getAudioStreams: jest.Mock;
-            };
-            getAudioStreams.mockResolvedValue({
-                streams: [{
-                    getTracks: () => [{ stop: jest.fn() }],
-                }],
-                trackOrder: [],
-            });
-
-            (mockApp.vault.adapter.readBinary as jest.Mock).mockResolvedValue(
-                new Uint8Array([1, 2, 3]).buffer,
-            );
-
-            await manager.startRecording();
-
-            // Send 3 chunks
-            for (let i = 0; i < 3; i++) {
-                const chunk = new Blob([new Uint8Array([1, 2, 3])], {
-                    type: 'audio/webm',
-                });
-                mockMediaRecorder.ondataavailable?.({ data: chunk } as BlobEvent);
-            }
-            await Promise.resolve();
-
-            await manager.stopRecording();
-
-            // 3 segment files + 1 final file
-            expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
-                expect.stringMatching(/-part1\.webm\.tmp$/),
-                expect.any(ArrayBuffer),
-            );
-            expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
-                expect.stringMatching(/-part2\.webm\.tmp$/),
-                expect.any(ArrayBuffer),
-            );
-            expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
-                expect.stringMatching(/-part3\.webm\.tmp$/),
-                expect.any(ArrayBuffer),
-            );
-            // Segments cleaned up
-            expect(mockApp.vault.adapter.remove).toHaveBeenCalledTimes(3);
-        });
-
-        it('should save multi-track WAV via PCM capture and merge', async () => {
-            const { Platform } = jest.requireMock('obsidian') as {
-                Platform: { isMobile: boolean; isMobileApp: boolean };
-            };
-            Platform.isMobile = false;
-            Platform.isMobileApp = false;
-
-            mockSettings = {
-                ...DEFAULT_SETTINGS,
-                enableMultiTrack: true,
-                outputMode: 'single',
-                recordingFormat: 'wav',
-            };
-            manager = new RecordingManager(mockApp, mockSettings, statusChangeCallback);
-
-            (global as Record<string, unknown>).MediaRecorder = jest.fn();
-            (global as Record<string, unknown>).MediaRecorder.isTypeSupported = jest
-                .fn()
-                .mockImplementation((mime: string) => mime === 'audio/webm');
-
-            const { getAudioStreams } = jest.requireMock('../../src/recording/AudioStreamHandler') as {
-                getAudioStreams: jest.Mock;
-            };
-            getAudioStreams.mockResolvedValue({
-                streams: [
-                    { getTracks: () => [{ stop: jest.fn() }] },
-                    { getTracks: () => [{ stop: jest.fn() }] },
-                ],
-                trackOrder: [],
-            });
-
-            await manager.startRecording();
-
-            // Simulate PCM chunks for both tracks
-            const pcmData = new Int16Array([100, -100, 200, -200]).buffer;
-            capturedPcmChunkCallback?.(pcmData);
-
-            await Promise.resolve();
-            await manager.stopRecording();
-
-            // Should have created WAV file via mergeAudioTracks path
-            expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
-                expect.stringMatching(/multitrack-.*\.wav$/),
-                expect.any(ArrayBuffer),
-            );
-        });
-    });
-
-    describe('cleanup', () => {
-        it('should reset all internal state', () => {
-            manager.cleanup();
-
-            expect(manager.getStatus()).toBe(RecordingStatus.Idle);
-        });
-
-        it('should stop all streams', () => {
-            const { stopAllStreams } = jest.requireMock('../../src/recording/AudioStreamHandler') as {
-                stopAllStreams: jest.Mock;
-            };
-
-            manager.cleanup();
-
-            expect(stopAllStreams).toHaveBeenCalled();
-        });
-    });
-
-    describe('stopRecording error recovery', () => {
-        let mockStopTrack: jest.Mock;
-
-        beforeEach(() => {
-            mockStopTrack = jest.fn();
-
-            const mockMediaRecorder = {
-                start: jest.fn(),
-                stop: jest.fn(),
-                pause: jest.fn(),
-                resume: jest.fn(),
-                ondataavailable: null as ((event: BlobEvent) => void) | null,
-                onerror: null as ((event: Event) => void) | null,
-                addEventListener: jest.fn((event: string, handler: () => void) => {
-                    if (event === 'stop') {
-                        handler();
-                    }
-                }),
-            };
-
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- Mock global MediaRecorder
-            (global as Record<string, unknown>).MediaRecorder = jest.fn(() => mockMediaRecorder);
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- Mock isTypeSupported
-            (global as Record<string, unknown>).MediaRecorder.isTypeSupported = jest.fn().mockReturnValue(true);
-
-            const { getAudioStreams } = jest.requireMock('../../src/recording/AudioStreamHandler') as {
-                getAudioStreams: jest.Mock;
-            };
-            getAudioStreams.mockResolvedValue({
-                streams: [{
-                    getTracks: () => [{ stop: mockStopTrack }],
-                }],
-                trackOrder: [],
-            });
-        });
-
-        it('should reset status to Idle even when save fails', async () => {
-            // Start recording first
-            await manager.startRecording();
-            expect(manager.getStatus()).toBe(RecordingStatus.Recording);
-
-            // Mock vault to throw error during save
-            (mockApp.vault.adapter.rename as jest.Mock).mockRejectedValue(
-                new Error('Save failed'),
-            );
-
-            // Stop recording - should recover
-            await manager.stopRecording();
-
-            // Status should be Idle despite error
-            expect(manager.getStatus()).toBe(RecordingStatus.Idle);
-            expect(statusChangeCallback).toHaveBeenLastCalledWith(RecordingStatus.Idle, undefined);
-        });
-
-        it('should stop streams even when save fails', async () => {
-            const { stopAllStreams } = jest.requireMock('../../src/recording/AudioStreamHandler') as {
-                stopAllStreams: jest.Mock;
-            };
-
-            await manager.startRecording();
-
-            // Mock vault to throw error during save
-            (mockApp.vault.adapter.rename as jest.Mock).mockRejectedValue(
-                new Error('Save failed'),
-            );
-
-            await manager.stopRecording();
-
-            // Streams should still be stopped
-            expect(stopAllStreams).toHaveBeenCalled();
-        });
-
-        it('should clear all arrays after stop', async () => {
-            await manager.startRecording();
-            await manager.stopRecording();
-
-            // Internal state should be cleared - verify by starting a new recording
-            // If arrays weren't cleared, this would have stale data
-            expect(manager.getStatus()).toBe(RecordingStatus.Idle);
-        });
-    });
-
-    describe('startRecording error handling', () => {
-        it('should configure MediaRecorder with bitrate from settings', async () => {
-            mockSettings = {
-                ...DEFAULT_SETTINGS,
-                bitrate: 192000,
-            };
-            manager = new RecordingManager(mockApp, mockSettings, statusChangeCallback);
-
-            const mockMediaRecorder = {
-                start: jest.fn(),
-                stop: jest.fn(),
-                pause: jest.fn(),
-                resume: jest.fn(),
-                ondataavailable: null as ((event: BlobEvent) => void) | null,
-                onerror: null as ((event: Event) => void) | null,
-                addEventListener: jest.fn((event: string, handler: () => void) => {
-                    if (event === 'stop') {
-                        handler();
-                    }
-                }),
-            };
-
-            (global as Record<string, unknown>).MediaRecorder = jest.fn(
-                () => mockMediaRecorder,
-            );
-            (global as Record<string, unknown>).MediaRecorder.isTypeSupported = jest
-                .fn()
-                .mockReturnValue(true);
-
-            const { getAudioStreams } = jest.requireMock('../../src/recording/AudioStreamHandler') as {
-                getAudioStreams: jest.Mock;
-            };
-            getAudioStreams.mockResolvedValue({
-                streams: [{
-                    getTracks: () => [{ stop: jest.fn() }],
-                }],
-                trackOrder: [],
-            });
-
-            await manager.startRecording();
-
-            expect(global.MediaRecorder).toHaveBeenCalledWith(
-                expect.anything(),
-                expect.objectContaining({
-                    audioBitsPerSecond: 192000,
-                }),
-            );
-        });
-
-        it('should handle unsupported format', async () => {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- Mock global MediaRecorder
-            (global as Record<string, unknown>).MediaRecorder = {
-                isTypeSupported: jest.fn().mockReturnValue(false),
-            };
-
-            await manager.startRecording();
-
-            // Should remain idle on error
-            expect(manager.getStatus()).toBe(RecordingStatus.Idle);
-        });
-
-        it('should handle stream acquisition error', async () => {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- Mock global MediaRecorder
-            (global as Record<string, unknown>).MediaRecorder = {
-                isTypeSupported: jest.fn().mockReturnValue(true),
-            };
-
-            const { getAudioStreams } = jest.requireMock('../../src/recording/AudioStreamHandler') as {
-                getAudioStreams: jest.Mock;
-            };
-            getAudioStreams.mockRejectedValue(new Error('Permission denied'));
-
-            await manager.startRecording();
-
-            expect(manager.getStatus()).toBe(RecordingStatus.Idle);
-        });
-    });
-
-    describe('lifecycle transitions', () => {
-        beforeEach(() => {
-            const mockMediaRecorder = {
-                start: jest.fn(),
-                stop: jest.fn(),
-                pause: jest.fn(),
-                resume: jest.fn(),
-                ondataavailable: null as ((event: BlobEvent) => void) | null,
-                onerror: null as ((event: Event) => void) | null,
-                addEventListener: jest.fn((event: string, handler: () => void) => {
-                    if (event === 'stop') {
-                        handler();
-                    }
-                }),
-            };
-
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- Mock global MediaRecorder
-            (global as Record<string, unknown>).MediaRecorder = jest.fn(() => mockMediaRecorder);
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- Mock isTypeSupported
-            (global as Record<string, unknown>).MediaRecorder.isTypeSupported = jest.fn().mockReturnValue(true);
-
-            const { getAudioStreams } = jest.requireMock('../../src/recording/AudioStreamHandler') as {
-                getAudioStreams: jest.Mock;
-            };
-            getAudioStreams.mockResolvedValue({
-                streams: [{
-                    getTracks: () => [{ stop: jest.fn() }],
-                }],
-                trackOrder: [],
-            });
-        });
-
-        it('should follow full lifecycle: idle -> recording -> paused -> recording -> idle', async () => {
-            expect(manager.getStatus()).toBe(RecordingStatus.Idle);
-
-            // Start recording
-            await manager.toggleRecording();
-            expect(manager.getStatus()).toBe(RecordingStatus.Recording);
-
-            // Pause
-            manager.togglePauseResume();
-            expect(manager.getStatus()).toBe(RecordingStatus.Paused);
-
-            // Resume
-            manager.togglePauseResume();
-            expect(manager.getStatus()).toBe(RecordingStatus.Recording);
-
-            // Stop
-            await manager.toggleRecording();
-            expect(manager.getStatus()).toBe(RecordingStatus.Idle);
-        });
-
-        it('should call onStatusChange for each transition', async () => {
-            await manager.toggleRecording();
-            manager.togglePauseResume();
-            manager.togglePauseResume();
-            await manager.toggleRecording();
-
-            // Recording, Paused, Recording, Saving(0%), Saving(20%), Saving(100%), Idle
-            expect(statusChangeCallback).toHaveBeenNthCalledWith(1, RecordingStatus.Recording, undefined);
-            expect(statusChangeCallback).toHaveBeenNthCalledWith(2, RecordingStatus.Paused, undefined);
-            expect(statusChangeCallback).toHaveBeenNthCalledWith(3, RecordingStatus.Recording, undefined);
-            // Saving progress callbacks
-            expect(statusChangeCallback).toHaveBeenCalledWith(
-                RecordingStatus.Saving,
-                expect.objectContaining({ percent: 0 }),
-            );
-            // Final idle
-            expect(statusChangeCallback).toHaveBeenLastCalledWith(RecordingStatus.Idle, undefined);
-        });
-    });
-
-    describe('single mode output format handling', () => {
-        /**
-         * Verifies that single-file output in multi-track mode keeps compressed
-         * MediaRecorder format and does not force WAV conversion.
-         */
-        it('should save single-mode multi-track recording with configured extension', async () => {
-            const { Platform } = jest.requireMock('obsidian') as {
-                Platform: { isMobile: boolean; isMobileApp: boolean };
-            };
-            Platform.isMobile = false;
-            Platform.isMobileApp = false;
-
-            mockSettings = {
-                ...DEFAULT_SETTINGS,
-                enableMultiTrack: true,
-                outputMode: 'single',
-                recordingFormat: 'webm',
-            };
-            manager = new RecordingManager(mockApp, mockSettings, statusChangeCallback);
-
-            const mockMediaRecorders = [0, 1].map(() => ({
-                start: jest.fn(),
-                stop: jest.fn(),
-                pause: jest.fn(),
-                resume: jest.fn(),
-                ondataavailable: null as ((event: BlobEvent) => void) | null,
-                onerror: null as ((event: Event) => void) | null,
-                addEventListener: jest.fn((event: string, handler: () => void) => {
-                    if (event === 'stop') {
-                        handler();
-                    }
-                }),
-            }));
-            let recorderIndex = 0;
-
-            (global as Record<string, unknown>).MediaRecorder = jest.fn(() => {
-                const recorder = mockMediaRecorders[recorderIndex] ?? mockMediaRecorders[0];
-                recorderIndex += 1;
-                return recorder;
-            });
-            (global as Record<string, unknown>).MediaRecorder.isTypeSupported = jest
-                .fn()
-                .mockReturnValue(true);
-
-            const { getAudioStreams } = jest.requireMock('../../src/recording/AudioStreamHandler') as {
-                getAudioStreams: jest.Mock;
-            };
-            getAudioStreams.mockResolvedValue({
-                streams: [
-                    { getTracks: () => [{ stop: jest.fn() }] },
-                    { getTracks: () => [{ stop: jest.fn() }] },
-                ],
-                trackOrder: [],
-            });
-
-            (mockApp.vault.adapter.readBinary as jest.Mock).mockResolvedValue(
-                new Uint8Array([1, 2, 3]).buffer,
-            );
-
-            await manager.startRecording();
-
-            const chunk = new Blob([new Uint8Array([1, 2, 3])], {
-                type: 'audio/webm',
-            });
-            mockMediaRecorders.forEach((recorder) => {
-                recorder.ondataavailable?.({ data: chunk } as BlobEvent);
-            });
-
-            await Promise.resolve();
-            await manager.stopRecording();
-
-            expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
-                expect.stringMatching(/multitrack-.*\.webm$/),
-                expect.any(ArrayBuffer),
-            );
-            expect(mockApp.vault.createBinary).not.toHaveBeenCalledWith(
-                expect.stringMatching(/\.wav$/),
-                expect.any(ArrayBuffer),
-            );
-            expect(mockApp.vault.adapter.remove).toHaveBeenCalledWith(
-                expect.stringMatching(/-part\d+\.webm\.tmp$/),
-            );
-        });
-
-        it('should rollback merged output when cleanup of temporary partial files fails', async () => {
-            const { Notice } = jest.requireMock('obsidian') as {
-                Notice: jest.Mock;
-            };
-
-            const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => { });
-
-            const { Platform } = jest.requireMock('obsidian') as {
-                Platform: { isMobile: boolean; isMobileApp: boolean };
-            };
-            Platform.isMobile = false;
-            Platform.isMobileApp = false;
-
-            mockSettings = {
-                ...DEFAULT_SETTINGS,
-                enableMultiTrack: true,
-                outputMode: 'single',
-                recordingFormat: 'webm',
-            };
-            manager = new RecordingManager(mockApp, mockSettings, statusChangeCallback);
-
-            const mockMediaRecorders = [0, 1].map(() => ({
-                start: jest.fn(),
-                stop: jest.fn(),
-                pause: jest.fn(),
-                resume: jest.fn(),
-                ondataavailable: null as ((event: BlobEvent) => void) | null,
-                onerror: null as ((event: Event) => void) | null,
-                addEventListener: jest.fn((event: string, handler: () => void) => {
-                    if (event === 'stop') {
-                        handler();
-                    }
-                }),
-            }));
-            let recorderIndex = 0;
-
-            (global as Record<string, unknown>).MediaRecorder = jest.fn(() => {
-                const recorder = mockMediaRecorders[recorderIndex] ?? mockMediaRecorders[0];
-                recorderIndex += 1;
-                return recorder;
-            });
-            (global as Record<string, unknown>).MediaRecorder.isTypeSupported = jest
-                .fn()
-                .mockReturnValue(true);
-
-            const { getAudioStreams } = jest.requireMock('../../src/recording/AudioStreamHandler') as {
-                getAudioStreams: jest.Mock;
-            };
-            getAudioStreams.mockResolvedValue({
-                streams: [
-                    { getTracks: () => [{ stop: jest.fn() }] },
-                    { getTracks: () => [{ stop: jest.fn() }] },
-                ],
-                trackOrder: [],
-            });
-
-            (mockApp.vault.adapter.readBinary as jest.Mock).mockResolvedValue(
-                new Uint8Array([1, 2, 3]).buffer,
-            );
-            (mockApp.vault.adapter.remove as jest.Mock).mockImplementation(
-                async (path: string) => {
-                    if (path.includes('.tmp')) {
-                        throw new Error('cleanup failed');
-                    }
-                    return undefined;
-                },
-            );
-
-            await manager.startRecording();
-
-            const chunk = new Blob([new Uint8Array([1, 2, 3])], {
-                type: 'audio/webm',
-            });
-            mockMediaRecorders.forEach((recorder) => {
-                recorder.ondataavailable?.({ data: chunk } as BlobEvent);
-            });
-
-            await Promise.resolve();
-            await manager.stopRecording();
-
-            expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
-                expect.stringMatching(/multitrack-.*\.webm$/),
-                expect.any(ArrayBuffer),
-            );
-            expect(mockApp.vault.adapter.remove).toHaveBeenCalledWith(
-                expect.stringMatching(/multitrack-.*\.webm$/),
-            );
-            expect(Notice).toHaveBeenCalledWith(
-                expect.stringContaining('Error stopping recording:'),
-            );
-            expect(consoleWarnSpy).toHaveBeenCalledWith(
-                expect.stringContaining('[AudioRecorder]'),
-                expect.objectContaining({
-                    error: expect.objectContaining({
-                        message: 'cleanup failed',
-                    }),
-                }),
-            );
-
-            consoleWarnSpy.mockRestore();
-        });
-
-
-        /**
-         * Ensures that WAV output mode uses direct PCM capture on desktop
-         * and writes files with .wav extension assembled from PCM segments.
-         */
-        it('should convert to wav only when output format is wav', async () => {
-            mockSettings = {
-                ...DEFAULT_SETTINGS,
-                recordingFormat: 'wav',
-            };
-            manager = new RecordingManager(mockApp, mockSettings, statusChangeCallback);
-
-            (global as Record<string, unknown>).MediaRecorder = jest.fn();
-            (global as Record<string, unknown>).MediaRecorder.isTypeSupported = jest
-                .fn()
-                .mockImplementation((mime: string) => mime === 'audio/webm');
-
-            const { getAudioStreams } = jest.requireMock('../../src/recording/AudioStreamHandler') as {
-                getAudioStreams: jest.Mock;
-            };
-            getAudioStreams.mockResolvedValue({
-                streams: [{
-                    getTracks: () => [{ stop: jest.fn() }],
-                }],
-                trackOrder: [],
-            });
-
-            await manager.startRecording();
-
-            // Simulate PCM chunk via captured callback
-            const pcmData = new Int16Array([100, -100, 200, -200]).buffer;
-            capturedPcmChunkCallback?.(pcmData);
-
-            await Promise.resolve();
-            await manager.stopRecording();
-
-            expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
-                expect.stringMatching(/\.wav$/),
-                expect.any(ArrayBuffer),
-            );
-            expect(mockApp.vault.adapter.rename).not.toHaveBeenCalled();
-        });
-    });
-
-    describe('context-aware save location', () => {
-        it('should save near active markdown file when enabled without subfolder', async () => {
-            mockSettings = {
-                ...DEFAULT_SETTINGS,
-                saveNearActiveFile: true,
-                activeFileSubfolder: '',
-            };
-            manager = new RecordingManager(mockApp, mockSettings, statusChangeCallback);
-            (mockApp.workspace.getActiveFile as jest.Mock).mockReturnValue({
-                path: 'Meetings/2026/Meeting Note.md',
-            });
-
-            const mockMediaRecorder = {
-                start: jest.fn(),
-                stop: jest.fn(),
-                pause: jest.fn(),
-                resume: jest.fn(),
-                ondataavailable: null as ((event: BlobEvent) => void) | null,
-                onerror: null as ((event: Event) => void) | null,
-                addEventListener: jest.fn((event: string, handler: () => void) => {
-                    if (event === 'stop') {
-                        handler();
-                    }
-                }),
-            };
-
-            (global as Record<string, unknown>).MediaRecorder = jest.fn(() => mockMediaRecorder);
-            (global as Record<string, unknown>).MediaRecorder.isTypeSupported = jest.fn().mockReturnValue(true);
-
-            const { getAudioStreams } = jest.requireMock('../../src/recording/AudioStreamHandler') as {
-                getAudioStreams: jest.Mock;
-            };
-            getAudioStreams.mockResolvedValue({
-                streams: [{ getTracks: () => [{ stop: jest.fn() }] }],
-                trackOrder: [],
-            });
-
-            await manager.startRecording();
-
-            const chunk = new Blob([new Uint8Array([1, 2, 3])], { type: 'audio/webm' });
-            mockMediaRecorder.ondataavailable?.({ data: chunk } as BlobEvent);
-            await Promise.resolve();
-
-            await manager.stopRecording();
-
-            expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
-                expect.stringMatching(/^Meetings\/2026\/recording-Track1-.*-part1\.webm\.tmp$/),
-                expect.any(ArrayBuffer),
-            );
-        });
-
-        it('should create active file subfolder and save recording there', async () => {
-            mockSettings = {
-                ...DEFAULT_SETTINGS,
-                saveNearActiveFile: true,
-                activeFileSubfolder: 'Audio',
-            };
-            manager = new RecordingManager(mockApp, mockSettings, statusChangeCallback);
-            (mockApp.workspace.getActiveFile as jest.Mock).mockReturnValue({
-                path: 'Meetings/2026/Meeting Note.md',
-            });
-
-            const mockMediaRecorder = {
-                start: jest.fn(),
-                stop: jest.fn(),
-                pause: jest.fn(),
-                resume: jest.fn(),
-                ondataavailable: null as ((event: BlobEvent) => void) | null,
-                onerror: null as ((event: Event) => void) | null,
-                addEventListener: jest.fn((event: string, handler: () => void) => {
-                    if (event === 'stop') {
-                        handler();
-                    }
-                }),
-            };
-
-            (global as Record<string, unknown>).MediaRecorder = jest.fn(() => mockMediaRecorder);
-            (global as Record<string, unknown>).MediaRecorder.isTypeSupported = jest.fn().mockReturnValue(true);
-
-            const { getAudioStreams } = jest.requireMock('../../src/recording/AudioStreamHandler') as {
-                getAudioStreams: jest.Mock;
-            };
-            getAudioStreams.mockResolvedValue({
-                streams: [{ getTracks: () => [{ stop: jest.fn() }] }],
-                trackOrder: [],
-            });
-
-            await manager.startRecording();
-
-            const chunk = new Blob([new Uint8Array([1, 2, 3])], { type: 'audio/webm' });
-            mockMediaRecorder.ondataavailable?.({ data: chunk } as BlobEvent);
-            await Promise.resolve();
-
-            await manager.stopRecording();
-
-            expect(mockApp.vault.createFolder).toHaveBeenCalledWith('Meetings/2026/Audio');
-            expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
-                expect.stringMatching(/^Meetings\/2026\/Audio\/recording-Track1-.*-part1\.webm\.tmp$/),
-                expect.any(ArrayBuffer),
-            );
-        });
-
-        it('should fallback to global save folder when near-active mode is disabled', async () => {
-            mockSettings = {
-                ...DEFAULT_SETTINGS,
-                saveFolder: 'Recordings',
-                saveNearActiveFile: false,
-                activeFileSubfolder: 'Audio',
-            };
-            manager = new RecordingManager(mockApp, mockSettings, statusChangeCallback);
-            (mockApp.workspace.getActiveFile as jest.Mock).mockReturnValue({
-                path: 'Meetings/2026/Meeting Note.md',
-            });
-
-            const mockMediaRecorder = {
-                start: jest.fn(),
-                stop: jest.fn(),
-                pause: jest.fn(),
-                resume: jest.fn(),
-                ondataavailable: null as ((event: BlobEvent) => void) | null,
-                onerror: null as ((event: Event) => void) | null,
-                addEventListener: jest.fn((event: string, handler: () => void) => {
-                    if (event === 'stop') {
-                        handler();
-                    }
-                }),
-            };
-
-            (global as Record<string, unknown>).MediaRecorder = jest.fn(() => mockMediaRecorder);
-            (global as Record<string, unknown>).MediaRecorder.isTypeSupported = jest.fn().mockReturnValue(true);
-
-            const { getAudioStreams } = jest.requireMock('../../src/recording/AudioStreamHandler') as {
-                getAudioStreams: jest.Mock;
-            };
-            getAudioStreams.mockResolvedValue({
-                streams: [{ getTracks: () => [{ stop: jest.fn() }] }],
-                trackOrder: [],
-            });
-
-            await manager.startRecording();
-
-            const chunk = new Blob([new Uint8Array([1, 2, 3])], { type: 'audio/webm' });
-            mockMediaRecorder.ondataavailable?.({ data: chunk } as BlobEvent);
-            await Promise.resolve();
-
-            await manager.stopRecording();
-
-            expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
-                expect.stringMatching(/^Recordings\/recording-Track1-.*-part1\.webm\.tmp$/),
-                expect.any(ArrayBuffer),
-            );
-        });
-    });
-
-    describe('insertFileLinks uses basename only', () => {
-        it('should insert only filename without directory path in wikilinks', async () => {
-            const mockReplaceSelection = jest.fn();
-            (mockApp.workspace.getActiveViewOfType as jest.Mock).mockReturnValue({
-                editor: { replaceSelection: mockReplaceSelection },
-            });
-
-            const mockMediaRecorder = {
-                start: jest.fn(),
-                stop: jest.fn(),
-                pause: jest.fn(),
-                resume: jest.fn(),
-                ondataavailable: null as ((event: BlobEvent) => void) | null,
-                onerror: null as ((event: Event) => void) | null,
-                addEventListener: jest.fn((event: string, handler: () => void) => {
-                    if (event === 'stop') {
-                        handler();
-                    }
-                }),
-            };
-
-            (global as Record<string, unknown>).MediaRecorder = jest.fn(() => mockMediaRecorder);
-            (global as Record<string, unknown>).MediaRecorder.isTypeSupported = jest.fn().mockReturnValue(true);
-
-            const { getAudioStreams } = jest.requireMock('../../src/recording/AudioStreamHandler') as {
-                getAudioStreams: jest.Mock;
-            };
-            getAudioStreams.mockResolvedValue({
-                streams: [{ getTracks: () => [{ stop: jest.fn() }] }],
-                trackOrder: [],
-            });
-
-            (mockApp.vault.adapter.readBinary as jest.Mock).mockResolvedValue(
-                new Uint8Array([1, 2, 3]).buffer,
-            );
-
-            await manager.startRecording();
-
-            const chunk = new Blob([new Uint8Array([1, 2, 3])], { type: 'audio/webm' });
-            mockMediaRecorder.ondataavailable?.({ data: chunk } as BlobEvent);
-            await Promise.resolve();
-
-            await manager.stopRecording();
-
-            expect(mockReplaceSelection).toHaveBeenCalled();
-            const insertedText = mockReplaceSelection.mock.calls[0][0] as string;
-            expect(insertedText).not.toContain('/');
-            expect(insertedText).toMatch(/^!\[\[recording-.*\]\]$/);
-        });
-
-        it('should use basename when file is saved in a nested directory', async () => {
-            mockSettings = {
-                ...DEFAULT_SETTINGS,
-                saveNearActiveFile: true,
-                activeFileSubfolder: 'Audio',
-            };
-            manager = new RecordingManager(mockApp, mockSettings, statusChangeCallback);
-            (mockApp.workspace.getActiveFile as jest.Mock).mockReturnValue({
-                path: 'Projects/Notes/Daily.md',
-            });
-
-            const mockReplaceSelection = jest.fn();
-            (mockApp.workspace.getActiveViewOfType as jest.Mock).mockReturnValue({
-                editor: { replaceSelection: mockReplaceSelection },
-            });
-
-            const mockMediaRecorder = {
-                start: jest.fn(),
-                stop: jest.fn(),
-                pause: jest.fn(),
-                resume: jest.fn(),
-                ondataavailable: null as ((event: BlobEvent) => void) | null,
-                onerror: null as ((event: Event) => void) | null,
-                addEventListener: jest.fn((event: string, handler: () => void) => {
-                    if (event === 'stop') {
-                        handler();
-                    }
-                }),
-            };
-
-            (global as Record<string, unknown>).MediaRecorder = jest.fn(() => mockMediaRecorder);
-            (global as Record<string, unknown>).MediaRecorder.isTypeSupported = jest.fn().mockReturnValue(true);
-
-            const { getAudioStreams } = jest.requireMock('../../src/recording/AudioStreamHandler') as {
-                getAudioStreams: jest.Mock;
-            };
-            getAudioStreams.mockResolvedValue({
-                streams: [{ getTracks: () => [{ stop: jest.fn() }] }],
-                trackOrder: [],
-            });
-
-            (mockApp.vault.adapter.readBinary as jest.Mock).mockResolvedValue(
-                new Uint8Array([1, 2, 3]).buffer,
-            );
-
-            await manager.startRecording();
-
-            const chunk = new Blob([new Uint8Array([1, 2, 3])], { type: 'audio/webm' });
-            mockMediaRecorder.ondataavailable?.({ data: chunk } as BlobEvent);
-            await Promise.resolve();
-
-            await manager.stopRecording();
-
-            expect(mockReplaceSelection).toHaveBeenCalled();
-            const insertedText = mockReplaceSelection.mock.calls[0][0] as string;
-            expect(insertedText).not.toContain('Projects/');
-            expect(insertedText).not.toContain('Audio/');
-            expect(insertedText).toMatch(/^!\[\[recording-.*\]\]$/);
-        });
-    });
-
+	let manager: RecordingManager;
+	let mockApp: App;
+	let mockSettings: AudioRecorderSettings;
+	let statusChangeCallback: jest.Mock;
+	let consoleErrorSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		// Reset mocks
+		jest.clearAllMocks();
+		consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+		// Create mock App
+		mockApp = {
+			vault: {
+				adapter: {
+					exists: jest.fn().mockResolvedValue(false),
+					rename: jest.fn().mockResolvedValue(undefined),
+					readBinary: jest.fn().mockResolvedValue(new ArrayBuffer(0)),
+					writeBinary: jest.fn().mockResolvedValue(undefined),
+					remove: jest.fn().mockResolvedValue(undefined),
+				},
+				createBinary: jest.fn().mockResolvedValue(undefined),
+				createFolder: jest.fn().mockResolvedValue(undefined),
+			},
+			workspace: {
+				getActiveViewOfType: jest.fn().mockReturnValue(null),
+				getActiveFile: jest.fn().mockReturnValue(null),
+			},
+		} as unknown as App;
+
+		// Use default settings
+		mockSettings = { ...DEFAULT_SETTINGS };
+
+		// Status change callback
+		statusChangeCallback = jest.fn();
+
+		// Create manager instance
+		manager = new RecordingManager(
+			mockApp,
+			mockSettings,
+			statusChangeCallback,
+		);
+	});
+
+	afterEach(() => {
+		consoleErrorSpy.mockRestore();
+	});
+
+	describe('constructor', () => {
+		it('should initialize with idle status', () => {
+			expect(manager.getStatus()).toBe(RecordingStatus.Idle);
+		});
+
+		it('should store the status change callback', () => {
+			expect(statusChangeCallback).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('getStatus', () => {
+		it('should return Idle initially', () => {
+			expect(manager.getStatus()).toBe(RecordingStatus.Idle);
+		});
+	});
+
+	describe('updateSettings', () => {
+		it('should update settings reference', () => {
+			const newSettings: AudioRecorderSettings = {
+				...DEFAULT_SETTINGS,
+				filePrefix: 'new-prefix',
+			};
+
+			manager.updateSettings(newSettings);
+
+			// Settings are private, but we can verify through behavior
+			expect(manager.getStatus()).toBe(RecordingStatus.Idle);
+		});
+	});
+
+	describe('toggleRecording', () => {
+		beforeEach(() => {
+			// Mock MediaRecorder
+			const mockMediaRecorder = {
+				start: jest.fn(),
+				stop: jest.fn(),
+				pause: jest.fn(),
+				resume: jest.fn(),
+				ondataavailable: null as ((event: BlobEvent) => void) | null,
+				onerror: null as ((event: Event) => void) | null,
+				addEventListener: jest.fn(
+					(event: string, handler: () => void) => {
+						if (event === 'stop') {
+							handler();
+						}
+					},
+				),
+			};
+
+			(global as Record<string, unknown>).MediaRecorder = jest.fn(
+				() => mockMediaRecorder,
+			);
+
+			(global as Record<string, unknown>).MediaRecorder.isTypeSupported =
+				jest.fn().mockReturnValue(true);
+
+			// Mock getAudioStreams
+			const { getAudioStreams } = jest.requireMock(
+				'../../src/recording/AudioStreamHandler',
+			);
+			getAudioStreams.mockResolvedValue({
+				streams: [
+					{
+						getTracks: () => [{ stop: jest.fn() }],
+					},
+				],
+				trackOrder: [],
+			});
+		});
+
+		it('should start recording when idle', async () => {
+			expect(manager.getStatus()).toBe(RecordingStatus.Idle);
+
+			await manager.toggleRecording();
+
+			expect(manager.getStatus()).toBe(RecordingStatus.Recording);
+			expect(statusChangeCallback).toHaveBeenCalledWith(
+				RecordingStatus.Recording,
+				undefined,
+			);
+		});
+
+		it('should stop recording when recording', async () => {
+			// First start
+			await manager.toggleRecording();
+			expect(manager.getStatus()).toBe(RecordingStatus.Recording);
+
+			// Then stop
+			await manager.toggleRecording();
+			expect(manager.getStatus()).toBe(RecordingStatus.Idle);
+		});
+	});
+
+	describe('togglePauseResume', () => {
+		let mockMediaRecorder: {
+			start: jest.Mock;
+			stop: jest.Mock;
+			pause: jest.Mock;
+			resume: jest.Mock;
+			ondataavailable: ((event: BlobEvent) => void) | null;
+			onerror: ((event: Event) => void) | null;
+			addEventListener: jest.Mock;
+		};
+
+		beforeEach(() => {
+			mockMediaRecorder = {
+				start: jest.fn(),
+				stop: jest.fn(),
+				pause: jest.fn(),
+				resume: jest.fn(),
+				ondataavailable: null,
+				onerror: null,
+				addEventListener: jest.fn(
+					(event: string, handler: () => void) => {
+						if (event === 'stop') {
+							handler();
+						}
+					},
+				),
+			};
+
+			(global as Record<string, unknown>).MediaRecorder = jest.fn(
+				() => mockMediaRecorder,
+			);
+
+			(global as Record<string, unknown>).MediaRecorder.isTypeSupported =
+				jest.fn().mockReturnValue(true);
+
+			const { getAudioStreams } = jest.requireMock(
+				'../../src/recording/AudioStreamHandler',
+			);
+			getAudioStreams.mockResolvedValue({
+				streams: [
+					{
+						getTracks: () => [{ stop: jest.fn() }],
+					},
+				],
+				trackOrder: [],
+			});
+		});
+
+		it('should do nothing when idle', () => {
+			manager.togglePauseResume();
+
+			expect(manager.getStatus()).toBe(RecordingStatus.Idle);
+			expect(mockMediaRecorder.pause).not.toHaveBeenCalled();
+		});
+
+		it('should pause when recording', async () => {
+			await manager.toggleRecording();
+			expect(manager.getStatus()).toBe(RecordingStatus.Recording);
+
+			manager.togglePauseResume();
+
+			expect(manager.getStatus()).toBe(RecordingStatus.Paused);
+			expect(statusChangeCallback).toHaveBeenCalledWith(
+				RecordingStatus.Paused,
+				undefined,
+			);
+		});
+
+		it('should resume when paused', async () => {
+			await manager.toggleRecording();
+			manager.togglePauseResume(); // Pause
+			expect(manager.getStatus()).toBe(RecordingStatus.Paused);
+
+			manager.togglePauseResume(); // Resume
+
+			expect(manager.getStatus()).toBe(RecordingStatus.Recording);
+			expect(statusChangeCallback).toHaveBeenCalledWith(
+				RecordingStatus.Recording,
+				undefined,
+			);
+		});
+	});
+
+	describe('streaming chunks', () => {
+		it('should write chunks as segment files on desktop', async () => {
+			const { Platform } = jest.requireMock('obsidian');
+			Platform.isMobile = false;
+			Platform.isMobileApp = false;
+
+			const mockMediaRecorder = {
+				start: jest.fn(),
+				stop: jest.fn(),
+				pause: jest.fn(),
+				resume: jest.fn(),
+				ondataavailable: null as ((event: BlobEvent) => void) | null,
+				onerror: null as ((event: Event) => void) | null,
+				addEventListener: jest.fn(
+					(event: string, handler: () => void) => {
+						if (event === 'stop') {
+							handler();
+						}
+					},
+				),
+			};
+
+			(global as Record<string, unknown>).MediaRecorder = jest.fn(
+				() => mockMediaRecorder,
+			);
+			(global as Record<string, unknown>).MediaRecorder.isTypeSupported =
+				jest.fn().mockReturnValue(true);
+
+			const { getAudioStreams } = jest.requireMock(
+				'../../src/recording/AudioStreamHandler',
+			);
+			getAudioStreams.mockResolvedValue({
+				streams: [
+					{
+						getTracks: () => [{ stop: jest.fn() }],
+					},
+				],
+				trackOrder: [],
+			});
+
+			(mockApp.vault.adapter.readBinary as jest.Mock).mockResolvedValue(
+				new Uint8Array([1, 2, 3]).buffer,
+			);
+
+			await manager.startRecording();
+
+			const chunk = new Blob([new Uint8Array([1, 2, 3])], {
+				type: 'audio/webm',
+			});
+			mockMediaRecorder.ondataavailable?.({ data: chunk } as BlobEvent);
+
+			await manager.stopRecording();
+
+			expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
+				expect.stringMatching(/-part1\.webm\.tmp$/),
+				expect.any(ArrayBuffer),
+			);
+		});
+
+		it('should flush mobile buffer when limit reached', async () => {
+			const { Platform } = jest.requireMock('obsidian');
+			Platform.isMobile = true;
+			Platform.isMobileApp = true;
+
+			const mockMediaRecorder = {
+				start: jest.fn(),
+				stop: jest.fn(),
+				pause: jest.fn(),
+				resume: jest.fn(),
+				ondataavailable: null as ((event: BlobEvent) => void) | null,
+				onerror: null as ((event: Event) => void) | null,
+				addEventListener: jest.fn(
+					(event: string, handler: () => void) => {
+						if (event === 'stop') {
+							handler();
+						}
+					},
+				),
+			};
+
+			(global as Record<string, unknown>).MediaRecorder = jest.fn(
+				() => mockMediaRecorder,
+			);
+			(global as Record<string, unknown>).MediaRecorder.isTypeSupported =
+				jest.fn().mockReturnValue(true);
+
+			const { getAudioStreams } = jest.requireMock(
+				'../../src/recording/AudioStreamHandler',
+			);
+			getAudioStreams.mockResolvedValue({
+				streams: [
+					{
+						getTracks: () => [{ stop: jest.fn() }],
+					},
+				],
+				trackOrder: [],
+			});
+
+			await manager.startRecording();
+
+			const target = (
+				manager as unknown as {
+					chunkTargets: Array<{ bufferedBytes: number }>;
+				}
+			).chunkTargets[0];
+			target.bufferedBytes = 50 * 1024 * 1024 - 1;
+
+			const chunk = new Blob([new Uint8Array([1])], {
+				type: 'audio/webm',
+			});
+			mockMediaRecorder.ondataavailable?.({ data: chunk } as BlobEvent);
+
+			await manager.stopRecording();
+
+			expect(mockApp.vault.createBinary).toHaveBeenCalled();
+		});
+
+		it('should write multiple chunks as separate segment files and clean up after finalization', async () => {
+			const { Platform } = jest.requireMock('obsidian');
+			Platform.isMobile = false;
+			Platform.isMobileApp = false;
+
+			const mockMediaRecorder = {
+				start: jest.fn(),
+				stop: jest.fn(),
+				pause: jest.fn(),
+				resume: jest.fn(),
+				ondataavailable: null as ((event: BlobEvent) => void) | null,
+				onerror: null as ((event: Event) => void) | null,
+				addEventListener: jest.fn(
+					(event: string, handler: () => void) => {
+						if (event === 'stop') {
+							handler();
+						}
+					},
+				),
+			};
+
+			(global as Record<string, unknown>).MediaRecorder = jest.fn(
+				() => mockMediaRecorder,
+			);
+			(global as Record<string, unknown>).MediaRecorder.isTypeSupported =
+				jest.fn().mockReturnValue(true);
+
+			const { getAudioStreams } = jest.requireMock(
+				'../../src/recording/AudioStreamHandler',
+			);
+			getAudioStreams.mockResolvedValue({
+				streams: [
+					{
+						getTracks: () => [{ stop: jest.fn() }],
+					},
+				],
+				trackOrder: [],
+			});
+
+			(mockApp.vault.adapter.readBinary as jest.Mock).mockResolvedValue(
+				new Uint8Array([1, 2, 3]).buffer,
+			);
+
+			await manager.startRecording();
+
+			// Send 3 chunks
+			for (let i = 0; i < 3; i++) {
+				const chunk = new Blob([new Uint8Array([1, 2, 3])], {
+					type: 'audio/webm',
+				});
+				mockMediaRecorder.ondataavailable?.({
+					data: chunk,
+				} as BlobEvent);
+			}
+			await Promise.resolve();
+
+			await manager.stopRecording();
+
+			// 3 segment files + 1 final file
+			expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
+				expect.stringMatching(/-part1\.webm\.tmp$/),
+				expect.any(ArrayBuffer),
+			);
+			expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
+				expect.stringMatching(/-part2\.webm\.tmp$/),
+				expect.any(ArrayBuffer),
+			);
+			expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
+				expect.stringMatching(/-part3\.webm\.tmp$/),
+				expect.any(ArrayBuffer),
+			);
+			// Segments cleaned up
+			expect(mockApp.vault.adapter.remove).toHaveBeenCalledTimes(3);
+		});
+
+		it('should save multi-track WAV via PCM capture and merge', async () => {
+			const { Platform } = jest.requireMock('obsidian');
+			Platform.isMobile = false;
+			Platform.isMobileApp = false;
+
+			mockSettings = {
+				...DEFAULT_SETTINGS,
+				enableMultiTrack: true,
+				outputMode: 'single',
+				recordingFormat: 'wav',
+			};
+			manager = new RecordingManager(
+				mockApp,
+				mockSettings,
+				statusChangeCallback,
+			);
+
+			(global as Record<string, unknown>).MediaRecorder = jest.fn();
+			(global as Record<string, unknown>).MediaRecorder.isTypeSupported =
+				jest
+					.fn()
+					.mockImplementation(
+						(mime: string) => mime === 'audio/webm',
+					);
+
+			const { getAudioStreams } = jest.requireMock(
+				'../../src/recording/AudioStreamHandler',
+			);
+			getAudioStreams.mockResolvedValue({
+				streams: [
+					{ getTracks: () => [{ stop: jest.fn() }] },
+					{ getTracks: () => [{ stop: jest.fn() }] },
+				],
+				trackOrder: [],
+			});
+
+			await manager.startRecording();
+
+			// Simulate PCM chunks for both tracks
+			const pcmData = new Int16Array([100, -100, 200, -200]).buffer;
+			capturedPcmChunkCallback?.(pcmData);
+
+			await Promise.resolve();
+			await manager.stopRecording();
+
+			// Should have created WAV file via mergeAudioTracks path
+			expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
+				expect.stringMatching(/multitrack-.*\.wav$/),
+				expect.any(ArrayBuffer),
+			);
+		});
+	});
+
+	describe('cleanup', () => {
+		it('should reset all internal state', () => {
+			manager.cleanup();
+
+			expect(manager.getStatus()).toBe(RecordingStatus.Idle);
+		});
+
+		it('should stop all streams', () => {
+			const { stopAllStreams } = jest.requireMock(
+				'../../src/recording/AudioStreamHandler',
+			);
+
+			manager.cleanup();
+
+			expect(stopAllStreams).toHaveBeenCalled();
+		});
+	});
+
+	describe('stopRecording error recovery', () => {
+		let mockStopTrack: jest.Mock;
+
+		beforeEach(() => {
+			mockStopTrack = jest.fn();
+
+			const mockMediaRecorder = {
+				start: jest.fn(),
+				stop: jest.fn(),
+				pause: jest.fn(),
+				resume: jest.fn(),
+				ondataavailable: null as ((event: BlobEvent) => void) | null,
+				onerror: null as ((event: Event) => void) | null,
+				addEventListener: jest.fn(
+					(event: string, handler: () => void) => {
+						if (event === 'stop') {
+							handler();
+						}
+					},
+				),
+			};
+
+			(global as Record<string, unknown>).MediaRecorder = jest.fn(
+				() => mockMediaRecorder,
+			);
+
+			(global as Record<string, unknown>).MediaRecorder.isTypeSupported =
+				jest.fn().mockReturnValue(true);
+
+			const { getAudioStreams } = jest.requireMock(
+				'../../src/recording/AudioStreamHandler',
+			);
+			getAudioStreams.mockResolvedValue({
+				streams: [
+					{
+						getTracks: () => [{ stop: mockStopTrack }],
+					},
+				],
+				trackOrder: [],
+			});
+		});
+
+		it('should reset status to Idle even when save fails', async () => {
+			// Start recording first
+			await manager.startRecording();
+			expect(manager.getStatus()).toBe(RecordingStatus.Recording);
+
+			// Mock vault to throw error during save
+			(mockApp.vault.adapter.rename as jest.Mock).mockRejectedValue(
+				new Error('Save failed'),
+			);
+
+			// Stop recording - should recover
+			await manager.stopRecording();
+
+			// Status should be Idle despite error
+			expect(manager.getStatus()).toBe(RecordingStatus.Idle);
+			expect(statusChangeCallback).toHaveBeenLastCalledWith(
+				RecordingStatus.Idle,
+				undefined,
+			);
+		});
+
+		it('should stop streams even when save fails', async () => {
+			const { stopAllStreams } = jest.requireMock(
+				'../../src/recording/AudioStreamHandler',
+			);
+
+			await manager.startRecording();
+
+			// Mock vault to throw error during save
+			(mockApp.vault.adapter.rename as jest.Mock).mockRejectedValue(
+				new Error('Save failed'),
+			);
+
+			await manager.stopRecording();
+
+			// Streams should still be stopped
+			expect(stopAllStreams).toHaveBeenCalled();
+		});
+
+		it('should clear all arrays after stop', async () => {
+			await manager.startRecording();
+			await manager.stopRecording();
+
+			// Internal state should be cleared - verify by starting a new recording
+			// If arrays weren't cleared, this would have stale data
+			expect(manager.getStatus()).toBe(RecordingStatus.Idle);
+		});
+	});
+
+	describe('startRecording error handling', () => {
+		it('should configure MediaRecorder with bitrate from settings', async () => {
+			mockSettings = {
+				...DEFAULT_SETTINGS,
+				bitrate: 192000,
+			};
+			manager = new RecordingManager(
+				mockApp,
+				mockSettings,
+				statusChangeCallback,
+			);
+
+			const mockMediaRecorder = {
+				start: jest.fn(),
+				stop: jest.fn(),
+				pause: jest.fn(),
+				resume: jest.fn(),
+				ondataavailable: null as ((event: BlobEvent) => void) | null,
+				onerror: null as ((event: Event) => void) | null,
+				addEventListener: jest.fn(
+					(event: string, handler: () => void) => {
+						if (event === 'stop') {
+							handler();
+						}
+					},
+				),
+			};
+
+			(global as Record<string, unknown>).MediaRecorder = jest.fn(
+				() => mockMediaRecorder,
+			);
+			(global as Record<string, unknown>).MediaRecorder.isTypeSupported =
+				jest.fn().mockReturnValue(true);
+
+			const { getAudioStreams } = jest.requireMock(
+				'../../src/recording/AudioStreamHandler',
+			);
+			getAudioStreams.mockResolvedValue({
+				streams: [
+					{
+						getTracks: () => [{ stop: jest.fn() }],
+					},
+				],
+				trackOrder: [],
+			});
+
+			await manager.startRecording();
+
+			expect(global.MediaRecorder).toHaveBeenCalledWith(
+				expect.anything(),
+				expect.objectContaining({
+					audioBitsPerSecond: 192000,
+				}),
+			);
+		});
+
+		it('should handle unsupported format', async () => {
+			(global as Record<string, unknown>).MediaRecorder = {
+				isTypeSupported: jest.fn().mockReturnValue(false),
+			};
+
+			await manager.startRecording();
+
+			// Should remain idle on error
+			expect(manager.getStatus()).toBe(RecordingStatus.Idle);
+		});
+
+		it('should handle stream acquisition error', async () => {
+			(global as Record<string, unknown>).MediaRecorder = {
+				isTypeSupported: jest.fn().mockReturnValue(true),
+			};
+
+			const { getAudioStreams } = jest.requireMock(
+				'../../src/recording/AudioStreamHandler',
+			);
+			getAudioStreams.mockRejectedValue(new Error('Permission denied'));
+
+			await manager.startRecording();
+
+			expect(manager.getStatus()).toBe(RecordingStatus.Idle);
+		});
+	});
+
+	describe('lifecycle transitions', () => {
+		beforeEach(() => {
+			const mockMediaRecorder = {
+				start: jest.fn(),
+				stop: jest.fn(),
+				pause: jest.fn(),
+				resume: jest.fn(),
+				ondataavailable: null as ((event: BlobEvent) => void) | null,
+				onerror: null as ((event: Event) => void) | null,
+				addEventListener: jest.fn(
+					(event: string, handler: () => void) => {
+						if (event === 'stop') {
+							handler();
+						}
+					},
+				),
+			};
+
+			(global as Record<string, unknown>).MediaRecorder = jest.fn(
+				() => mockMediaRecorder,
+			);
+
+			(global as Record<string, unknown>).MediaRecorder.isTypeSupported =
+				jest.fn().mockReturnValue(true);
+
+			const { getAudioStreams } = jest.requireMock(
+				'../../src/recording/AudioStreamHandler',
+			);
+			getAudioStreams.mockResolvedValue({
+				streams: [
+					{
+						getTracks: () => [{ stop: jest.fn() }],
+					},
+				],
+				trackOrder: [],
+			});
+		});
+
+		it('should follow full lifecycle: idle -> recording -> paused -> recording -> idle', async () => {
+			expect(manager.getStatus()).toBe(RecordingStatus.Idle);
+
+			// Start recording
+			await manager.toggleRecording();
+			expect(manager.getStatus()).toBe(RecordingStatus.Recording);
+
+			// Pause
+			manager.togglePauseResume();
+			expect(manager.getStatus()).toBe(RecordingStatus.Paused);
+
+			// Resume
+			manager.togglePauseResume();
+			expect(manager.getStatus()).toBe(RecordingStatus.Recording);
+
+			// Stop
+			await manager.toggleRecording();
+			expect(manager.getStatus()).toBe(RecordingStatus.Idle);
+		});
+
+		it('should call onStatusChange for each transition', async () => {
+			await manager.toggleRecording();
+			manager.togglePauseResume();
+			manager.togglePauseResume();
+			await manager.toggleRecording();
+
+			// Recording, Paused, Recording, Saving(0%), Saving(20%), Saving(100%), Idle
+			expect(statusChangeCallback).toHaveBeenNthCalledWith(
+				1,
+				RecordingStatus.Recording,
+				undefined,
+			);
+			expect(statusChangeCallback).toHaveBeenNthCalledWith(
+				2,
+				RecordingStatus.Paused,
+				undefined,
+			);
+			expect(statusChangeCallback).toHaveBeenNthCalledWith(
+				3,
+				RecordingStatus.Recording,
+				undefined,
+			);
+			// Saving progress callbacks
+			expect(statusChangeCallback).toHaveBeenCalledWith(
+				RecordingStatus.Saving,
+				expect.objectContaining({ percent: 0 }),
+			);
+			// Final idle
+			expect(statusChangeCallback).toHaveBeenLastCalledWith(
+				RecordingStatus.Idle,
+				undefined,
+			);
+		});
+	});
+
+	describe('single mode output format handling', () => {
+		/**
+		 * Verifies that single-file output in multi-track mode keeps compressed
+		 * MediaRecorder format and does not force WAV conversion.
+		 */
+		it('should save single-mode multi-track recording with configured extension', async () => {
+			const { Platform } = jest.requireMock('obsidian');
+			Platform.isMobile = false;
+			Platform.isMobileApp = false;
+
+			mockSettings = {
+				...DEFAULT_SETTINGS,
+				enableMultiTrack: true,
+				outputMode: 'single',
+				recordingFormat: 'webm',
+			};
+			manager = new RecordingManager(
+				mockApp,
+				mockSettings,
+				statusChangeCallback,
+			);
+
+			const mockMediaRecorders = [0, 1].map(() => ({
+				start: jest.fn(),
+				stop: jest.fn(),
+				pause: jest.fn(),
+				resume: jest.fn(),
+				ondataavailable: null as ((event: BlobEvent) => void) | null,
+				onerror: null as ((event: Event) => void) | null,
+				addEventListener: jest.fn(
+					(event: string, handler: () => void) => {
+						if (event === 'stop') {
+							handler();
+						}
+					},
+				),
+			}));
+			let recorderIndex = 0;
+
+			(global as Record<string, unknown>).MediaRecorder = jest.fn(() => {
+				const recorder =
+					mockMediaRecorders[recorderIndex] ?? mockMediaRecorders[0];
+				recorderIndex += 1;
+				return recorder;
+			});
+			(global as Record<string, unknown>).MediaRecorder.isTypeSupported =
+				jest.fn().mockReturnValue(true);
+
+			const { getAudioStreams } = jest.requireMock(
+				'../../src/recording/AudioStreamHandler',
+			);
+			getAudioStreams.mockResolvedValue({
+				streams: [
+					{ getTracks: () => [{ stop: jest.fn() }] },
+					{ getTracks: () => [{ stop: jest.fn() }] },
+				],
+				trackOrder: [],
+			});
+
+			(mockApp.vault.adapter.readBinary as jest.Mock).mockResolvedValue(
+				new Uint8Array([1, 2, 3]).buffer,
+			);
+
+			await manager.startRecording();
+
+			const chunk = new Blob([new Uint8Array([1, 2, 3])], {
+				type: 'audio/webm',
+			});
+			mockMediaRecorders.forEach((recorder) => {
+				recorder.ondataavailable?.({ data: chunk } as BlobEvent);
+			});
+
+			await Promise.resolve();
+			await manager.stopRecording();
+
+			expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
+				expect.stringMatching(/multitrack-.*\.webm$/),
+				expect.any(ArrayBuffer),
+			);
+			expect(mockApp.vault.createBinary).not.toHaveBeenCalledWith(
+				expect.stringMatching(/\.wav$/),
+				expect.any(ArrayBuffer),
+			);
+			expect(mockApp.vault.adapter.remove).toHaveBeenCalledWith(
+				expect.stringMatching(/-part\d+\.webm\.tmp$/),
+			);
+		});
+
+		it('should rollback merged output when cleanup of temporary partial files fails', async () => {
+			const { Notice } = jest.requireMock('obsidian');
+
+			const consoleWarnSpy = jest
+				.spyOn(console, 'warn')
+				.mockImplementation(() => {});
+
+			const { Platform } = jest.requireMock('obsidian');
+			Platform.isMobile = false;
+			Platform.isMobileApp = false;
+
+			mockSettings = {
+				...DEFAULT_SETTINGS,
+				enableMultiTrack: true,
+				outputMode: 'single',
+				recordingFormat: 'webm',
+			};
+			manager = new RecordingManager(
+				mockApp,
+				mockSettings,
+				statusChangeCallback,
+			);
+
+			const mockMediaRecorders = [0, 1].map(() => ({
+				start: jest.fn(),
+				stop: jest.fn(),
+				pause: jest.fn(),
+				resume: jest.fn(),
+				ondataavailable: null as ((event: BlobEvent) => void) | null,
+				onerror: null as ((event: Event) => void) | null,
+				addEventListener: jest.fn(
+					(event: string, handler: () => void) => {
+						if (event === 'stop') {
+							handler();
+						}
+					},
+				),
+			}));
+			let recorderIndex = 0;
+
+			(global as Record<string, unknown>).MediaRecorder = jest.fn(() => {
+				const recorder =
+					mockMediaRecorders[recorderIndex] ?? mockMediaRecorders[0];
+				recorderIndex += 1;
+				return recorder;
+			});
+			(global as Record<string, unknown>).MediaRecorder.isTypeSupported =
+				jest.fn().mockReturnValue(true);
+
+			const { getAudioStreams } = jest.requireMock(
+				'../../src/recording/AudioStreamHandler',
+			);
+			getAudioStreams.mockResolvedValue({
+				streams: [
+					{ getTracks: () => [{ stop: jest.fn() }] },
+					{ getTracks: () => [{ stop: jest.fn() }] },
+				],
+				trackOrder: [],
+			});
+
+			(mockApp.vault.adapter.readBinary as jest.Mock).mockResolvedValue(
+				new Uint8Array([1, 2, 3]).buffer,
+			);
+			(mockApp.vault.adapter.remove as jest.Mock).mockImplementation(
+				async (path: string) => {
+					if (path.includes('.tmp')) {
+						throw new Error('cleanup failed');
+					}
+					return undefined;
+				},
+			);
+
+			await manager.startRecording();
+
+			const chunk = new Blob([new Uint8Array([1, 2, 3])], {
+				type: 'audio/webm',
+			});
+			mockMediaRecorders.forEach((recorder) => {
+				recorder.ondataavailable?.({ data: chunk } as BlobEvent);
+			});
+
+			await Promise.resolve();
+			await manager.stopRecording();
+
+			expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
+				expect.stringMatching(/multitrack-.*\.webm$/),
+				expect.any(ArrayBuffer),
+			);
+			expect(mockApp.vault.adapter.remove).toHaveBeenCalledWith(
+				expect.stringMatching(/multitrack-.*\.webm$/),
+			);
+			expect(Notice).toHaveBeenCalledWith(
+				expect.stringContaining('Error stopping recording:'),
+			);
+			expect(consoleWarnSpy).toHaveBeenCalledWith(
+				expect.stringContaining('[AudioRecorder]'),
+				expect.objectContaining({
+					error: expect.objectContaining({
+						message: 'cleanup failed',
+					}),
+				}),
+			);
+
+			consoleWarnSpy.mockRestore();
+		});
+
+		/**
+		 * Ensures that WAV output mode uses direct PCM capture on desktop
+		 * and writes files with .wav extension assembled from PCM segments.
+		 */
+		it('should convert to wav only when output format is wav', async () => {
+			mockSettings = {
+				...DEFAULT_SETTINGS,
+				recordingFormat: 'wav',
+			};
+			manager = new RecordingManager(
+				mockApp,
+				mockSettings,
+				statusChangeCallback,
+			);
+
+			(global as Record<string, unknown>).MediaRecorder = jest.fn();
+			(global as Record<string, unknown>).MediaRecorder.isTypeSupported =
+				jest
+					.fn()
+					.mockImplementation(
+						(mime: string) => mime === 'audio/webm',
+					);
+
+			const { getAudioStreams } = jest.requireMock(
+				'../../src/recording/AudioStreamHandler',
+			);
+			getAudioStreams.mockResolvedValue({
+				streams: [
+					{
+						getTracks: () => [{ stop: jest.fn() }],
+					},
+				],
+				trackOrder: [],
+			});
+
+			await manager.startRecording();
+
+			// Simulate PCM chunk via captured callback
+			const pcmData = new Int16Array([100, -100, 200, -200]).buffer;
+			capturedPcmChunkCallback?.(pcmData);
+
+			await Promise.resolve();
+			await manager.stopRecording();
+
+			expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
+				expect.stringMatching(/\.wav$/),
+				expect.any(ArrayBuffer),
+			);
+			expect(mockApp.vault.adapter.rename).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('context-aware save location', () => {
+		it('should save near active markdown file when enabled without subfolder', async () => {
+			mockSettings = {
+				...DEFAULT_SETTINGS,
+				saveNearActiveFile: true,
+				activeFileSubfolder: '',
+			};
+			manager = new RecordingManager(
+				mockApp,
+				mockSettings,
+				statusChangeCallback,
+			);
+			(mockApp.workspace.getActiveFile as jest.Mock).mockReturnValue({
+				path: 'Meetings/2026/Meeting Note.md',
+			});
+
+			const mockMediaRecorder = {
+				start: jest.fn(),
+				stop: jest.fn(),
+				pause: jest.fn(),
+				resume: jest.fn(),
+				ondataavailable: null as ((event: BlobEvent) => void) | null,
+				onerror: null as ((event: Event) => void) | null,
+				addEventListener: jest.fn(
+					(event: string, handler: () => void) => {
+						if (event === 'stop') {
+							handler();
+						}
+					},
+				),
+			};
+
+			(global as Record<string, unknown>).MediaRecorder = jest.fn(
+				() => mockMediaRecorder,
+			);
+			(global as Record<string, unknown>).MediaRecorder.isTypeSupported =
+				jest.fn().mockReturnValue(true);
+
+			const { getAudioStreams } = jest.requireMock(
+				'../../src/recording/AudioStreamHandler',
+			);
+			getAudioStreams.mockResolvedValue({
+				streams: [{ getTracks: () => [{ stop: jest.fn() }] }],
+				trackOrder: [],
+			});
+
+			await manager.startRecording();
+
+			const chunk = new Blob([new Uint8Array([1, 2, 3])], {
+				type: 'audio/webm',
+			});
+			mockMediaRecorder.ondataavailable?.({ data: chunk } as BlobEvent);
+			await Promise.resolve();
+
+			await manager.stopRecording();
+
+			expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
+				expect.stringMatching(
+					/^Meetings\/2026\/recording-Track1-.*-part1\.webm\.tmp$/,
+				),
+				expect.any(ArrayBuffer),
+			);
+		});
+
+		it('should create active file subfolder and save recording there', async () => {
+			mockSettings = {
+				...DEFAULT_SETTINGS,
+				saveNearActiveFile: true,
+				activeFileSubfolder: 'Audio',
+			};
+			manager = new RecordingManager(
+				mockApp,
+				mockSettings,
+				statusChangeCallback,
+			);
+			(mockApp.workspace.getActiveFile as jest.Mock).mockReturnValue({
+				path: 'Meetings/2026/Meeting Note.md',
+			});
+
+			const mockMediaRecorder = {
+				start: jest.fn(),
+				stop: jest.fn(),
+				pause: jest.fn(),
+				resume: jest.fn(),
+				ondataavailable: null as ((event: BlobEvent) => void) | null,
+				onerror: null as ((event: Event) => void) | null,
+				addEventListener: jest.fn(
+					(event: string, handler: () => void) => {
+						if (event === 'stop') {
+							handler();
+						}
+					},
+				),
+			};
+
+			(global as Record<string, unknown>).MediaRecorder = jest.fn(
+				() => mockMediaRecorder,
+			);
+			(global as Record<string, unknown>).MediaRecorder.isTypeSupported =
+				jest.fn().mockReturnValue(true);
+
+			const { getAudioStreams } = jest.requireMock(
+				'../../src/recording/AudioStreamHandler',
+			);
+			getAudioStreams.mockResolvedValue({
+				streams: [{ getTracks: () => [{ stop: jest.fn() }] }],
+				trackOrder: [],
+			});
+
+			await manager.startRecording();
+
+			const chunk = new Blob([new Uint8Array([1, 2, 3])], {
+				type: 'audio/webm',
+			});
+			mockMediaRecorder.ondataavailable?.({ data: chunk } as BlobEvent);
+			await Promise.resolve();
+
+			await manager.stopRecording();
+
+			expect(mockApp.vault.createFolder).toHaveBeenCalledWith(
+				'Meetings/2026/Audio',
+			);
+			expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
+				expect.stringMatching(
+					/^Meetings\/2026\/Audio\/recording-Track1-.*-part1\.webm\.tmp$/,
+				),
+				expect.any(ArrayBuffer),
+			);
+		});
+
+		it('should fallback to global save folder when near-active mode is disabled', async () => {
+			mockSettings = {
+				...DEFAULT_SETTINGS,
+				saveFolder: 'Recordings',
+				saveNearActiveFile: false,
+				activeFileSubfolder: 'Audio',
+			};
+			manager = new RecordingManager(
+				mockApp,
+				mockSettings,
+				statusChangeCallback,
+			);
+			(mockApp.workspace.getActiveFile as jest.Mock).mockReturnValue({
+				path: 'Meetings/2026/Meeting Note.md',
+			});
+
+			const mockMediaRecorder = {
+				start: jest.fn(),
+				stop: jest.fn(),
+				pause: jest.fn(),
+				resume: jest.fn(),
+				ondataavailable: null as ((event: BlobEvent) => void) | null,
+				onerror: null as ((event: Event) => void) | null,
+				addEventListener: jest.fn(
+					(event: string, handler: () => void) => {
+						if (event === 'stop') {
+							handler();
+						}
+					},
+				),
+			};
+
+			(global as Record<string, unknown>).MediaRecorder = jest.fn(
+				() => mockMediaRecorder,
+			);
+			(global as Record<string, unknown>).MediaRecorder.isTypeSupported =
+				jest.fn().mockReturnValue(true);
+
+			const { getAudioStreams } = jest.requireMock(
+				'../../src/recording/AudioStreamHandler',
+			);
+			getAudioStreams.mockResolvedValue({
+				streams: [{ getTracks: () => [{ stop: jest.fn() }] }],
+				trackOrder: [],
+			});
+
+			await manager.startRecording();
+
+			const chunk = new Blob([new Uint8Array([1, 2, 3])], {
+				type: 'audio/webm',
+			});
+			mockMediaRecorder.ondataavailable?.({ data: chunk } as BlobEvent);
+			await Promise.resolve();
+
+			await manager.stopRecording();
+
+			expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
+				expect.stringMatching(
+					/^Recordings\/recording-Track1-.*-part1\.webm\.tmp$/,
+				),
+				expect.any(ArrayBuffer),
+			);
+		});
+	});
+
+	describe('insertFileLinks uses basename only', () => {
+		it('should insert only filename without directory path in wikilinks', async () => {
+			const mockReplaceSelection = jest.fn();
+			(
+				mockApp.workspace.getActiveViewOfType as jest.Mock
+			).mockReturnValue({
+				editor: { replaceSelection: mockReplaceSelection },
+			});
+
+			const mockMediaRecorder = {
+				start: jest.fn(),
+				stop: jest.fn(),
+				pause: jest.fn(),
+				resume: jest.fn(),
+				ondataavailable: null as ((event: BlobEvent) => void) | null,
+				onerror: null as ((event: Event) => void) | null,
+				addEventListener: jest.fn(
+					(event: string, handler: () => void) => {
+						if (event === 'stop') {
+							handler();
+						}
+					},
+				),
+			};
+
+			(global as Record<string, unknown>).MediaRecorder = jest.fn(
+				() => mockMediaRecorder,
+			);
+			(global as Record<string, unknown>).MediaRecorder.isTypeSupported =
+				jest.fn().mockReturnValue(true);
+
+			const { getAudioStreams } = jest.requireMock(
+				'../../src/recording/AudioStreamHandler',
+			);
+			getAudioStreams.mockResolvedValue({
+				streams: [{ getTracks: () => [{ stop: jest.fn() }] }],
+				trackOrder: [],
+			});
+
+			(mockApp.vault.adapter.readBinary as jest.Mock).mockResolvedValue(
+				new Uint8Array([1, 2, 3]).buffer,
+			);
+
+			await manager.startRecording();
+
+			const chunk = new Blob([new Uint8Array([1, 2, 3])], {
+				type: 'audio/webm',
+			});
+			mockMediaRecorder.ondataavailable?.({ data: chunk } as BlobEvent);
+			await Promise.resolve();
+
+			await manager.stopRecording();
+
+			expect(mockReplaceSelection).toHaveBeenCalled();
+			const insertedText = mockReplaceSelection.mock
+				.calls[0][0] as string;
+			expect(insertedText).not.toContain('/');
+			expect(insertedText).toMatch(/^!\[\[recording-.*\]\]$/);
+		});
+
+		it('should use basename when file is saved in a nested directory', async () => {
+			mockSettings = {
+				...DEFAULT_SETTINGS,
+				saveNearActiveFile: true,
+				activeFileSubfolder: 'Audio',
+			};
+			manager = new RecordingManager(
+				mockApp,
+				mockSettings,
+				statusChangeCallback,
+			);
+			(mockApp.workspace.getActiveFile as jest.Mock).mockReturnValue({
+				path: 'Projects/Notes/Daily.md',
+			});
+
+			const mockReplaceSelection = jest.fn();
+			(
+				mockApp.workspace.getActiveViewOfType as jest.Mock
+			).mockReturnValue({
+				editor: { replaceSelection: mockReplaceSelection },
+			});
+
+			const mockMediaRecorder = {
+				start: jest.fn(),
+				stop: jest.fn(),
+				pause: jest.fn(),
+				resume: jest.fn(),
+				ondataavailable: null as ((event: BlobEvent) => void) | null,
+				onerror: null as ((event: Event) => void) | null,
+				addEventListener: jest.fn(
+					(event: string, handler: () => void) => {
+						if (event === 'stop') {
+							handler();
+						}
+					},
+				),
+			};
+
+			(global as Record<string, unknown>).MediaRecorder = jest.fn(
+				() => mockMediaRecorder,
+			);
+			(global as Record<string, unknown>).MediaRecorder.isTypeSupported =
+				jest.fn().mockReturnValue(true);
+
+			const { getAudioStreams } = jest.requireMock(
+				'../../src/recording/AudioStreamHandler',
+			);
+			getAudioStreams.mockResolvedValue({
+				streams: [{ getTracks: () => [{ stop: jest.fn() }] }],
+				trackOrder: [],
+			});
+
+			(mockApp.vault.adapter.readBinary as jest.Mock).mockResolvedValue(
+				new Uint8Array([1, 2, 3]).buffer,
+			);
+
+			await manager.startRecording();
+
+			const chunk = new Blob([new Uint8Array([1, 2, 3])], {
+				type: 'audio/webm',
+			});
+			mockMediaRecorder.ondataavailable?.({ data: chunk } as BlobEvent);
+			await Promise.resolve();
+
+			await manager.stopRecording();
+
+			expect(mockReplaceSelection).toHaveBeenCalled();
+			const insertedText = mockReplaceSelection.mock
+				.calls[0][0] as string;
+			expect(insertedText).not.toContain('Projects/');
+			expect(insertedText).not.toContain('Audio/');
+			expect(insertedText).toMatch(/^!\[\[recording-.*\]\]$/);
+		});
+	});
 });

--- a/tests/unit/RibbonIcon.test.ts
+++ b/tests/unit/RibbonIcon.test.ts
@@ -5,100 +5,111 @@
  */
 /** @jest-environment jsdom */
 
-import { updateRibbonIcon, initializeRibbonIcon } from '../../src/ui/RibbonIcon';
+import {
+	updateRibbonIcon,
+	initializeRibbonIcon,
+} from '../../src/ui/RibbonIcon';
 import { RecordingStatus } from '../../src/types';
 
 // Mock the setIcon function from obsidian
 jest.mock('obsidian', () => ({
-    setIcon: jest.fn((el: HTMLElement, iconName: string) => {
-        el.setAttribute('data-icon', iconName);
-    }),
+	setIcon: jest.fn((el: HTMLElement, iconName: string) => {
+		el.setAttribute('data-icon', iconName);
+	}),
 }));
 
 describe('RibbonIcon', () => {
-    let ribbonElement: HTMLElement;
+	let ribbonElement: HTMLElement;
 
-    beforeEach(() => {
-        ribbonElement = document.createElement('div');
-        ribbonElement.className = 'side-dock-ribbon-action';
-    });
+	beforeEach(() => {
+		ribbonElement = document.createElement('div');
+		ribbonElement.className = 'side-dock-ribbon-action';
+	});
 
-    describe('updateRibbonIcon', () => {
-        it('should handle null element gracefully', () => {
-            expect(() => {
-                updateRibbonIcon(null, RecordingStatus.Recording);
-            }).not.toThrow();
-        });
+	describe('updateRibbonIcon', () => {
+		it('should handle null element gracefully', () => {
+			expect(() => {
+				updateRibbonIcon(null, RecordingStatus.Recording);
+			}).not.toThrow();
+		});
 
-        it('should change icon to mic and add is-recording class when recording', () => {
-            updateRibbonIcon(ribbonElement, RecordingStatus.Recording);
+		it('should change icon to mic and add is-recording class when recording', () => {
+			updateRibbonIcon(ribbonElement, RecordingStatus.Recording);
 
-            expect(ribbonElement.getAttribute('data-icon')).toBe('mic');
-            expect(ribbonElement.classList.contains('is-recording')).toBe(true);
-        });
+			expect(ribbonElement.getAttribute('data-icon')).toBe('mic');
+			expect(ribbonElement.classList.contains('is-recording')).toBe(true);
+		});
 
-        it('should change icon to mic and add is-recording class when paused', () => {
-            updateRibbonIcon(ribbonElement, RecordingStatus.Paused);
+		it('should change icon to mic and add is-recording class when paused', () => {
+			updateRibbonIcon(ribbonElement, RecordingStatus.Paused);
 
-            expect(ribbonElement.getAttribute('data-icon')).toBe('mic');
-            expect(ribbonElement.classList.contains('is-recording')).toBe(true);
-        });
+			expect(ribbonElement.getAttribute('data-icon')).toBe('mic');
+			expect(ribbonElement.classList.contains('is-recording')).toBe(true);
+		});
 
-        it('should change icon to microphone and remove is-recording class when idle', () => {
-            // First set to recording
-            ribbonElement.classList.add('is-recording');
-            ribbonElement.setAttribute('data-icon', 'mic');
+		it('should change icon to microphone and remove is-recording class when idle', () => {
+			// First set to recording
+			ribbonElement.classList.add('is-recording');
+			ribbonElement.setAttribute('data-icon', 'mic');
 
-            updateRibbonIcon(ribbonElement, RecordingStatus.Idle);
+			updateRibbonIcon(ribbonElement, RecordingStatus.Idle);
 
-            expect(ribbonElement.getAttribute('data-icon')).toBe('microphone');
-            expect(ribbonElement.classList.contains('is-recording')).toBe(false);
-        });
+			expect(ribbonElement.getAttribute('data-icon')).toBe('microphone');
+			expect(ribbonElement.classList.contains('is-recording')).toBe(
+				false,
+			);
+		});
 
-        it('should change icon to save and add is-saving class when saving', () => {
-            updateRibbonIcon(ribbonElement, RecordingStatus.Saving);
+		it('should change icon to save and add is-saving class when saving', () => {
+			updateRibbonIcon(ribbonElement, RecordingStatus.Saving);
 
-            expect(ribbonElement.getAttribute('data-icon')).toBe('save');
-            expect(ribbonElement.classList.contains('is-saving')).toBe(true);
-            expect(ribbonElement.classList.contains('is-recording')).toBe(false);
-        });
+			expect(ribbonElement.getAttribute('data-icon')).toBe('save');
+			expect(ribbonElement.classList.contains('is-saving')).toBe(true);
+			expect(ribbonElement.classList.contains('is-recording')).toBe(
+				false,
+			);
+		});
 
-        it('should remove is-saving class when transitioning from saving to idle', () => {
-            ribbonElement.classList.add('is-saving');
-            ribbonElement.setAttribute('data-icon', 'save');
+		it('should remove is-saving class when transitioning from saving to idle', () => {
+			ribbonElement.classList.add('is-saving');
+			ribbonElement.setAttribute('data-icon', 'save');
 
-            updateRibbonIcon(ribbonElement, RecordingStatus.Idle);
+			updateRibbonIcon(ribbonElement, RecordingStatus.Idle);
 
-            expect(ribbonElement.getAttribute('data-icon')).toBe('microphone');
-            expect(ribbonElement.classList.contains('is-saving')).toBe(false);
-        });
+			expect(ribbonElement.getAttribute('data-icon')).toBe('microphone');
+			expect(ribbonElement.classList.contains('is-saving')).toBe(false);
+		});
 
-        it('should handle default case same as idle', () => {
-            ribbonElement.classList.add('is-recording');
+		it('should handle default case same as idle', () => {
+			ribbonElement.classList.add('is-recording');
 
-            // Force an unknown status value to test default case
-            updateRibbonIcon(ribbonElement, 'unknown' as RecordingStatus);
+			// Force an unknown status value to test default case
+			updateRibbonIcon(ribbonElement, 'unknown' as RecordingStatus);
 
-            expect(ribbonElement.getAttribute('data-icon')).toBe('microphone');
-            expect(ribbonElement.classList.contains('is-recording')).toBe(false);
-        });
-    });
+			expect(ribbonElement.getAttribute('data-icon')).toBe('microphone');
+			expect(ribbonElement.classList.contains('is-recording')).toBe(
+				false,
+			);
+		});
+	});
 
-    describe('initializeRibbonIcon', () => {
-        it('should handle null element gracefully', () => {
-            expect(() => {
-                initializeRibbonIcon(null);
-            }).not.toThrow();
-        });
+	describe('initializeRibbonIcon', () => {
+		it('should handle null element gracefully', () => {
+			expect(() => {
+				initializeRibbonIcon(null);
+			}).not.toThrow();
+		});
 
-        it('should set ribbon icon to idle state', () => {
-            ribbonElement.classList.add('is-recording');
-            ribbonElement.setAttribute('data-icon', 'mic');
+		it('should set ribbon icon to idle state', () => {
+			ribbonElement.classList.add('is-recording');
+			ribbonElement.setAttribute('data-icon', 'mic');
 
-            initializeRibbonIcon(ribbonElement);
+			initializeRibbonIcon(ribbonElement);
 
-            expect(ribbonElement.getAttribute('data-icon')).toBe('microphone');
-            expect(ribbonElement.classList.contains('is-recording')).toBe(false);
-        });
-    });
+			expect(ribbonElement.getAttribute('data-icon')).toBe('microphone');
+			expect(ribbonElement.classList.contains('is-recording')).toBe(
+				false,
+			);
+		});
+	});
 });

--- a/tests/unit/Settings.test.ts
+++ b/tests/unit/Settings.test.ts
@@ -8,338 +8,348 @@
  */
 
 import {
-    AudioRecorderSettings,
-    DEFAULT_SETTINGS,
-    mergeSettings,
-    mergeSettingsAsync,
-    OutputMode,
-    TrackAudioSources,
+	AudioRecorderSettings,
+	DEFAULT_SETTINGS,
+	mergeSettings,
+	mergeSettingsAsync,
+	OutputMode,
+	TrackAudioSources,
 } from '../../src/settings/Settings';
 
 describe('Settings', () => {
-    describe('DEFAULT_SETTINGS', () => {
-        it('should have correct default recording format', () => {
-            expect(DEFAULT_SETTINGS.recordingFormat).toBe('webm');
-        });
+	describe('DEFAULT_SETTINGS', () => {
+		it('should have correct default recording format', () => {
+			expect(DEFAULT_SETTINGS.recordingFormat).toBe('webm');
+		});
 
-        it('should have empty save folder by default', () => {
-            expect(DEFAULT_SETTINGS.saveFolder).toBe('');
-        });
+		it('should have empty save folder by default', () => {
+			expect(DEFAULT_SETTINGS.saveFolder).toBe('');
+		});
 
-        it('should have save-near-active-file mode disabled by default', () => {
-            expect(DEFAULT_SETTINGS.saveNearActiveFile).toBe(false);
-        });
+		it('should have save-near-active-file mode disabled by default', () => {
+			expect(DEFAULT_SETTINGS.saveNearActiveFile).toBe(false);
+		});
 
-        it('should have empty active file subfolder by default', () => {
-            expect(DEFAULT_SETTINGS.activeFileSubfolder).toBe('');
-        });
+		it('should have empty active file subfolder by default', () => {
+			expect(DEFAULT_SETTINGS.activeFileSubfolder).toBe('');
+		});
 
-        it('should have default file prefix', () => {
-            expect(DEFAULT_SETTINGS.filePrefix).toBe('recording');
-        });
+		it('should have default file prefix', () => {
+			expect(DEFAULT_SETTINGS.filePrefix).toBe('recording');
+		});
 
-        it('should have empty hotkeys by default', () => {
-            expect(DEFAULT_SETTINGS.startStopHotkey).toBe('');
-            expect(DEFAULT_SETTINGS.pauseHotkey).toBe('');
-            expect(DEFAULT_SETTINGS.resumeHotkey).toBe('');
-        });
+		it('should have empty hotkeys by default', () => {
+			expect(DEFAULT_SETTINGS.startStopHotkey).toBe('');
+			expect(DEFAULT_SETTINGS.pauseHotkey).toBe('');
+			expect(DEFAULT_SETTINGS.resumeHotkey).toBe('');
+		});
 
-        it('should have empty audio device ID', () => {
-            expect(DEFAULT_SETTINGS.audioDeviceId).toBe('');
-        });
+		it('should have empty audio device ID', () => {
+			expect(DEFAULT_SETTINGS.audioDeviceId).toBe('');
+		});
 
-        it('should have default sample rate of 44100', () => {
-            expect(DEFAULT_SETTINGS.sampleRate).toBe(44100);
-        });
+		it('should have default sample rate of 44100', () => {
+			expect(DEFAULT_SETTINGS.sampleRate).toBe(44100);
+		});
 
-        it('should have default bitrate of 128000', () => {
-            expect(DEFAULT_SETTINGS.bitrate).toBe(128000);
-        });
+		it('should have default bitrate of 128000', () => {
+			expect(DEFAULT_SETTINGS.bitrate).toBe(128000);
+		});
 
-        it('should have multi-track disabled by default', () => {
-            expect(DEFAULT_SETTINGS.enableMultiTrack).toBe(false);
-        });
+		it('should have multi-track disabled by default', () => {
+			expect(DEFAULT_SETTINGS.enableMultiTrack).toBe(false);
+		});
 
-        it('should have max tracks set to 2 by default', () => {
-            expect(DEFAULT_SETTINGS.maxTracks).toBe(2);
-        });
+		it('should have max tracks set to 2 by default', () => {
+			expect(DEFAULT_SETTINGS.maxTracks).toBe(2);
+		});
 
-        it('should have single output mode by default', () => {
-            expect(DEFAULT_SETTINGS.outputMode).toBe('single');
-        });
+		it('should have single output mode by default', () => {
+			expect(DEFAULT_SETTINGS.outputMode).toBe('single');
+		});
 
-        it('should use source names for tracks by default', () => {
-            expect(DEFAULT_SETTINGS.useSourceNamesForTracks).toBe(true);
-        });
+		it('should use source names for tracks by default', () => {
+			expect(DEFAULT_SETTINGS.useSourceNamesForTracks).toBe(true);
+		});
 
-        it('should have empty track audio sources', () => {
-            expect(DEFAULT_SETTINGS.trackAudioSources).toBeInstanceOf(Map);
-            expect(DEFAULT_SETTINGS.trackAudioSources.size).toBe(0);
-        });
+		it('should have empty track audio sources', () => {
+			expect(DEFAULT_SETTINGS.trackAudioSources).toBeInstanceOf(Map);
+			expect(DEFAULT_SETTINGS.trackAudioSources.size).toBe(0);
+		});
 
-        it('should have debug mode disabled by default', () => {
-            expect(DEFAULT_SETTINGS.debug).toBe(false);
-        });
+		it('should have debug mode disabled by default', () => {
+			expect(DEFAULT_SETTINGS.debug).toBe(false);
+		});
 
-        it('should be a complete AudioRecorderSettings object', () => {
-            const expectedKeys: (keyof AudioRecorderSettings)[] = [
-                'recordingFormat',
-                'saveFolder',
-                'saveNearActiveFile',
-                'activeFileSubfolder',
-                'filePrefix',
-                'startStopHotkey',
-                'pauseHotkey',
-                'resumeHotkey',
-                'audioDeviceId',
-                'sampleRate',
-                'bitrate',
-                'enableMultiTrack',
-                'maxTracks',
-                'outputMode',
-                'useSourceNamesForTracks',
-                'trackAudioSources',
-                'debug',
-            ];
+		it('should be a complete AudioRecorderSettings object', () => {
+			const expectedKeys: (keyof AudioRecorderSettings)[] = [
+				'recordingFormat',
+				'saveFolder',
+				'saveNearActiveFile',
+				'activeFileSubfolder',
+				'filePrefix',
+				'startStopHotkey',
+				'pauseHotkey',
+				'resumeHotkey',
+				'audioDeviceId',
+				'sampleRate',
+				'bitrate',
+				'enableMultiTrack',
+				'maxTracks',
+				'outputMode',
+				'useSourceNamesForTracks',
+				'trackAudioSources',
+				'debug',
+			];
 
-            expectedKeys.forEach((key) => {
-                expect(DEFAULT_SETTINGS).toHaveProperty(key);
-            });
-        });
-    });
+			expectedKeys.forEach((key) => {
+				expect(DEFAULT_SETTINGS).toHaveProperty(key);
+			});
+		});
+	});
 
-    describe('mergeSettings', () => {
-        it('should return default settings when given empty object', () => {
-            const result = mergeSettings({});
-            expect(result).toEqual(DEFAULT_SETTINGS);
-        });
+	describe('mergeSettings', () => {
+		it('should return default settings when given empty object', () => {
+			const result = mergeSettings({});
+			expect(result).toEqual(DEFAULT_SETTINGS);
+		});
 
-        it('should override specific settings while keeping defaults', () => {
-            const partial: Partial<AudioRecorderSettings> = {
-                recordingFormat: 'ogg',
-                sampleRate: 48000,
-            };
+		it('should override specific settings while keeping defaults', () => {
+			const partial: Partial<AudioRecorderSettings> = {
+				recordingFormat: 'ogg',
+				sampleRate: 48000,
+			};
 
-            const result = mergeSettings(partial);
+			const result = mergeSettings(partial);
 
-            expect(result.recordingFormat).toBe('ogg');
-            expect(result.sampleRate).toBe(48000);
-            expect(result.filePrefix).toBe(DEFAULT_SETTINGS.filePrefix);
-            expect(result.debug).toBe(DEFAULT_SETTINGS.debug);
-        });
+			expect(result.recordingFormat).toBe('ogg');
+			expect(result.sampleRate).toBe(48000);
+			expect(result.filePrefix).toBe(DEFAULT_SETTINGS.filePrefix);
+			expect(result.debug).toBe(DEFAULT_SETTINGS.debug);
+		});
 
-        it('should merge track audio sources', () => {
-            const trackSources: TrackAudioSources = new Map([
-                [1, { deviceId: 'device-id-1' }],
-                [2, { deviceId: 'device-id-2' }],
-            ]);
+		it('should merge track audio sources', () => {
+			const trackSources: TrackAudioSources = new Map([
+				[1, { deviceId: 'device-id-1' }],
+				[2, { deviceId: 'device-id-2' }],
+			]);
 
-            const result = mergeSettings({ trackAudioSources: trackSources });
+			const result = mergeSettings({ trackAudioSources: trackSources });
 
-            expect(result.trackAudioSources.get(1)?.deviceId).toBe('device-id-1');
-            expect(result.trackAudioSources.get(2)?.deviceId).toBe('device-id-2');
-        });
+			expect(result.trackAudioSources.get(1)?.deviceId).toBe(
+				'device-id-1',
+			);
+			expect(result.trackAudioSources.get(2)?.deviceId).toBe(
+				'device-id-2',
+			);
+		});
 
-        it('should normalize serialized track audio sources into a Map', () => {
-            const result = mergeSettings({
-                trackAudioSources: { 1: 'device-id-1', 2: 'device-id-2' },
-            });
+		it('should normalize serialized track audio sources into a Map', () => {
+			const result = mergeSettings({
+				trackAudioSources: { 1: 'device-id-1', 2: 'device-id-2' },
+			});
 
-            expect(result.trackAudioSources).toBeInstanceOf(Map);
-            expect(result.trackAudioSources.get(1)?.deviceId).toBe('device-id-1');
-            expect(result.trackAudioSources.get(2)?.deviceId).toBe('device-id-2');
-        });
+			expect(result.trackAudioSources).toBeInstanceOf(Map);
+			expect(result.trackAudioSources.get(1)?.deviceId).toBe(
+				'device-id-1',
+			);
+			expect(result.trackAudioSources.get(2)?.deviceId).toBe(
+				'device-id-2',
+			);
+		});
 
-        it('should handle output mode changes', () => {
-            const modes: OutputMode[] = ['single', 'multiple'];
+		it('should handle output mode changes', () => {
+			const modes: OutputMode[] = ['single', 'multiple'];
 
-            modes.forEach((mode) => {
-                const result = mergeSettings({ outputMode: mode });
-                expect(result.outputMode).toBe(mode);
-            });
-        });
+			modes.forEach((mode) => {
+				const result = mergeSettings({ outputMode: mode });
+				expect(result.outputMode).toBe(mode);
+			});
+		});
 
-        it('should preserve all user settings when fully specified', () => {
-            const fullSettings: AudioRecorderSettings = {
-                recordingFormat: 'mp3',
-                saveFolder: '/recordings',
-                saveNearActiveFile: true,
-                activeFileSubfolder: 'Audio',
-                filePrefix: 'audio',
-                startStopHotkey: 'Ctrl+R',
-                pauseHotkey: 'Ctrl+P',
-                resumeHotkey: 'Ctrl+E',
-                audioDeviceId: 'test-device',
-                sampleRate: 22050,
-                bitrate: 64000,
-                enableMultiTrack: true,
-                maxTracks: 4,
-                outputMode: 'multiple',
-                useSourceNamesForTracks: false,
-                trackAudioSources: new Map([
-                    [1, { deviceId: 'dev1' }],
-                    [2, { deviceId: 'dev2' }],
-                ]),
-                debug: true,
-            };
+		it('should preserve all user settings when fully specified', () => {
+			const fullSettings: AudioRecorderSettings = {
+				recordingFormat: 'mp3',
+				saveFolder: '/recordings',
+				saveNearActiveFile: true,
+				activeFileSubfolder: 'Audio',
+				filePrefix: 'audio',
+				startStopHotkey: 'Ctrl+R',
+				pauseHotkey: 'Ctrl+P',
+				resumeHotkey: 'Ctrl+E',
+				audioDeviceId: 'test-device',
+				sampleRate: 22050,
+				bitrate: 64000,
+				enableMultiTrack: true,
+				maxTracks: 4,
+				outputMode: 'multiple',
+				useSourceNamesForTracks: false,
+				trackAudioSources: new Map([
+					[1, { deviceId: 'dev1' }],
+					[2, { deviceId: 'dev2' }],
+				]),
+				debug: true,
+			};
 
-            const result = mergeSettings(fullSettings);
+			const result = mergeSettings(fullSettings);
 
-            expect(result).toEqual(fullSettings);
-        });
+			expect(result).toEqual(fullSettings);
+		});
 
-        it('should not modify the default settings object', () => {
-            const originalDefaults = { ...DEFAULT_SETTINGS };
+		it('should not modify the default settings object', () => {
+			const originalDefaults = { ...DEFAULT_SETTINGS };
 
-            mergeSettings({ recordingFormat: 'wav' });
+			mergeSettings({ recordingFormat: 'wav' });
 
-            expect(DEFAULT_SETTINGS).toEqual(originalDefaults);
-        });
+			expect(DEFAULT_SETTINGS).toEqual(originalDefaults);
+		});
 
-        it('should handle boolean settings correctly', () => {
-            const result1 = mergeSettings({ debug: true });
-            const result2 = mergeSettings({ enableMultiTrack: true });
+		it('should handle boolean settings correctly', () => {
+			const result1 = mergeSettings({ debug: true });
+			const result2 = mergeSettings({ enableMultiTrack: true });
 
-            expect(result1.debug).toBe(true);
-            expect(result2.enableMultiTrack).toBe(true);
-        });
+			expect(result1.debug).toBe(true);
+			expect(result2.enableMultiTrack).toBe(true);
+		});
 
-        it('should handle numeric settings correctly', () => {
-            const result = mergeSettings({
-                sampleRate: 96000,
-                bitrate: 320000,
-                maxTracks: 8,
-            });
+		it('should handle numeric settings correctly', () => {
+			const result = mergeSettings({
+				sampleRate: 96000,
+				bitrate: 320000,
+				maxTracks: 8,
+			});
 
-            expect(result.sampleRate).toBe(96000);
-            expect(result.bitrate).toBe(320000);
-            expect(result.maxTracks).toBe(8);
-        });
-    });
+			expect(result.sampleRate).toBe(96000);
+			expect(result.bitrate).toBe(320000);
+			expect(result.maxTracks).toBe(8);
+		});
+	});
 
-    describe('Type definitions', () => {
-        it('OutputMode should only accept valid values', () => {
-            const validModes: OutputMode[] = ['single', 'multiple'];
-            expect(validModes).toHaveLength(2);
-        });
+	describe('Type definitions', () => {
+		it('OutputMode should only accept valid values', () => {
+			const validModes: OutputMode[] = ['single', 'multiple'];
+			expect(validModes).toHaveLength(2);
+		});
 
-        it('TrackAudioSources should map numbers to device IDs', () => {
-            const sources: TrackAudioSources = new Map([
-                [1, { deviceId: 'device-1' }],
-                [2, { deviceId: 'device-2' }],
-                [3, { deviceId: 'device-3' }],
-            ]);
+		it('TrackAudioSources should map numbers to device IDs', () => {
+			const sources: TrackAudioSources = new Map([
+				[1, { deviceId: 'device-1' }],
+				[2, { deviceId: 'device-2' }],
+				[3, { deviceId: 'device-3' }],
+			]);
 
-            expect(sources.size).toBe(3);
-            expect(sources.get(1)?.deviceId).toBe('device-1');
-        });
-    });
+			expect(sources.size).toBe(3);
+			expect(sources.get(1)?.deviceId).toBe('device-1');
+		});
+	});
 });
 
 describe('mergeSettingsAsync', () => {
-    const mockEnumerateDevices = jest.fn();
-    const mockGetUserMedia = jest.fn();
+	const mockEnumerateDevices = jest.fn();
+	const mockGetUserMedia = jest.fn();
 
-    beforeEach(() => {
-        jest.clearAllMocks();
-        Object.defineProperty(global, 'navigator', {
-            value: {
-                mediaDevices: {
-                    enumerateDevices: mockEnumerateDevices,
-                    getUserMedia: mockGetUserMedia,
-                },
-            },
-            writable: true,
-        });
-    });
+	beforeEach(() => {
+		jest.clearAllMocks();
+		Object.defineProperty(global, 'navigator', {
+			value: {
+				mediaDevices: {
+					enumerateDevices: mockEnumerateDevices,
+					getUserMedia: mockGetUserMedia,
+				},
+			},
+			writable: true,
+		});
+	});
 
-    it('should auto-select default device when audioDeviceId is empty', async () => {
-        const devices: MediaDeviceInfo[] = [
-            {
-                deviceId: 'default',
-                label: 'Default - Microphone',
-                kind: 'audioinput',
-                groupId: 'group1',
-                toJSON: () => ({}),
-            },
-        ] as MediaDeviceInfo[];
+	it('should auto-select default device when audioDeviceId is empty', async () => {
+		const devices: MediaDeviceInfo[] = [
+			{
+				deviceId: 'default',
+				label: 'Default - Microphone',
+				kind: 'audioinput',
+				groupId: 'group1',
+				toJSON: () => ({}),
+			},
+		] as MediaDeviceInfo[];
 
-        mockGetUserMedia.mockResolvedValue({ getTracks: () => [] });
-        mockEnumerateDevices.mockResolvedValue(devices);
+		mockGetUserMedia.mockResolvedValue({ getTracks: () => [] });
+		mockEnumerateDevices.mockResolvedValue(devices);
 
-        const result = await mergeSettingsAsync({});
+		const result = await mergeSettingsAsync({});
 
-        expect(result.audioDeviceId).toBe('default');
-    });
+		expect(result.audioDeviceId).toBe('default');
+	});
 
-    it('should auto-select default device when audioDeviceId is whitespace', async () => {
-        const devices: MediaDeviceInfo[] = [
-            {
-                deviceId: 'default',
-                label: 'Default - Microphone',
-                kind: 'audioinput',
-                groupId: 'group1',
-                toJSON: () => ({}),
-            },
-        ] as MediaDeviceInfo[];
+	it('should auto-select default device when audioDeviceId is whitespace', async () => {
+		const devices: MediaDeviceInfo[] = [
+			{
+				deviceId: 'default',
+				label: 'Default - Microphone',
+				kind: 'audioinput',
+				groupId: 'group1',
+				toJSON: () => ({}),
+			},
+		] as MediaDeviceInfo[];
 
-        mockGetUserMedia.mockResolvedValue({ getTracks: () => [] });
-        mockEnumerateDevices.mockResolvedValue(devices);
+		mockGetUserMedia.mockResolvedValue({ getTracks: () => [] });
+		mockEnumerateDevices.mockResolvedValue(devices);
 
-        const result = await mergeSettingsAsync({ audioDeviceId: '   ' });
+		const result = await mergeSettingsAsync({ audioDeviceId: '   ' });
 
-        expect(result.audioDeviceId).toBe('default');
-    });
+		expect(result.audioDeviceId).toBe('default');
+	});
 
-    it('should keep existing device ID when already set', async () => {
-        const devices: MediaDeviceInfo[] = [
-            {
-                deviceId: 'default',
-                label: 'Default - Microphone',
-                kind: 'audioinput',
-                groupId: 'group1',
-                toJSON: () => ({}),
-            },
-        ] as MediaDeviceInfo[];
+	it('should keep existing device ID when already set', async () => {
+		const devices: MediaDeviceInfo[] = [
+			{
+				deviceId: 'default',
+				label: 'Default - Microphone',
+				kind: 'audioinput',
+				groupId: 'group1',
+				toJSON: () => ({}),
+			},
+		] as MediaDeviceInfo[];
 
-        mockGetUserMedia.mockResolvedValue({ getTracks: () => [] });
-        mockEnumerateDevices.mockResolvedValue(devices);
+		mockGetUserMedia.mockResolvedValue({ getTracks: () => [] });
+		mockEnumerateDevices.mockResolvedValue(devices);
 
-        const result = await mergeSettingsAsync({ audioDeviceId: 'my-custom-device' });
+		const result = await mergeSettingsAsync({
+			audioDeviceId: 'my-custom-device',
+		});
 
-        expect(result.audioDeviceId).toBe('my-custom-device');
-    });
+		expect(result.audioDeviceId).toBe('my-custom-device');
+	});
 
-    it('should leave audioDeviceId empty when no default device available', async () => {
-        mockGetUserMedia.mockRejectedValue(new Error('Permission denied'));
+	it('should leave audioDeviceId empty when no default device available', async () => {
+		mockGetUserMedia.mockRejectedValue(new Error('Permission denied'));
 
-        const result = await mergeSettingsAsync({});
+		const result = await mergeSettingsAsync({});
 
-        expect(result.audioDeviceId).toBe('');
-    });
+		expect(result.audioDeviceId).toBe('');
+	});
 
-    it('should preserve other settings while auto-selecting device', async () => {
-        const devices: MediaDeviceInfo[] = [
-            {
-                deviceId: 'default',
-                label: 'Default - Microphone',
-                kind: 'audioinput',
-                groupId: 'group1',
-                toJSON: () => ({}),
-            },
-        ] as MediaDeviceInfo[];
+	it('should preserve other settings while auto-selecting device', async () => {
+		const devices: MediaDeviceInfo[] = [
+			{
+				deviceId: 'default',
+				label: 'Default - Microphone',
+				kind: 'audioinput',
+				groupId: 'group1',
+				toJSON: () => ({}),
+			},
+		] as MediaDeviceInfo[];
 
-        mockGetUserMedia.mockResolvedValue({ getTracks: () => [] });
-        mockEnumerateDevices.mockResolvedValue(devices);
+		mockGetUserMedia.mockResolvedValue({ getTracks: () => [] });
+		mockEnumerateDevices.mockResolvedValue(devices);
 
-        const result = await mergeSettingsAsync({
-            recordingFormat: 'wav',
-            sampleRate: 48000,
-        });
+		const result = await mergeSettingsAsync({
+			recordingFormat: 'wav',
+			sampleRate: 48000,
+		});
 
-        expect(result.audioDeviceId).toBe('default');
-        expect(result.recordingFormat).toBe('wav');
-        expect(result.sampleRate).toBe(48000);
-        expect(result.filePrefix).toBe(DEFAULT_SETTINGS.filePrefix);
-    });
+		expect(result.audioDeviceId).toBe('default');
+		expect(result.recordingFormat).toBe('wav');
+		expect(result.sampleRate).toBe(48000);
+		expect(result.filePrefix).toBe(DEFAULT_SETTINGS.filePrefix);
+	});
 });

--- a/tests/unit/Settings.validation.test.ts
+++ b/tests/unit/Settings.validation.test.ts
@@ -4,126 +4,142 @@
  */
 
 import {
-    AudioRecorderSettings,
-    DEFAULT_SETTINGS,
-    validateSettings,
+	AudioRecorderSettings,
+	DEFAULT_SETTINGS,
+	validateSettings,
 } from '../../src/settings/Settings';
 import { SettingsValidationError } from '../../src/errors';
 
 describe('validateSettings', () => {
-    it('should throw SettingsValidationError when audioDeviceId is empty', () => {
-        const settings: AudioRecorderSettings = {
-            ...DEFAULT_SETTINGS,
-            audioDeviceId: '',
-        };
-        expect(() => validateSettings(settings)).toThrow(SettingsValidationError);
-        expect(() => validateSettings(settings)).toThrow(
-            /Audio device is not selected/,
-        );
-    });
+	it('should throw SettingsValidationError when audioDeviceId is empty', () => {
+		const settings: AudioRecorderSettings = {
+			...DEFAULT_SETTINGS,
+			audioDeviceId: '',
+		};
+		expect(() => validateSettings(settings)).toThrow(
+			SettingsValidationError,
+		);
+		expect(() => validateSettings(settings)).toThrow(
+			/Audio device is not selected/,
+		);
+	});
 
-    it('should throw SettingsValidationError when audioDeviceId is whitespace', () => {
-        const settings: AudioRecorderSettings = {
-            ...DEFAULT_SETTINGS,
-            audioDeviceId: '   ',
-        };
-        expect(() => validateSettings(settings)).toThrow(SettingsValidationError);
-    });
+	it('should throw SettingsValidationError when audioDeviceId is whitespace', () => {
+		const settings: AudioRecorderSettings = {
+			...DEFAULT_SETTINGS,
+			audioDeviceId: '   ',
+		};
+		expect(() => validateSettings(settings)).toThrow(
+			SettingsValidationError,
+		);
+	});
 
-    it('should throw SettingsValidationError when sampleRate is zero', () => {
-        const settings: AudioRecorderSettings = {
-            ...DEFAULT_SETTINGS,
-            audioDeviceId: 'valid-device',
-            sampleRate: 0,
-        };
-        expect(() => validateSettings(settings)).toThrow(SettingsValidationError);
-        expect(() => validateSettings(settings)).toThrow(
-            /Sample rate must be a positive number/,
-        );
-    });
+	it('should throw SettingsValidationError when sampleRate is zero', () => {
+		const settings: AudioRecorderSettings = {
+			...DEFAULT_SETTINGS,
+			audioDeviceId: 'valid-device',
+			sampleRate: 0,
+		};
+		expect(() => validateSettings(settings)).toThrow(
+			SettingsValidationError,
+		);
+		expect(() => validateSettings(settings)).toThrow(
+			/Sample rate must be a positive number/,
+		);
+	});
 
-    it('should throw SettingsValidationError when sampleRate is negative', () => {
-        const settings: AudioRecorderSettings = {
-            ...DEFAULT_SETTINGS,
-            audioDeviceId: 'valid-device',
-            sampleRate: -44100,
-        };
-        expect(() => validateSettings(settings)).toThrow(SettingsValidationError);
-    });
+	it('should throw SettingsValidationError when sampleRate is negative', () => {
+		const settings: AudioRecorderSettings = {
+			...DEFAULT_SETTINGS,
+			audioDeviceId: 'valid-device',
+			sampleRate: -44100,
+		};
+		expect(() => validateSettings(settings)).toThrow(
+			SettingsValidationError,
+		);
+	});
 
-    it('should throw SettingsValidationError when recordingFormat is empty', () => {
-        const settings: AudioRecorderSettings = {
-            ...DEFAULT_SETTINGS,
-            audioDeviceId: 'valid-device',
-            recordingFormat: '',
-        };
-        expect(() => validateSettings(settings)).toThrow(SettingsValidationError);
-        expect(() => validateSettings(settings)).toThrow(
-            /Recording format is not selected/,
-        );
-    });
+	it('should throw SettingsValidationError when recordingFormat is empty', () => {
+		const settings: AudioRecorderSettings = {
+			...DEFAULT_SETTINGS,
+			audioDeviceId: 'valid-device',
+			recordingFormat: '',
+		};
+		expect(() => validateSettings(settings)).toThrow(
+			SettingsValidationError,
+		);
+		expect(() => validateSettings(settings)).toThrow(
+			/Recording format is not selected/,
+		);
+	});
 
-    it('should throw when multi-track enabled but no sources configured', () => {
-        const settings: AudioRecorderSettings = {
-            ...DEFAULT_SETTINGS,
-            audioDeviceId: 'valid-device',
-            enableMultiTrack: true,
-            trackAudioSources: new Map(),
-        };
-        expect(() => validateSettings(settings)).toThrow(SettingsValidationError);
-        expect(() => validateSettings(settings)).toThrow(
-            /no audio sources are selected/,
-        );
-    });
+	it('should throw when multi-track enabled but no sources configured', () => {
+		const settings: AudioRecorderSettings = {
+			...DEFAULT_SETTINGS,
+			audioDeviceId: 'valid-device',
+			enableMultiTrack: true,
+			trackAudioSources: new Map(),
+		};
+		expect(() => validateSettings(settings)).toThrow(
+			SettingsValidationError,
+		);
+		expect(() => validateSettings(settings)).toThrow(
+			/no audio sources are selected/,
+		);
+	});
 
-    it('should throw when multi-track source has empty deviceId', () => {
-        const settings: AudioRecorderSettings = {
-            ...DEFAULT_SETTINGS,
-            audioDeviceId: 'valid-device',
-            enableMultiTrack: true,
-            trackAudioSources: new Map([
-                [1, { deviceId: 'device-1' }],
-                [2, { deviceId: '' }],
-            ]),
-        };
-        expect(() => validateSettings(settings)).toThrow(SettingsValidationError);
-        expect(() => validateSettings(settings)).toThrow(
-            /Track 2 has no audio source selected/,
-        );
-    });
+	it('should throw when multi-track source has empty deviceId', () => {
+		const settings: AudioRecorderSettings = {
+			...DEFAULT_SETTINGS,
+			audioDeviceId: 'valid-device',
+			enableMultiTrack: true,
+			trackAudioSources: new Map([
+				[1, { deviceId: 'device-1' }],
+				[2, { deviceId: '' }],
+			]),
+		};
+		expect(() => validateSettings(settings)).toThrow(
+			SettingsValidationError,
+		);
+		expect(() => validateSettings(settings)).toThrow(
+			/Track 2 has no audio source selected/,
+		);
+	});
 
-    it('should pass validation with valid settings', () => {
-        const settings: AudioRecorderSettings = {
-            ...DEFAULT_SETTINGS,
-            audioDeviceId: 'valid-device',
-        };
-        expect(() => validateSettings(settings)).not.toThrow();
-    });
+	it('should pass validation with valid settings', () => {
+		const settings: AudioRecorderSettings = {
+			...DEFAULT_SETTINGS,
+			audioDeviceId: 'valid-device',
+		};
+		expect(() => validateSettings(settings)).not.toThrow();
+	});
 
-    it('should pass validation with valid multi-track settings', () => {
-        const settings: AudioRecorderSettings = {
-            ...DEFAULT_SETTINGS,
-            audioDeviceId: 'valid-device',
-            enableMultiTrack: true,
-            trackAudioSources: new Map([
-                [1, { deviceId: 'device-1' }],
-                [2, { deviceId: 'device-2' }],
-            ]),
-        };
-        expect(() => validateSettings(settings)).not.toThrow();
-    });
+	it('should pass validation with valid multi-track settings', () => {
+		const settings: AudioRecorderSettings = {
+			...DEFAULT_SETTINGS,
+			audioDeviceId: 'valid-device',
+			enableMultiTrack: true,
+			trackAudioSources: new Map([
+				[1, { deviceId: 'device-1' }],
+				[2, { deviceId: 'device-2' }],
+			]),
+		};
+		expect(() => validateSettings(settings)).not.toThrow();
+	});
 
-    it('should include field name in error message', () => {
-        const settings: AudioRecorderSettings = {
-            ...DEFAULT_SETTINGS,
-            audioDeviceId: '',
-        };
-        try {
-            validateSettings(settings);
-            fail('Expected error to be thrown');
-        } catch (error) {
-            expect(error).toBeInstanceOf(SettingsValidationError);
-            expect((error as SettingsValidationError).field).toBe('audioDeviceId');
-        }
-    });
+	it('should include field name in error message', () => {
+		const settings: AudioRecorderSettings = {
+			...DEFAULT_SETTINGS,
+			audioDeviceId: '',
+		};
+		try {
+			validateSettings(settings);
+			fail('Expected error to be thrown');
+		} catch (error) {
+			expect(error).toBeInstanceOf(SettingsValidationError);
+			expect((error as SettingsValidationError).field).toBe(
+				'audioDeviceId',
+			);
+		}
+	});
 });

--- a/tests/unit/StatusBar.test.ts
+++ b/tests/unit/StatusBar.test.ts
@@ -7,12 +7,17 @@
 
 import { updateStatusBar, initializeStatusBar } from '../../src/ui/StatusBar';
 import { RecordingStatus } from '../../src/types';
+import type { RecordingControls } from '../../src/types';
+
+jest.mock('obsidian', () => ({
+	setIcon: jest.fn(),
+}));
 
 /**
  * Polyfill Obsidian's HTMLElement extensions for jsdom.
  */
 function addObsidianElementMethods(el: HTMLElement): HTMLElement {
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- required for patching Obsidian DOM extensions
 	const obsEl = el as any;
 	obsEl.empty = function () {
 		while (this.firstChild) {
@@ -49,7 +54,9 @@ describe('StatusBar', () => {
 	let statusBarItem: HTMLElement;
 
 	beforeEach(() => {
-		statusBarItem = addObsidianElementMethods(document.createElement('div'));
+		statusBarItem = addObsidianElementMethods(
+			document.createElement('div'),
+		);
 	});
 
 	describe('updateStatusBar', () => {
@@ -62,7 +69,7 @@ describe('StatusBar', () => {
 		it('should show "Recording..." and add is-recording class when recording', () => {
 			updateStatusBar(statusBarItem, RecordingStatus.Recording);
 
-			expect(statusBarItem.textContent).toBe('Recording...');
+			expect(statusBarItem.textContent).toContain('Recording...');
 			expect(statusBarItem.classList.contains('is-recording')).toBe(true);
 			expect(statusBarItem.classList.contains('is-saving')).toBe(false);
 		});
@@ -70,7 +77,7 @@ describe('StatusBar', () => {
 		it('should show "Recording paused" when paused', () => {
 			updateStatusBar(statusBarItem, RecordingStatus.Paused);
 
-			expect(statusBarItem.textContent).toBe('Recording paused');
+			expect(statusBarItem.textContent).toContain('Recording paused');
 			expect(statusBarItem.classList.contains('is-recording')).toBe(true);
 		});
 
@@ -82,7 +89,9 @@ describe('StatusBar', () => {
 			updateStatusBar(statusBarItem, RecordingStatus.Idle);
 
 			expect(statusBarItem.textContent).toBe('');
-			expect(statusBarItem.classList.contains('is-recording')).toBe(false);
+			expect(statusBarItem.classList.contains('is-recording')).toBe(
+				false,
+			);
 			expect(statusBarItem.classList.contains('is-saving')).toBe(false);
 		});
 
@@ -93,14 +102,20 @@ describe('StatusBar', () => {
 			});
 
 			expect(statusBarItem.classList.contains('is-saving')).toBe(true);
-			expect(statusBarItem.classList.contains('is-recording')).toBe(false);
+			expect(statusBarItem.classList.contains('is-recording')).toBe(
+				false,
+			);
 
 			const text = statusBarItem.querySelector('span');
 			expect(text?.textContent).toBe('Assembling audio...');
 
-			const progressBar = statusBarItem.querySelector('.aar-save-progress-bar') as HTMLElement;
+			const progressBar = statusBarItem.querySelector(
+				'.aar-save-progress-bar',
+			) as HTMLElement;
 			expect(progressBar).not.toBeNull();
-			expect(progressBar?.style.getPropertyValue('--save-progress')).toBe('40%');
+			expect(
+				progressBar?.style.getPropertyValue('--save-progress'),
+			).toBe('40%');
 		});
 
 		it('should show default "Saving..." when no progress provided', () => {
@@ -109,8 +124,12 @@ describe('StatusBar', () => {
 			const text = statusBarItem.querySelector('span');
 			expect(text?.textContent).toBe('Saving...');
 
-			const progressBar = statusBarItem.querySelector('.aar-save-progress-bar') as HTMLElement;
-			expect(progressBar?.style.getPropertyValue('--save-progress')).toBe('0%');
+			const progressBar = statusBarItem.querySelector(
+				'.aar-save-progress-bar',
+			) as HTMLElement;
+			expect(
+				progressBar?.style.getPropertyValue('--save-progress'),
+			).toBe('0%');
 		});
 
 		it('should have progress container with correct classes', () => {
@@ -119,7 +138,8 @@ describe('StatusBar', () => {
 				description: 'Writing file...',
 			});
 
-			const container = statusBarItem.querySelector('.aar-save-progress');
+			const container =
+				statusBarItem.querySelector('.aar-save-progress');
 			expect(container).not.toBeNull();
 
 			const bar = container?.querySelector('.aar-save-progress-bar');
@@ -143,11 +163,15 @@ describe('StatusBar', () => {
 				percent: 50,
 				description: 'Assembling...',
 			});
-			expect(statusBarItem.querySelector('.aar-save-progress')).not.toBeNull();
+			expect(
+				statusBarItem.querySelector('.aar-save-progress'),
+			).not.toBeNull();
 
 			updateStatusBar(statusBarItem, RecordingStatus.Recording);
-			expect(statusBarItem.querySelector('.aar-save-progress')).toBeNull();
-			expect(statusBarItem.textContent).toBe('Recording...');
+			expect(
+				statusBarItem.querySelector('.aar-save-progress'),
+			).toBeNull();
+			expect(statusBarItem.textContent).toContain('Recording...');
 		});
 
 		it('should handle default case same as idle', () => {
@@ -156,7 +180,231 @@ describe('StatusBar', () => {
 			updateStatusBar(statusBarItem, 'unknown' as RecordingStatus);
 
 			expect(statusBarItem.textContent).toBe('');
-			expect(statusBarItem.classList.contains('is-recording')).toBe(false);
+			expect(statusBarItem.classList.contains('is-recording')).toBe(
+				false,
+			);
+		});
+	});
+
+	describe('recording controls', () => {
+		it('should render pause and stop buttons when recording with controls', () => {
+			const controls: RecordingControls = {
+				onPauseResume: jest.fn(),
+				onStop: jest.fn(),
+				isPaused: false,
+			};
+
+			updateStatusBar(
+				statusBarItem,
+				RecordingStatus.Recording,
+				undefined,
+				controls,
+			);
+
+			const container = statusBarItem.querySelector(
+				'.aar-recording-controls',
+			);
+			expect(container).not.toBeNull();
+
+			const label = statusBarItem.querySelector('.aar-recording-label');
+			expect(label?.textContent).toBe('Recording...');
+
+			const buttons = statusBarItem.querySelectorAll('.aar-control-btn');
+			expect(buttons.length).toBe(2);
+		});
+
+		it('should render resume and stop buttons when paused with controls', () => {
+			const controls: RecordingControls = {
+				onPauseResume: jest.fn(),
+				onStop: jest.fn(),
+				isPaused: true,
+			};
+
+			updateStatusBar(
+				statusBarItem,
+				RecordingStatus.Paused,
+				undefined,
+				controls,
+			);
+
+			const label = statusBarItem.querySelector('.aar-recording-label');
+			expect(label?.textContent).toBe('Recording paused');
+
+			const buttons = statusBarItem.querySelectorAll('.aar-control-btn');
+			expect(buttons.length).toBe(2);
+
+			// First button should have aria-label "Resume recording"
+			expect(buttons[0].getAttribute('aria-label')).toBe(
+				'Resume recording',
+			);
+			expect(buttons[1].getAttribute('aria-label')).toBe(
+				'Stop recording',
+			);
+		});
+
+		it('should call onPauseResume when pause button is clicked', () => {
+			const controls: RecordingControls = {
+				onPauseResume: jest.fn(),
+				onStop: jest.fn(),
+				isPaused: false,
+			};
+
+			updateStatusBar(
+				statusBarItem,
+				RecordingStatus.Recording,
+				undefined,
+				controls,
+			);
+
+			const buttons = statusBarItem.querySelectorAll('.aar-control-btn');
+			expect(buttons[0].getAttribute('aria-label')).toBe(
+				'Pause recording',
+			);
+
+			buttons[0].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+			expect(controls.onPauseResume).toHaveBeenCalledTimes(1);
+		});
+
+		it('should call onStop when stop button is clicked', () => {
+			const controls: RecordingControls = {
+				onPauseResume: jest.fn(),
+				onStop: jest.fn(),
+				isPaused: false,
+			};
+
+			updateStatusBar(
+				statusBarItem,
+				RecordingStatus.Recording,
+				undefined,
+				controls,
+			);
+
+			const buttons = statusBarItem.querySelectorAll('.aar-control-btn');
+			buttons[1].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+			expect(controls.onStop).toHaveBeenCalledTimes(1);
+		});
+
+		it('should not render buttons when controls are not provided', () => {
+			updateStatusBar(statusBarItem, RecordingStatus.Recording);
+
+			const buttons = statusBarItem.querySelectorAll('.aar-control-btn');
+			expect(buttons.length).toBe(0);
+
+			// Should still show recording label in container
+			const label = statusBarItem.querySelector('.aar-recording-label');
+			expect(label?.textContent).toBe('Recording...');
+		});
+
+		it('should set accessible attributes on control buttons', () => {
+			const controls: RecordingControls = {
+				onPauseResume: jest.fn(),
+				onStop: jest.fn(),
+				isPaused: false,
+			};
+
+			updateStatusBar(
+				statusBarItem,
+				RecordingStatus.Recording,
+				undefined,
+				controls,
+			);
+
+			const buttons = statusBarItem.querySelectorAll('.aar-control-btn');
+			for (const button of buttons) {
+				expect(button.getAttribute('role')).toBe('button');
+				expect(button.getAttribute('tabindex')).toBe('0');
+				expect(button.getAttribute('aria-label')).toBeTruthy();
+			}
+		});
+
+		it('should stop event propagation on button click', () => {
+			const controls: RecordingControls = {
+				onPauseResume: jest.fn(),
+				onStop: jest.fn(),
+				isPaused: false,
+			};
+
+			updateStatusBar(
+				statusBarItem,
+				RecordingStatus.Recording,
+				undefined,
+				controls,
+			);
+
+			const buttons = statusBarItem.querySelectorAll('.aar-control-btn');
+			const event = new MouseEvent('click', { bubbles: true });
+			const stopPropSpy = jest.spyOn(event, 'stopPropagation');
+
+			buttons[0].dispatchEvent(event);
+			expect(stopPropSpy).toHaveBeenCalled();
+		});
+
+		it('should show buttons container with correct class', () => {
+			const controls: RecordingControls = {
+				onPauseResume: jest.fn(),
+				onStop: jest.fn(),
+				isPaused: false,
+			};
+
+			updateStatusBar(
+				statusBarItem,
+				RecordingStatus.Recording,
+				undefined,
+				controls,
+			);
+
+			const buttonsContainer = statusBarItem.querySelector(
+				'.aar-recording-buttons',
+			);
+			expect(buttonsContainer).not.toBeNull();
+		});
+
+		it('should clear controls when transitioning to idle', () => {
+			const controls: RecordingControls = {
+				onPauseResume: jest.fn(),
+				onStop: jest.fn(),
+				isPaused: false,
+			};
+
+			updateStatusBar(
+				statusBarItem,
+				RecordingStatus.Recording,
+				undefined,
+				controls,
+			);
+			expect(
+				statusBarItem.querySelectorAll('.aar-control-btn').length,
+			).toBe(2);
+
+			updateStatusBar(statusBarItem, RecordingStatus.Idle);
+			expect(
+				statusBarItem.querySelectorAll('.aar-control-btn').length,
+			).toBe(0);
+		});
+
+		it('should clear controls when transitioning to saving', () => {
+			const controls: RecordingControls = {
+				onPauseResume: jest.fn(),
+				onStop: jest.fn(),
+				isPaused: false,
+			};
+
+			updateStatusBar(
+				statusBarItem,
+				RecordingStatus.Recording,
+				undefined,
+				controls,
+			);
+
+			updateStatusBar(statusBarItem, RecordingStatus.Saving, {
+				percent: 10,
+				description: 'Saving...',
+			});
+
+			expect(
+				statusBarItem.querySelectorAll('.aar-control-btn').length,
+			).toBe(0);
+			expect(statusBarItem.classList.contains('is-saving')).toBe(true);
 		});
 	});
 
@@ -174,7 +422,9 @@ describe('StatusBar', () => {
 			initializeStatusBar(statusBarItem);
 
 			expect(statusBarItem.textContent).toBe('');
-			expect(statusBarItem.classList.contains('is-recording')).toBe(false);
+			expect(statusBarItem.classList.contains('is-recording')).toBe(
+				false,
+			);
 		});
 	});
 });

--- a/tests/unit/StatusBar.test.ts
+++ b/tests/unit/StatusBar.test.ts
@@ -113,9 +113,9 @@ describe('StatusBar', () => {
 				'.aar-save-progress-bar',
 			) as HTMLElement;
 			expect(progressBar).not.toBeNull();
-			expect(
-				progressBar?.style.getPropertyValue('--save-progress'),
-			).toBe('40%');
+			expect(progressBar?.style.getPropertyValue('--save-progress')).toBe(
+				'40%',
+			);
 		});
 
 		it('should show default "Saving..." when no progress provided', () => {
@@ -127,9 +127,9 @@ describe('StatusBar', () => {
 			const progressBar = statusBarItem.querySelector(
 				'.aar-save-progress-bar',
 			) as HTMLElement;
-			expect(
-				progressBar?.style.getPropertyValue('--save-progress'),
-			).toBe('0%');
+			expect(progressBar?.style.getPropertyValue('--save-progress')).toBe(
+				'0%',
+			);
 		});
 
 		it('should have progress container with correct classes', () => {
@@ -138,8 +138,7 @@ describe('StatusBar', () => {
 				description: 'Writing file...',
 			});
 
-			const container =
-				statusBarItem.querySelector('.aar-save-progress');
+			const container = statusBarItem.querySelector('.aar-save-progress');
 			expect(container).not.toBeNull();
 
 			const bar = container?.querySelector('.aar-save-progress-bar');
@@ -261,7 +260,9 @@ describe('StatusBar', () => {
 				'Pause recording',
 			);
 
-			buttons[0].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+			buttons[0].dispatchEvent(
+				new MouseEvent('click', { bubbles: true }),
+			);
 			expect(controls.onPauseResume).toHaveBeenCalledTimes(1);
 		});
 
@@ -280,7 +281,9 @@ describe('StatusBar', () => {
 			);
 
 			const buttons = statusBarItem.querySelectorAll('.aar-control-btn');
-			buttons[1].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+			buttons[1].dispatchEvent(
+				new MouseEvent('click', { bubbles: true }),
+			);
 			expect(controls.onStop).toHaveBeenCalledTimes(1);
 		});
 

--- a/tests/unit/SystemDiagnostics.test.ts
+++ b/tests/unit/SystemDiagnostics.test.ts
@@ -8,11 +8,11 @@ import { SystemDiagnostics } from 'src/diagnostics/SystemDiagnostics';
 import type { AudioRecorderSettings } from 'src/settings/Settings';
 import * as AudioCapabilityDetector from 'src/recording/AudioCapabilityDetector';
 import {
-    FORMAT_WEBM,
-    FORMAT_OGG,
-    FORMAT_MP4,
-    DEFAULT_SAMPLE_RATE,
-    DEFAULT_BITRATE,
+	FORMAT_WEBM,
+	FORMAT_OGG,
+	FORMAT_MP4,
+	DEFAULT_SAMPLE_RATE,
+	DEFAULT_BITRATE,
 } from 'src/recording/AudioCapabilityDetector';
 
 // ---------------------------------------------------------------------------
@@ -20,37 +20,37 @@ import {
 // ---------------------------------------------------------------------------
 
 function makeSettings(
-    overrides: Partial<AudioRecorderSettings> = {},
+	overrides: Partial<AudioRecorderSettings> = {},
 ): AudioRecorderSettings {
-    return {
-        recordingFormat: FORMAT_WEBM,
-        bitrate: DEFAULT_BITRATE,
-        sampleRate: DEFAULT_SAMPLE_RATE,
-        saveFolder: 'recordings',
-        saveNearActiveFile: false,
-        activeFileSubfolder: '',
-        filePrefix: 'recording',
-        startStopHotkey: '',
-        pauseHotkey: '',
-        resumeHotkey: '',
-        audioDeviceId: 'device-1',
-        enableMultiTrack: false,
-        maxTracks: 2,
-        outputMode: 'single',
-        useSourceNamesForTracks: true,
-        trackAudioSources: new Map([
-            [1, { deviceId: 'dev-a' }],
-            [2, { deviceId: 'dev-b' }],
-        ]),
-        debug: true,
-        ...overrides,
-    };
+	return {
+		recordingFormat: FORMAT_WEBM,
+		bitrate: DEFAULT_BITRATE,
+		sampleRate: DEFAULT_SAMPLE_RATE,
+		saveFolder: 'recordings',
+		saveNearActiveFile: false,
+		activeFileSubfolder: '',
+		filePrefix: 'recording',
+		startStopHotkey: '',
+		pauseHotkey: '',
+		resumeHotkey: '',
+		audioDeviceId: 'device-1',
+		enableMultiTrack: false,
+		maxTracks: 2,
+		outputMode: 'single',
+		useSourceNamesForTracks: true,
+		trackAudioSources: new Map([
+			[1, { deviceId: 'dev-a' }],
+			[2, { deviceId: 'dev-b' }],
+		]),
+		debug: true,
+		...overrides,
+	};
 }
 
 function makeApp(apiVersion = '1.5.0') {
-    return { apiVersion } as unknown as Parameters<
-        typeof SystemDiagnostics.collectEnvironment
-    >[0];
+	return { apiVersion } as unknown as Parameters<
+		typeof SystemDiagnostics.collectEnvironment
+	>[0];
 }
 
 // ---------------------------------------------------------------------------
@@ -58,37 +58,37 @@ function makeApp(apiVersion = '1.5.0') {
 // ---------------------------------------------------------------------------
 
 describe('SystemDiagnostics.collectPluginSettings', () => {
-    it('serializes all scalar settings fields', () => {
-        const settings = makeSettings();
-        const result = SystemDiagnostics.collectPluginSettings(settings);
+	it('serializes all scalar settings fields', () => {
+		const settings = makeSettings();
+		const result = SystemDiagnostics.collectPluginSettings(settings);
 
-        expect(result.recordingFormat).toBe(FORMAT_WEBM);
-        expect(result.bitrate).toBe(DEFAULT_BITRATE);
-        expect(result.sampleRate).toBe(DEFAULT_SAMPLE_RATE);
-        expect(result.saveFolder).toBe('recordings');
-        expect(result.saveNearActiveFile).toBe(false);
-        expect(result.activeFileSubfolder).toBe('');
-        expect(result.filePrefix).toBe('recording');
-        expect(result.enableMultiTrack).toBe(false);
-        expect(result.maxTracks).toBe(2);
-        expect(result.outputMode).toBe('single');
-        expect(result.audioDeviceId).toBe('device-1');
-        expect(result.debug).toBe(true);
-    });
+		expect(result.recordingFormat).toBe(FORMAT_WEBM);
+		expect(result.bitrate).toBe(DEFAULT_BITRATE);
+		expect(result.sampleRate).toBe(DEFAULT_SAMPLE_RATE);
+		expect(result.saveFolder).toBe('recordings');
+		expect(result.saveNearActiveFile).toBe(false);
+		expect(result.activeFileSubfolder).toBe('');
+		expect(result.filePrefix).toBe('recording');
+		expect(result.enableMultiTrack).toBe(false);
+		expect(result.maxTracks).toBe(2);
+		expect(result.outputMode).toBe('single');
+		expect(result.audioDeviceId).toBe('device-1');
+		expect(result.debug).toBe(true);
+	});
 
-    it('serializes trackAudioSources Map to a plain Record', () => {
-        const settings = makeSettings();
-        const result = SystemDiagnostics.collectPluginSettings(settings);
+	it('serializes trackAudioSources Map to a plain Record', () => {
+		const settings = makeSettings();
+		const result = SystemDiagnostics.collectPluginSettings(settings);
 
-        expect(result.trackAudioSources).toEqual({ 1: 'dev-a', 2: 'dev-b' });
-    });
+		expect(result.trackAudioSources).toEqual({ 1: 'dev-a', 2: 'dev-b' });
+	});
 
-    it('handles empty trackAudioSources', () => {
-        const settings = makeSettings({ trackAudioSources: new Map() });
-        const result = SystemDiagnostics.collectPluginSettings(settings);
+	it('handles empty trackAudioSources', () => {
+		const settings = makeSettings({ trackAudioSources: new Map() });
+		const result = SystemDiagnostics.collectPluginSettings(settings);
 
-        expect(result.trackAudioSources).toEqual({});
-    });
+		expect(result.trackAudioSources).toEqual({});
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -96,72 +96,72 @@ describe('SystemDiagnostics.collectPluginSettings', () => {
 // ---------------------------------------------------------------------------
 
 describe('SystemDiagnostics.collectEnvironment', () => {
-    const originalProcess = global.process;
+	const originalProcess = global.process;
 
-    afterEach(() => {
-        // eslint-disable-next-line
+	afterEach(() => {
+		// eslint-disable-next-line
         (global as unknown as { process: NodeJS.Process }).process = originalProcess;
-    });
+	});
 
-    it('reads apiVersion from app', () => {
-        const app = makeApp('1.7.3');
-        const result = SystemDiagnostics.collectEnvironment(app);
+	it('reads apiVersion from app', () => {
+		const app = makeApp('1.7.3');
+		const result = SystemDiagnostics.collectEnvironment(app);
 
-        expect(result.obsidianVersion).toBe('1.7.3');
-    });
+		expect(result.obsidianVersion).toBe('1.7.3');
+	});
 
-    it('reads electron and node versions from process.versions', () => {
-        const proc = {
-            versions: { electron: '28.0.0', node: '20.11.0' },
-            platform: 'win32',
-            arch: 'x64',
-        };
-        // eslint-disable-next-line -- test override of global
+	it('reads electron and node versions from process.versions', () => {
+		const proc = {
+			versions: { electron: '28.0.0', node: '20.11.0' },
+			platform: 'win32',
+			arch: 'x64',
+		};
+		// eslint-disable-next-line -- test override of global
         (global as unknown as { process: typeof proc }).process = proc;
 
-        const result = SystemDiagnostics.collectEnvironment(makeApp());
+		const result = SystemDiagnostics.collectEnvironment(makeApp());
 
-        expect(result.electronVersion).toBe('28.0.0');
-        expect(result.nodeVersion).toBe('20.11.0');
-        expect(result.platform).toBe('win32');
-        expect(result.arch).toBe('x64');
-    });
+		expect(result.electronVersion).toBe('28.0.0');
+		expect(result.nodeVersion).toBe('20.11.0');
+		expect(result.platform).toBe('win32');
+		expect(result.arch).toBe('x64');
+	});
 
-    it('uses "unknown" when process.platform is absent', () => {
-        const proc = { versions: { electron: '28.0.0', node: '20.11.0' } };
-        // eslint-disable-next-line -- test override of global
+	it('uses "unknown" when process.platform is absent', () => {
+		const proc = { versions: { electron: '28.0.0', node: '20.11.0' } };
+		// eslint-disable-next-line -- test override of global
         (global as unknown as { process: typeof proc }).process = proc;
 
-        const result = SystemDiagnostics.collectEnvironment(makeApp());
+		const result = SystemDiagnostics.collectEnvironment(makeApp());
 
-        expect(result.platform).toBe('unknown');
-    });
+		expect(result.platform).toBe('unknown');
+	});
 
-    it('returns "unknown" for electronVersion when process is undefined', () => {
-        // eslint-disable-next-line -- test override of global
+	it('returns "unknown" for electronVersion when process is undefined', () => {
+		// eslint-disable-next-line -- test override of global
         (global as unknown as { process: undefined }).process = undefined;
 
-        const result = SystemDiagnostics.collectEnvironment(makeApp());
+		const result = SystemDiagnostics.collectEnvironment(makeApp());
 
-        expect(result.electronVersion).toBe('unknown');
-        expect(result.nodeVersion).toBe('unknown');
-        expect(result.arch).toBe('unknown');
-    });
+		expect(result.electronVersion).toBe('unknown');
+		expect(result.nodeVersion).toBe('unknown');
+		expect(result.arch).toBe('unknown');
+	});
 
-    it('returns "unknown" obsidianVersion when app has no apiVersion', () => {
-        const app = {} as Parameters<
-            typeof SystemDiagnostics.collectEnvironment
-        >[0];
-        const result = SystemDiagnostics.collectEnvironment(app);
+	it('returns "unknown" obsidianVersion when app has no apiVersion', () => {
+		const app = {} as Parameters<
+			typeof SystemDiagnostics.collectEnvironment
+		>[0];
+		const result = SystemDiagnostics.collectEnvironment(app);
 
-        expect(result.obsidianVersion).toBe('unknown');
-    });
+		expect(result.obsidianVersion).toBe('unknown');
+	});
 
-    it('returns "unknown" for userAgent', () => {
-        const result = SystemDiagnostics.collectEnvironment(makeApp());
+	it('returns "unknown" for userAgent', () => {
+		const result = SystemDiagnostics.collectEnvironment(makeApp());
 
-        expect(result.userAgent).toBe('unknown');
-    });
+		expect(result.userAgent).toBe('unknown');
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -169,76 +169,76 @@ describe('SystemDiagnostics.collectEnvironment', () => {
 // ---------------------------------------------------------------------------
 
 describe('SystemDiagnostics.collectAudioDevices', () => {
-    const mockEnumerate = jest.fn();
+	const mockEnumerate = jest.fn();
 
-    beforeEach(() => {
-        Object.defineProperty(global.navigator, 'mediaDevices', {
-            value: { enumerateDevices: mockEnumerate },
-            configurable: true,
-        });
-    });
+	beforeEach(() => {
+		Object.defineProperty(global.navigator, 'mediaDevices', {
+			value: { enumerateDevices: mockEnumerate },
+			configurable: true,
+		});
+	});
 
-    it('returns audioinput and audiooutput devices', async () => {
-        mockEnumerate.mockResolvedValueOnce([
-            {
-                deviceId: 'in-1',
-                label: 'Mic 1',
-                groupId: 'grp-1',
-                kind: 'audioinput',
-            },
-            {
-                deviceId: 'out-1',
-                label: 'Speaker 1',
-                groupId: 'grp-2',
-                kind: 'audiooutput',
-            },
-            {
-                deviceId: 'vid-1',
-                label: 'Camera',
-                groupId: 'grp-3',
-                kind: 'videoinput',
-            },
-        ]);
+	it('returns audioinput and audiooutput devices', async () => {
+		mockEnumerate.mockResolvedValueOnce([
+			{
+				deviceId: 'in-1',
+				label: 'Mic 1',
+				groupId: 'grp-1',
+				kind: 'audioinput',
+			},
+			{
+				deviceId: 'out-1',
+				label: 'Speaker 1',
+				groupId: 'grp-2',
+				kind: 'audiooutput',
+			},
+			{
+				deviceId: 'vid-1',
+				label: 'Camera',
+				groupId: 'grp-3',
+				kind: 'videoinput',
+			},
+		]);
 
-        const result = await SystemDiagnostics.collectAudioDevices();
+		const result = await SystemDiagnostics.collectAudioDevices();
 
-        expect(result).toHaveLength(2);
-        expect(result[0]).toEqual({
-            deviceId: 'in-1',
-            label: 'Mic 1',
-            groupId: 'grp-1',
-            kind: 'audioinput',
-        });
-        expect(result[1]).toEqual({
-            deviceId: 'out-1',
-            label: 'Speaker 1',
-            groupId: 'grp-2',
-            kind: 'audiooutput',
-        });
-    });
+		expect(result).toHaveLength(2);
+		expect(result[0]).toEqual({
+			deviceId: 'in-1',
+			label: 'Mic 1',
+			groupId: 'grp-1',
+			kind: 'audioinput',
+		});
+		expect(result[1]).toEqual({
+			deviceId: 'out-1',
+			label: 'Speaker 1',
+			groupId: 'grp-2',
+			kind: 'audiooutput',
+		});
+	});
 
-    it('returns empty array when no audio devices exist', async () => {
-        mockEnumerate.mockResolvedValueOnce([]);
+	it('returns empty array when no audio devices exist', async () => {
+		mockEnumerate.mockResolvedValueOnce([]);
 
-        const result = await SystemDiagnostics.collectAudioDevices();
+		const result = await SystemDiagnostics.collectAudioDevices();
 
-        expect(result).toEqual([]);
-    });
+		expect(result).toEqual([]);
+	});
 
-    it('filters out videoinput devices', async () => {
-        mockEnumerate.mockResolvedValueOnce([
-            {
-                deviceId: 'vid-1',
-                label: 'Camera',
-                groupId: 'g1',
-                kind: 'videoinput',
-            },
-        ]);
+	it('filters out videoinput devices', async () => {
+		mockEnumerate.mockResolvedValueOnce([
+			{
+				deviceId: 'vid-1',
+				label: 'Camera',
+				groupId: 'g1',
+				kind: 'videoinput',
+			},
+		]);
 
-        const result = await SystemDiagnostics.collectAudioDevices();
+		const result = await SystemDiagnostics.collectAudioDevices();
 
-        expect(result).toHaveLength(0);
-    });
+		expect(result).toHaveLength(0);
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -246,158 +246,167 @@ describe('SystemDiagnostics.collectAudioDevices', () => {
 // ---------------------------------------------------------------------------
 
 describe('SystemDiagnostics.collectAudioCapabilities', () => {
-    const mockDetectCapabilities = jest.spyOn(
-        AudioCapabilityDetector,
-        'detectCapabilities',
-    );
-    const mockDetectCodecSupport = jest.spyOn(
-        AudioCapabilityDetector,
-        'detectCodecSupport',
-    );
+	const mockDetectCapabilities = jest.spyOn(
+		AudioCapabilityDetector,
+		'detectCapabilities',
+	);
+	const mockDetectCodecSupport = jest.spyOn(
+		AudioCapabilityDetector,
+		'detectCodecSupport',
+	);
 
-    beforeEach(() => {
-        mockDetectCapabilities.mockReset();
-        mockDetectCodecSupport.mockReset();
-        mockDetectCodecSupport.mockReturnValue([]);
-    });
+	beforeEach(() => {
+		mockDetectCapabilities.mockReset();
+		mockDetectCodecSupport.mockReset();
+		mockDetectCodecSupport.mockReturnValue([]);
+	});
 
-    it('maps detectCapabilities result to capabilities object', () => {
-        mockDetectCapabilities.mockReturnValueOnce({
-            supportedFormats: [FORMAT_WEBM, FORMAT_OGG],
-            supportedSampleRates: [DEFAULT_SAMPLE_RATE, 48000],
-            supportedBitrates: [DEFAULT_BITRATE, 256000],
-            defaultFormat: FORMAT_WEBM,
-            defaultSampleRate: DEFAULT_SAMPLE_RATE,
-            defaultBitrate: DEFAULT_BITRATE,
-        });
+	it('maps detectCapabilities result to capabilities object', () => {
+		mockDetectCapabilities.mockReturnValueOnce({
+			supportedFormats: [FORMAT_WEBM, FORMAT_OGG],
+			supportedSampleRates: [DEFAULT_SAMPLE_RATE, 48000],
+			supportedBitrates: [DEFAULT_BITRATE, 256000],
+			defaultFormat: FORMAT_WEBM,
+			defaultSampleRate: DEFAULT_SAMPLE_RATE,
+			defaultBitrate: DEFAULT_BITRATE,
+		});
 
-        const result = SystemDiagnostics.collectAudioCapabilities();
+		const result = SystemDiagnostics.collectAudioCapabilities();
 
-        expect(result.supportedFormats).toEqual([FORMAT_WEBM, FORMAT_OGG]);
-        expect(result.supportedSampleRates).toEqual([DEFAULT_SAMPLE_RATE, 48000]);
-        expect(result.supportedBitrates).toEqual([DEFAULT_BITRATE, 256000]);
-    });
+		expect(result.supportedFormats).toEqual([FORMAT_WEBM, FORMAT_OGG]);
+		expect(result.supportedSampleRates).toEqual([
+			DEFAULT_SAMPLE_RATE,
+			48000,
+		]);
+		expect(result.supportedBitrates).toEqual([DEFAULT_BITRATE, 256000]);
+	});
 
-    it('includes codecSupport from detectCodecSupport()', () => {
-        mockDetectCapabilities.mockReturnValueOnce({
-            supportedFormats: [],
-            supportedSampleRates: [],
-            supportedBitrates: [],
-            defaultFormat: FORMAT_WEBM,
-            defaultSampleRate: DEFAULT_SAMPLE_RATE,
-            defaultBitrate: DEFAULT_BITRATE,
-        });
-        const fakeCodecSupport = [
-            {
-                mimeType: 'audio/webm',
-                supported: true,
-                withCodecs: [
-                    { codec: 'opus', mimeType: 'audio/webm;codecs=opus', supported: true },
-                ],
-            },
-        ];
-        mockDetectCodecSupport.mockReturnValueOnce(fakeCodecSupport);
+	it('includes codecSupport from detectCodecSupport()', () => {
+		mockDetectCapabilities.mockReturnValueOnce({
+			supportedFormats: [],
+			supportedSampleRates: [],
+			supportedBitrates: [],
+			defaultFormat: FORMAT_WEBM,
+			defaultSampleRate: DEFAULT_SAMPLE_RATE,
+			defaultBitrate: DEFAULT_BITRATE,
+		});
+		const fakeCodecSupport = [
+			{
+				mimeType: 'audio/webm',
+				supported: true,
+				withCodecs: [
+					{
+						codec: 'opus',
+						mimeType: 'audio/webm;codecs=opus',
+						supported: true,
+					},
+				],
+			},
+		];
+		mockDetectCodecSupport.mockReturnValueOnce(fakeCodecSupport);
 
-        const result = SystemDiagnostics.collectAudioCapabilities();
+		const result = SystemDiagnostics.collectAudioCapabilities();
 
-        expect(result.codecSupport).toEqual(fakeCodecSupport);
-    });
+		expect(result.codecSupport).toEqual(fakeCodecSupport);
+	});
 
-    it('reports mediaRecorderAvailable as true when MediaRecorder exists', () => {
-        mockDetectCapabilities.mockReturnValueOnce({
-            supportedFormats: [],
-            supportedSampleRates: [],
-            supportedBitrates: [],
-            defaultFormat: FORMAT_WEBM,
-            defaultSampleRate: DEFAULT_SAMPLE_RATE,
-            defaultBitrate: DEFAULT_BITRATE,
-        });
+	it('reports mediaRecorderAvailable as true when MediaRecorder exists', () => {
+		mockDetectCapabilities.mockReturnValueOnce({
+			supportedFormats: [],
+			supportedSampleRates: [],
+			supportedBitrates: [],
+			defaultFormat: FORMAT_WEBM,
+			defaultSampleRate: DEFAULT_SAMPLE_RATE,
+			defaultBitrate: DEFAULT_BITRATE,
+		});
 
-        // MediaRecorder appears in jsdom
-        const result = SystemDiagnostics.collectAudioCapabilities();
+		// MediaRecorder appears in jsdom
+		const result = SystemDiagnostics.collectAudioCapabilities();
 
-        expect(result.mediaRecorderAvailable).toBe(typeof MediaRecorder !== 'undefined');
-    });
+		expect(result.mediaRecorderAvailable).toBe(
+			typeof MediaRecorder !== 'undefined',
+		);
+	});
 
-    it('reports getUserMediaAvailable based on navigator.mediaDevices', () => {
-        mockDetectCapabilities.mockReturnValueOnce({
-            supportedFormats: [],
-            supportedSampleRates: [],
-            supportedBitrates: [],
-            defaultFormat: FORMAT_WEBM,
-            defaultSampleRate: DEFAULT_SAMPLE_RATE,
-            defaultBitrate: DEFAULT_BITRATE,
-        });
+	it('reports getUserMediaAvailable based on navigator.mediaDevices', () => {
+		mockDetectCapabilities.mockReturnValueOnce({
+			supportedFormats: [],
+			supportedSampleRates: [],
+			supportedBitrates: [],
+			defaultFormat: FORMAT_WEBM,
+			defaultSampleRate: DEFAULT_SAMPLE_RATE,
+			defaultBitrate: DEFAULT_BITRATE,
+		});
 
-        const result = SystemDiagnostics.collectAudioCapabilities();
+		const result = SystemDiagnostics.collectAudioCapabilities();
 
-        const expected =
-            typeof navigator.mediaDevices !== 'undefined' &&
-            typeof navigator.mediaDevices.getUserMedia === 'function';
-        expect(result.getUserMediaAvailable).toBe(expected);
-    });
+		const expected =
+			typeof navigator.mediaDevices !== 'undefined' &&
+			typeof navigator.mediaDevices.getUserMedia === 'function';
+		expect(result.getUserMediaAvailable).toBe(expected);
+	});
 });
 
 describe('SystemDiagnostics.collectActiveRecordingConfig', () => {
-    beforeEach(() => {
-        (global as Record<string, unknown>).MediaRecorder = {
-            isTypeSupported: jest.fn((type: string) =>
-                type === 'audio/mp4' || type === 'audio/webm',
-            ),
-        };
-    });
+	beforeEach(() => {
+		(global as Record<string, unknown>).MediaRecorder = {
+			isTypeSupported: jest.fn(
+				(type: string) => type === 'audio/mp4' || type === 'audio/webm',
+			),
+		};
+	});
 
-    it('returns correct config for a directly supported format (mp4)', () => {
-        const settings = makeSettings({ recordingFormat: FORMAT_MP4 });
-        const result = SystemDiagnostics.collectActiveRecordingConfig(settings);
+	it('returns correct config for a directly supported format (mp4)', () => {
+		const settings = makeSettings({ recordingFormat: FORMAT_MP4 });
+		const result = SystemDiagnostics.collectActiveRecordingConfig(settings);
 
-        expect(result.outputFormat).toBe(FORMAT_MP4);
-        expect(result.recorderFormat).toBe(FORMAT_MP4);
-        expect(result.mimeType).toBe('audio/mp4');
-        expect(result.mimeTypeSupported).toBe(true);
-        expect(result.validationResult.valid).toBe(true);
-    });
+		expect(result.outputFormat).toBe(FORMAT_MP4);
+		expect(result.recorderFormat).toBe(FORMAT_MP4);
+		expect(result.mimeType).toBe('audio/mp4');
+		expect(result.mimeTypeSupported).toBe(true);
+		expect(result.validationResult.valid).toBe(true);
+	});
 
-    it('resolves WAV to webm intermediate when webm is supported', () => {
-        const settings = makeSettings({ recordingFormat: 'wav' });
-        const result = SystemDiagnostics.collectActiveRecordingConfig(settings);
+	it('resolves WAV to webm intermediate when webm is supported', () => {
+		const settings = makeSettings({ recordingFormat: 'wav' });
+		const result = SystemDiagnostics.collectActiveRecordingConfig(settings);
 
-        expect(result.outputFormat).toBe('wav');
-        expect(result.recorderFormat).toBe(FORMAT_WEBM);
-        expect(result.mimeType).toBe('audio/webm');
-        expect(result.mimeTypeSupported).toBe(true);
-    });
+		expect(result.outputFormat).toBe('wav');
+		expect(result.recorderFormat).toBe(FORMAT_WEBM);
+		expect(result.mimeType).toBe('audio/webm');
+		expect(result.mimeTypeSupported).toBe(true);
+	});
 
-    it('resolves WAV to ogg when webm is unavailable but ogg is supported', () => {
-        (global as Record<string, unknown>).MediaRecorder = {
-            isTypeSupported: jest.fn((type: string) => type === 'audio/ogg'),
-        };
-        const settings = makeSettings({ recordingFormat: 'wav' });
-        const result = SystemDiagnostics.collectActiveRecordingConfig(settings);
+	it('resolves WAV to ogg when webm is unavailable but ogg is supported', () => {
+		(global as Record<string, unknown>).MediaRecorder = {
+			isTypeSupported: jest.fn((type: string) => type === 'audio/ogg'),
+		};
+		const settings = makeSettings({ recordingFormat: 'wav' });
+		const result = SystemDiagnostics.collectActiveRecordingConfig(settings);
 
-        expect(result.recorderFormat).toBe(FORMAT_OGG);
-        expect(result.mimeTypeSupported).toBe(true);
-    });
+		expect(result.recorderFormat).toBe(FORMAT_OGG);
+		expect(result.mimeTypeSupported).toBe(true);
+	});
 
-    it('reports mimeTypeSupported=false for WAV when no intermediate is available', () => {
-        (global as Record<string, unknown>).MediaRecorder = {
-            isTypeSupported: jest.fn().mockReturnValue(false),
-        };
-        const settings = makeSettings({ recordingFormat: 'wav' });
-        const result = SystemDiagnostics.collectActiveRecordingConfig(settings);
+	it('reports mimeTypeSupported=false for WAV when no intermediate is available', () => {
+		(global as Record<string, unknown>).MediaRecorder = {
+			isTypeSupported: jest.fn().mockReturnValue(false),
+		};
+		const settings = makeSettings({ recordingFormat: 'wav' });
+		const result = SystemDiagnostics.collectActiveRecordingConfig(settings);
 
-        expect(result.mimeTypeSupported).toBe(false);
-        expect(result.validationResult.valid).toBe(false);
-    });
+		expect(result.mimeTypeSupported).toBe(false);
+		expect(result.validationResult.valid).toBe(false);
+	});
 
-    it('reports mimeTypeSupported=false for an unsupported format', () => {
-        const settings = makeSettings({ recordingFormat: FORMAT_OGG });
-        const result = SystemDiagnostics.collectActiveRecordingConfig(settings);
+	it('reports mimeTypeSupported=false for an unsupported format', () => {
+		const settings = makeSettings({ recordingFormat: FORMAT_OGG });
+		const result = SystemDiagnostics.collectActiveRecordingConfig(settings);
 
-        // ogg is not in our mock
-        expect(result.mimeTypeSupported).toBe(false);
-        expect(result.validationResult.valid).toBe(false);
-    });
+		// ogg is not in our mock
+		expect(result.mimeTypeSupported).toBe(false);
+		expect(result.validationResult.valid).toBe(false);
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -405,79 +414,82 @@ describe('SystemDiagnostics.collectActiveRecordingConfig', () => {
 // ---------------------------------------------------------------------------
 
 describe('SystemDiagnostics.collect', () => {
-    const mockEnumerate = jest.fn();
-    const mockDetectCapabilities = jest.spyOn(
-        AudioCapabilityDetector,
-        'detectCapabilities',
-    );
-    const mockDetectCodecSupport = jest.spyOn(
-        AudioCapabilityDetector,
-        'detectCodecSupport',
-    );
+	const mockEnumerate = jest.fn();
+	const mockDetectCapabilities = jest.spyOn(
+		AudioCapabilityDetector,
+		'detectCapabilities',
+	);
+	const mockDetectCodecSupport = jest.spyOn(
+		AudioCapabilityDetector,
+		'detectCodecSupport',
+	);
 
-    beforeEach(() => {
-        Object.defineProperty(global.navigator, 'mediaDevices', {
-            value: { enumerateDevices: mockEnumerate },
-            configurable: true,
-        });
-        mockEnumerate.mockResolvedValue([]);
-        mockDetectCapabilities.mockReturnValue({
-            supportedFormats: [FORMAT_WEBM],
-            supportedSampleRates: [DEFAULT_SAMPLE_RATE],
-            supportedBitrates: [DEFAULT_BITRATE],
-            defaultFormat: FORMAT_WEBM,
-            defaultSampleRate: DEFAULT_SAMPLE_RATE,
-            defaultBitrate: DEFAULT_BITRATE,
-        });
-        mockDetectCodecSupport.mockReturnValue([]);
-        (global as Record<string, unknown>).MediaRecorder = {
-            isTypeSupported: jest.fn((type: string) => type === 'audio/webm'),
-        };
-    });
+	beforeEach(() => {
+		Object.defineProperty(global.navigator, 'mediaDevices', {
+			value: { enumerateDevices: mockEnumerate },
+			configurable: true,
+		});
+		mockEnumerate.mockResolvedValue([]);
+		mockDetectCapabilities.mockReturnValue({
+			supportedFormats: [FORMAT_WEBM],
+			supportedSampleRates: [DEFAULT_SAMPLE_RATE],
+			supportedBitrates: [DEFAULT_BITRATE],
+			defaultFormat: FORMAT_WEBM,
+			defaultSampleRate: DEFAULT_SAMPLE_RATE,
+			defaultBitrate: DEFAULT_BITRATE,
+		});
+		mockDetectCodecSupport.mockReturnValue([]);
+		(global as Record<string, unknown>).MediaRecorder = {
+			isTypeSupported: jest.fn((type: string) => type === 'audio/webm'),
+		};
+	});
 
-    afterEach(() => {
-        mockDetectCapabilities.mockReset();
-        mockDetectCodecSupport.mockReset();
-    });
+	afterEach(() => {
+		mockDetectCapabilities.mockReset();
+		mockDetectCodecSupport.mockReset();
+	});
 
-    it('returns a complete DiagnosticsData object', async () => {
-        const settings = makeSettings();
-        const app = makeApp('1.6.0');
+	it('returns a complete DiagnosticsData object', async () => {
+		const settings = makeSettings();
+		const app = makeApp('1.6.0');
 
-        const result = await SystemDiagnostics.collect(settings, app);
+		const result = await SystemDiagnostics.collect(settings, app);
 
-        expect(result).toHaveProperty('pluginSettings');
-        expect(result).toHaveProperty('environment');
-        expect(result).toHaveProperty('audioDevices');
-        expect(result).toHaveProperty('audioCapabilities');
-        expect(result).toHaveProperty('activeRecordingConfig');
-        expect(result.environment.obsidianVersion).toBe('1.6.0');
-        expect(result.pluginSettings.recordingFormat).toBe(FORMAT_WEBM);
-        expect(Array.isArray(result.audioDevices)).toBe(true);
-    });
+		expect(result).toHaveProperty('pluginSettings');
+		expect(result).toHaveProperty('environment');
+		expect(result).toHaveProperty('audioDevices');
+		expect(result).toHaveProperty('audioCapabilities');
+		expect(result).toHaveProperty('activeRecordingConfig');
+		expect(result.environment.obsidianVersion).toBe('1.6.0');
+		expect(result.pluginSettings.recordingFormat).toBe(FORMAT_WEBM);
+		expect(Array.isArray(result.audioDevices)).toBe(true);
+	});
 
-    it('propagates audio devices collected asynchronously', async () => {
-        mockEnumerate.mockResolvedValueOnce([
-            {
-                deviceId: 'in-1',
-                label: 'Mic',
-                groupId: 'g1',
-                kind: 'audioinput',
-            },
-        ]);
+	it('propagates audio devices collected asynchronously', async () => {
+		mockEnumerate.mockResolvedValueOnce([
+			{
+				deviceId: 'in-1',
+				label: 'Mic',
+				groupId: 'g1',
+				kind: 'audioinput',
+			},
+		]);
 
-        const result = await SystemDiagnostics.collect(makeSettings(), makeApp());
+		const result = await SystemDiagnostics.collect(
+			makeSettings(),
+			makeApp(),
+		);
 
-        expect(result.audioDevices).toHaveLength(1);
-        expect(result.audioDevices[0].deviceId).toBe('in-1');
-    });
+		expect(result.audioDevices).toHaveLength(1);
+		expect(result.audioDevices[0].deviceId).toBe('in-1');
+	});
 
-    it('activeRecordingConfig reflects current settings format', async () => {
-        const settings = makeSettings({ recordingFormat: FORMAT_WEBM });
-        const result = await SystemDiagnostics.collect(settings, makeApp());
+	it('activeRecordingConfig reflects current settings format', async () => {
+		const settings = makeSettings({ recordingFormat: FORMAT_WEBM });
+		const result = await SystemDiagnostics.collect(settings, makeApp());
 
-        expect(result.activeRecordingConfig.outputFormat).toBe(FORMAT_WEBM);
-        expect(result.activeRecordingConfig.mimeType).toBe('audio/webm');
-        expect(result.activeRecordingConfig.mimeTypeSupported).toBe(true);
-    });
+		expect(result.activeRecordingConfig.outputFormat).toBe(FORMAT_WEBM);
+		expect(result.activeRecordingConfig.mimeType).toBe('audio/webm');
+		expect(result.activeRecordingConfig.mimeTypeSupported).toBe(true);
+	});
 });

--- a/tests/unit/SystemInfoModal.test.ts
+++ b/tests/unit/SystemInfoModal.test.ts
@@ -13,49 +13,49 @@ import { App } from 'obsidian';
 // ---------------------------------------------------------------------------
 
 function makeData(overrides: Partial<DiagnosticsData> = {}): DiagnosticsData {
-    return {
-        pluginSettings: {
-            recordingFormat: 'webm',
-            bitrate: 128000,
-            sampleRate: 44100,
-            saveFolder: '',
-            saveNearActiveFile: false,
-            activeFileSubfolder: '',
-            filePrefix: 'recording',
-            enableMultiTrack: false,
-            maxTracks: 2,
-            outputMode: 'single',
-            trackAudioSources: {},
-            audioDeviceId: 'dev-1',
-            debug: false,
-        },
-        environment: {
-            obsidianVersion: '1.5.0',
-            electronVersion: '28.0.0',
-            nodeVersion: '20.0.0',
-            platform: 'linux',
-            arch: 'x64',
-            userAgent: 'test-agent',
-        },
-        audioDevices: [
-            { deviceId: 'd1', label: 'Mic', groupId: 'g1', kind: 'audioinput' },
-        ],
-        audioCapabilities: {
-            supportedFormats: ['webm'],
-            supportedSampleRates: [44100],
-            supportedBitrates: [128000],
-            mediaRecorderAvailable: true,
-            getUserMediaAvailable: true,
-        },
-        ...overrides,
-    };
+	return {
+		pluginSettings: {
+			recordingFormat: 'webm',
+			bitrate: 128000,
+			sampleRate: 44100,
+			saveFolder: '',
+			saveNearActiveFile: false,
+			activeFileSubfolder: '',
+			filePrefix: 'recording',
+			enableMultiTrack: false,
+			maxTracks: 2,
+			outputMode: 'single',
+			trackAudioSources: {},
+			audioDeviceId: 'dev-1',
+			debug: false,
+		},
+		environment: {
+			obsidianVersion: '1.5.0',
+			electronVersion: '28.0.0',
+			nodeVersion: '20.0.0',
+			platform: 'linux',
+			arch: 'x64',
+			userAgent: 'test-agent',
+		},
+		audioDevices: [
+			{ deviceId: 'd1', label: 'Mic', groupId: 'g1', kind: 'audioinput' },
+		],
+		audioCapabilities: {
+			supportedFormats: ['webm'],
+			supportedSampleRates: [44100],
+			supportedBitrates: [128000],
+			mediaRecorderAvailable: true,
+			getUserMediaAvailable: true,
+		},
+		...overrides,
+	};
 }
 
 function makeModal(data: DiagnosticsData = makeData()) {
-    const app = new App();
-    const modal = new SystemInfoModal(app, data);
-    modal.onOpen();
-    return modal;
+	const app = new App();
+	const modal = new SystemInfoModal(app, data);
+	modal.onOpen();
+	return modal;
 }
 
 // ---------------------------------------------------------------------------
@@ -63,30 +63,30 @@ function makeModal(data: DiagnosticsData = makeData()) {
 // ---------------------------------------------------------------------------
 
 describe('SystemInfoModal.onOpen', () => {
-    it('renders a "Copy to clipboard" button', () => {
-        const modal = makeModal();
+	it('renders a "Copy to clipboard" button', () => {
+		const modal = makeModal();
 
-        const btn = modal.contentEl.querySelector('button');
-        expect(btn).not.toBeNull();
-        expect(btn?.textContent).toBe('Copy to clipboard');
-    });
+		const btn = modal.contentEl.querySelector('button');
+		expect(btn).not.toBeNull();
+		expect(btn?.textContent).toBe('Copy to clipboard');
+	});
 
-    it('renders a pre element with JSON content', () => {
-        const data = makeData();
-        const modal = makeModal(data);
-        const expectedJson = JSON.stringify(data, null, 2);
+	it('renders a pre element with JSON content', () => {
+		const data = makeData();
+		const modal = makeModal(data);
+		const expectedJson = JSON.stringify(data, null, 2);
 
-        const pre = modal.contentEl.querySelector('pre');
-        expect(pre).not.toBeNull();
-        expect(pre?.textContent).toBe(expectedJson);
-    });
+		const pre = modal.contentEl.querySelector('pre');
+		expect(pre).not.toBeNull();
+		expect(pre?.textContent).toBe(expectedJson);
+	});
 
-    it('pre element has the aar-system-info-json CSS class', () => {
-        const modal = makeModal();
+	it('pre element has the aar-system-info-json CSS class', () => {
+		const modal = makeModal();
 
-        const pre = modal.contentEl.querySelector('pre');
-        expect(pre?.classList.contains('aar-system-info-json')).toBe(true);
-    });
+		const pre = modal.contentEl.querySelector('pre');
+		expect(pre?.classList.contains('aar-system-info-json')).toBe(true);
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -94,85 +94,99 @@ describe('SystemInfoModal.onOpen', () => {
 // ---------------------------------------------------------------------------
 
 describe('SystemInfoModal copy button', () => {
-    beforeEach(() => {
-        jest.useFakeTimers();
-        Object.defineProperty(global.navigator, 'clipboard', {
-            value: { writeText: jest.fn().mockResolvedValue(undefined) },
-            configurable: true,
-        });
-    });
+	beforeEach(() => {
+		jest.useFakeTimers();
+		Object.defineProperty(global.navigator, 'clipboard', {
+			value: { writeText: jest.fn().mockResolvedValue(undefined) },
+			configurable: true,
+		});
+	});
 
-    afterEach(() => {
-        jest.useRealTimers();
-    });
+	afterEach(() => {
+		jest.useRealTimers();
+	});
 
-    it('calls clipboard.writeText with formatted JSON on click', async () => {
-        const data = makeData();
-        const modal = makeModal(data);
-        const expectedJson = JSON.stringify(data, null, 2);
+	it('calls clipboard.writeText with formatted JSON on click', async () => {
+		const data = makeData();
+		const modal = makeModal(data);
+		const expectedJson = JSON.stringify(data, null, 2);
 
-        const btn = modal.contentEl.querySelector('button') as HTMLButtonElement;
-        btn.click();
-        await Promise.resolve();
+		const btn = modal.contentEl.querySelector(
+			'button',
+		) as HTMLButtonElement;
+		btn.click();
+		await Promise.resolve();
 
-        expect(navigator.clipboard.writeText).toHaveBeenCalledWith(expectedJson);
-    });
+		expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+			expectedJson,
+		);
+	});
 
-    it('changes button text to "Copied!" after click', async () => {
-        const modal = makeModal();
+	it('changes button text to "Copied!" after click', async () => {
+		const modal = makeModal();
 
-        const btn = modal.contentEl.querySelector('button') as HTMLButtonElement;
-        btn.click();
-        await Promise.resolve();
+		const btn = modal.contentEl.querySelector(
+			'button',
+		) as HTMLButtonElement;
+		btn.click();
+		await Promise.resolve();
 
-        expect(btn.textContent).toBe('Copied!');
-    });
+		expect(btn.textContent).toBe('Copied!');
+	});
 
-    it('adds aar-system-info-copied CSS class after click', async () => {
-        const modal = makeModal();
+	it('adds aar-system-info-copied CSS class after click', async () => {
+		const modal = makeModal();
 
-        const btn = modal.contentEl.querySelector('button') as HTMLButtonElement;
-        btn.click();
-        await Promise.resolve();
+		const btn = modal.contentEl.querySelector(
+			'button',
+		) as HTMLButtonElement;
+		btn.click();
+		await Promise.resolve();
 
-        expect(btn.classList.contains('aar-system-info-copied')).toBe(true);
-    });
+		expect(btn.classList.contains('aar-system-info-copied')).toBe(true);
+	});
 
-    it('reverts button text back to "Copy to clipboard" after 2 seconds', async () => {
-        const modal = makeModal();
+	it('reverts button text back to "Copy to clipboard" after 2 seconds', async () => {
+		const modal = makeModal();
 
-        const btn = modal.contentEl.querySelector('button') as HTMLButtonElement;
-        btn.click();
-        await Promise.resolve();
+		const btn = modal.contentEl.querySelector(
+			'button',
+		) as HTMLButtonElement;
+		btn.click();
+		await Promise.resolve();
 
-        jest.advanceTimersByTime(2000);
+		jest.advanceTimersByTime(2000);
 
-        expect(btn.textContent).toBe('Copy to clipboard');
-    });
+		expect(btn.textContent).toBe('Copy to clipboard');
+	});
 
-    it('removes aar-system-info-copied CSS class after 2 seconds', async () => {
-        const modal = makeModal();
+	it('removes aar-system-info-copied CSS class after 2 seconds', async () => {
+		const modal = makeModal();
 
-        const btn = modal.contentEl.querySelector('button') as HTMLButtonElement;
-        btn.click();
-        await Promise.resolve();
+		const btn = modal.contentEl.querySelector(
+			'button',
+		) as HTMLButtonElement;
+		btn.click();
+		await Promise.resolve();
 
-        jest.advanceTimersByTime(2000);
+		jest.advanceTimersByTime(2000);
 
-        expect(btn.classList.contains('aar-system-info-copied')).toBe(false);
-    });
+		expect(btn.classList.contains('aar-system-info-copied')).toBe(false);
+	});
 
-    it('does not revert button text before 2 seconds have passed', async () => {
-        const modal = makeModal();
+	it('does not revert button text before 2 seconds have passed', async () => {
+		const modal = makeModal();
 
-        const btn = modal.contentEl.querySelector('button') as HTMLButtonElement;
-        btn.click();
-        await Promise.resolve();
+		const btn = modal.contentEl.querySelector(
+			'button',
+		) as HTMLButtonElement;
+		btn.click();
+		await Promise.resolve();
 
-        jest.advanceTimersByTime(1999);
+		jest.advanceTimersByTime(1999);
 
-        expect(btn.textContent).toBe('Copied!');
-    });
+		expect(btn.textContent).toBe('Copied!');
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -180,13 +194,13 @@ describe('SystemInfoModal copy button', () => {
 // ---------------------------------------------------------------------------
 
 describe('SystemInfoModal.onClose', () => {
-    it('empties contentEl on close', () => {
-        const modal = makeModal();
+	it('empties contentEl on close', () => {
+		const modal = makeModal();
 
-        expect(modal.contentEl.children.length).toBeGreaterThan(0);
+		expect(modal.contentEl.children.length).toBeGreaterThan(0);
 
-        modal.onClose();
+		modal.onClose();
 
-        expect(modal.contentEl.children.length).toBe(0);
-    });
+		expect(modal.contentEl.children.length).toBe(0);
+	});
 });

--- a/tests/unit/WavEncoder.test.ts
+++ b/tests/unit/WavEncoder.test.ts
@@ -4,233 +4,281 @@
  */
 /** @jest-environment jsdom */
 
-import { bufferToWave, getWavHeaderInfo, createWavHeader, assembleWavFromPcmSegments } from '../../src/recording/WavEncoder';
+import {
+	bufferToWave,
+	getWavHeaderInfo,
+	createWavHeader,
+	assembleWavFromPcmSegments,
+} from '../../src/recording/WavEncoder';
 
 describe('WavEncoder', () => {
-    describe('bufferToWave', () => {
-        it('should create a valid WAV blob from mono AudioBuffer', () => {
-            // Create a mock AudioBuffer
-            const sampleRate = 44100;
-            const length = 1024;
-            const numberOfChannels = 1;
+	describe('bufferToWave', () => {
+		it('should create a valid WAV blob from mono AudioBuffer', () => {
+			// Create a mock AudioBuffer
+			const sampleRate = 44100;
+			const length = 1024;
+			const numberOfChannels = 1;
 
-            const audioBuffer = createMockAudioBuffer(numberOfChannels, length, sampleRate);
+			const audioBuffer = createMockAudioBuffer(
+				numberOfChannels,
+				length,
+				sampleRate,
+			);
 
-            const result = bufferToWave(audioBuffer, length);
+			const result = bufferToWave(audioBuffer, length);
 
-            expect(result).toBeInstanceOf(Blob);
-            expect(result.type).toBe('audio/wav');
-            // Header (44 bytes) + data (length * channels * 2 bytes per sample)
-            expect(result.size).toBe(44 + length * numberOfChannels * 2);
-        });
+			expect(result).toBeInstanceOf(Blob);
+			expect(result.type).toBe('audio/wav');
+			// Header (44 bytes) + data (length * channels * 2 bytes per sample)
+			expect(result.size).toBe(44 + length * numberOfChannels * 2);
+		});
 
-        it('should create a valid WAV blob from stereo AudioBuffer', () => {
-            const sampleRate = 48000;
-            const length = 2048;
-            const numberOfChannels = 2;
+		it('should create a valid WAV blob from stereo AudioBuffer', () => {
+			const sampleRate = 48000;
+			const length = 2048;
+			const numberOfChannels = 2;
 
-            const audioBuffer = createMockAudioBuffer(numberOfChannels, length, sampleRate);
+			const audioBuffer = createMockAudioBuffer(
+				numberOfChannels,
+				length,
+				sampleRate,
+			);
 
-            const result = bufferToWave(audioBuffer, length);
+			const result = bufferToWave(audioBuffer, length);
 
-            expect(result).toBeInstanceOf(Blob);
-            expect(result.type).toBe('audio/wav');
-            expect(result.size).toBe(44 + length * numberOfChannels * 2);
-        });
+			expect(result).toBeInstanceOf(Blob);
+			expect(result.type).toBe('audio/wav');
+			expect(result.size).toBe(44 + length * numberOfChannels * 2);
+		});
 
-        it('should handle empty buffer', () => {
-            const audioBuffer = createMockAudioBuffer(1, 0, 44100);
+		it('should handle empty buffer', () => {
+			const audioBuffer = createMockAudioBuffer(1, 0, 44100);
 
-            const result = bufferToWave(audioBuffer, 0);
+			const result = bufferToWave(audioBuffer, 0);
 
-            expect(result).toBeInstanceOf(Blob);
-            expect(result.size).toBe(44); // Header only
-        });
+			expect(result).toBeInstanceOf(Blob);
+			expect(result.size).toBe(44); // Header only
+		});
 
-        it('should handle length parameter smaller than buffer length', () => {
-            const audioBuffer = createMockAudioBuffer(1, 1000, 44100);
-            const partialLength = 500;
+		it('should handle length parameter smaller than buffer length', () => {
+			const audioBuffer = createMockAudioBuffer(1, 1000, 44100);
+			const partialLength = 500;
 
-            const result = bufferToWave(audioBuffer, partialLength);
+			const result = bufferToWave(audioBuffer, partialLength);
 
-            expect(result.size).toBe(44 + partialLength * 1 * 2);
-        });
+			expect(result.size).toBe(44 + partialLength * 1 * 2);
+		});
 
-        it('should properly interleave stereo samples', async () => {
-            const sampleRate = 44100;
-            const length = 4;
+		it('should properly interleave stereo samples', async () => {
+			const sampleRate = 44100;
+			const length = 4;
 
-            const audioBuffer = createMockAudioBuffer(2, length, sampleRate);
-            // Set known values
-            const channelData0 = audioBuffer.getChannelData(0);
-            const channelData1 = audioBuffer.getChannelData(1);
-            channelData0[0] = 0.5;
-            channelData1[0] = -0.5;
+			const audioBuffer = createMockAudioBuffer(2, length, sampleRate);
+			// Set known values
+			const channelData0 = audioBuffer.getChannelData(0);
+			const channelData1 = audioBuffer.getChannelData(1);
+			channelData0[0] = 0.5;
+			channelData1[0] = -0.5;
 
-            const result = bufferToWave(audioBuffer, length);
+			const result = bufferToWave(audioBuffer, length);
 
-            expect(result).toBeInstanceOf(Blob);
-        });
+			expect(result).toBeInstanceOf(Blob);
+		});
 
-        it('should clamp sample values to valid range', () => {
-            const audioBuffer = createMockAudioBuffer(1, 4, 44100);
-            const channelData = audioBuffer.getChannelData(0);
-            // Set values outside valid range
-            channelData[0] = 2.0;  // Should be clamped to 1.0
-            channelData[1] = -2.0; // Should be clamped to -1.0
+		it('should clamp sample values to valid range', () => {
+			const audioBuffer = createMockAudioBuffer(1, 4, 44100);
+			const channelData = audioBuffer.getChannelData(0);
+			// Set values outside valid range
+			channelData[0] = 2.0; // Should be clamped to 1.0
+			channelData[1] = -2.0; // Should be clamped to -1.0
 
-            const result = bufferToWave(audioBuffer, 4);
+			const result = bufferToWave(audioBuffer, 4);
 
-            expect(result).toBeInstanceOf(Blob);
-            expect(result.type).toBe('audio/wav');
-        });
-    });
+			expect(result).toBeInstanceOf(Blob);
+			expect(result.type).toBe('audio/wav');
+		});
+	});
 
-    describe('getWavHeaderInfo', () => {
-        it('should calculate correct header info for mono audio', () => {
-            const info = getWavHeaderInfo(1, 44100, 1000);
+	describe('getWavHeaderInfo', () => {
+		it('should calculate correct header info for mono audio', () => {
+			const info = getWavHeaderInfo(1, 44100, 1000);
 
-            expect(info.headerSize).toBe(44);
-            expect(info.totalSize).toBe(1044);
-            expect(info.byteRate).toBe(88200); // 44100 * 2 * 1
-        });
+			expect(info.headerSize).toBe(44);
+			expect(info.totalSize).toBe(1044);
+			expect(info.byteRate).toBe(88200); // 44100 * 2 * 1
+		});
 
-        it('should calculate correct header info for stereo audio', () => {
-            const info = getWavHeaderInfo(2, 48000, 5000);
+		it('should calculate correct header info for stereo audio', () => {
+			const info = getWavHeaderInfo(2, 48000, 5000);
 
-            expect(info.headerSize).toBe(44);
-            expect(info.totalSize).toBe(5044);
-            expect(info.byteRate).toBe(192000); // 48000 * 2 * 2
-        });
+			expect(info.headerSize).toBe(44);
+			expect(info.totalSize).toBe(5044);
+			expect(info.byteRate).toBe(192000); // 48000 * 2 * 2
+		});
 
-        it('should handle different sample rates', () => {
-            const rates = [8000, 16000, 22050, 44100, 48000, 96000];
+		it('should handle different sample rates', () => {
+			const rates = [8000, 16000, 22050, 44100, 48000, 96000];
 
-            rates.forEach((rate) => {
-                const info = getWavHeaderInfo(1, rate, 0);
-                expect(info.byteRate).toBe(rate * 2);
-            });
-        });
-    });
+			rates.forEach((rate) => {
+				const info = getWavHeaderInfo(1, rate, 0);
+				expect(info.byteRate).toBe(rate * 2);
+			});
+		});
+	});
 });
 
-    describe('createWavHeader', () => {
-        it('should create a 44-byte WAV header', () => {
-            const header = createWavHeader(1, 44100, 1000);
+describe('createWavHeader', () => {
+	it('should create a 44-byte WAV header', () => {
+		const header = createWavHeader(1, 44100, 1000);
 
-            expect(header.byteLength).toBe(44);
-        });
+		expect(header.byteLength).toBe(44);
+	});
 
-        it('should contain valid RIFF/WAVE markers', () => {
-            const header = createWavHeader(1, 44100, 1000);
-            const view = new DataView(header);
+	it('should contain valid RIFF/WAVE markers', () => {
+		const header = createWavHeader(1, 44100, 1000);
+		const view = new DataView(header);
 
-            // RIFF
-            expect(String.fromCharCode(view.getUint8(0), view.getUint8(1), view.getUint8(2), view.getUint8(3))).toBe('RIFF');
-            // WAVE
-            expect(String.fromCharCode(view.getUint8(8), view.getUint8(9), view.getUint8(10), view.getUint8(11))).toBe('WAVE');
-            // fmt
-            expect(String.fromCharCode(view.getUint8(12), view.getUint8(13), view.getUint8(14), view.getUint8(15))).toBe('fmt ');
-            // data
-            expect(String.fromCharCode(view.getUint8(36), view.getUint8(37), view.getUint8(38), view.getUint8(39))).toBe('data');
-        });
+		// RIFF
+		expect(
+			String.fromCharCode(
+				view.getUint8(0),
+				view.getUint8(1),
+				view.getUint8(2),
+				view.getUint8(3),
+			),
+		).toBe('RIFF');
+		// WAVE
+		expect(
+			String.fromCharCode(
+				view.getUint8(8),
+				view.getUint8(9),
+				view.getUint8(10),
+				view.getUint8(11),
+			),
+		).toBe('WAVE');
+		// fmt
+		expect(
+			String.fromCharCode(
+				view.getUint8(12),
+				view.getUint8(13),
+				view.getUint8(14),
+				view.getUint8(15),
+			),
+		).toBe('fmt ');
+		// data
+		expect(
+			String.fromCharCode(
+				view.getUint8(36),
+				view.getUint8(37),
+				view.getUint8(38),
+				view.getUint8(39),
+			),
+		).toBe('data');
+	});
 
-        it('should set correct file size in RIFF header', () => {
-            const pcmDataLength = 5000;
-            const header = createWavHeader(1, 44100, pcmDataLength);
-            const view = new DataView(header);
+	it('should set correct file size in RIFF header', () => {
+		const pcmDataLength = 5000;
+		const header = createWavHeader(1, 44100, pcmDataLength);
+		const view = new DataView(header);
 
-            // RIFF chunk size = file size - 8
-            expect(view.getUint32(4, true)).toBe(44 - 8 + pcmDataLength);
-        });
+		// RIFF chunk size = file size - 8
+		expect(view.getUint32(4, true)).toBe(44 - 8 + pcmDataLength);
+	});
 
-        it('should set correct audio format fields for mono', () => {
-            const header = createWavHeader(1, 44100, 1000);
-            const view = new DataView(header);
+	it('should set correct audio format fields for mono', () => {
+		const header = createWavHeader(1, 44100, 1000);
+		const view = new DataView(header);
 
-            expect(view.getUint16(20, true)).toBe(1); // PCM format
-            expect(view.getUint16(22, true)).toBe(1); // 1 channel
-            expect(view.getUint32(24, true)).toBe(44100); // sample rate
-            expect(view.getUint32(28, true)).toBe(88200); // byte rate: 44100 * 1 * 2
-            expect(view.getUint16(32, true)).toBe(2); // block align: 1 * 2
-            expect(view.getUint16(34, true)).toBe(16); // bits per sample
-        });
+		expect(view.getUint16(20, true)).toBe(1); // PCM format
+		expect(view.getUint16(22, true)).toBe(1); // 1 channel
+		expect(view.getUint32(24, true)).toBe(44100); // sample rate
+		expect(view.getUint32(28, true)).toBe(88200); // byte rate: 44100 * 1 * 2
+		expect(view.getUint16(32, true)).toBe(2); // block align: 1 * 2
+		expect(view.getUint16(34, true)).toBe(16); // bits per sample
+	});
 
-        it('should set correct audio format fields for stereo', () => {
-            const header = createWavHeader(2, 48000, 2000);
-            const view = new DataView(header);
+	it('should set correct audio format fields for stereo', () => {
+		const header = createWavHeader(2, 48000, 2000);
+		const view = new DataView(header);
 
-            expect(view.getUint16(22, true)).toBe(2); // 2 channels
-            expect(view.getUint32(24, true)).toBe(48000); // sample rate
-            expect(view.getUint32(28, true)).toBe(192000); // byte rate: 48000 * 2 * 2
-            expect(view.getUint16(32, true)).toBe(4); // block align: 2 * 2
-        });
+		expect(view.getUint16(22, true)).toBe(2); // 2 channels
+		expect(view.getUint32(24, true)).toBe(48000); // sample rate
+		expect(view.getUint32(28, true)).toBe(192000); // byte rate: 48000 * 2 * 2
+		expect(view.getUint16(32, true)).toBe(4); // block align: 2 * 2
+	});
 
-        it('should set correct data subchunk size', () => {
-            const pcmDataLength = 8800;
-            const header = createWavHeader(1, 44100, pcmDataLength);
-            const view = new DataView(header);
+	it('should set correct data subchunk size', () => {
+		const pcmDataLength = 8800;
+		const header = createWavHeader(1, 44100, pcmDataLength);
+		const view = new DataView(header);
 
-            expect(view.getUint32(40, true)).toBe(pcmDataLength);
-        });
-    });
+		expect(view.getUint32(40, true)).toBe(pcmDataLength);
+	});
+});
 
-    describe('assembleWavFromPcmSegments', () => {
-        it('should assemble WAV from single segment', () => {
-            const pcmData = new Int16Array([100, -100, 200, -200]).buffer;
-            const result = assembleWavFromPcmSegments([pcmData], 1, 44100);
+describe('assembleWavFromPcmSegments', () => {
+	it('should assemble WAV from single segment', () => {
+		const pcmData = new Int16Array([100, -100, 200, -200]).buffer;
+		const result = assembleWavFromPcmSegments([pcmData], 1, 44100);
 
-            expect(result.byteLength).toBe(44 + pcmData.byteLength);
-        });
+		expect(result.byteLength).toBe(44 + pcmData.byteLength);
+	});
 
-        it('should assemble WAV from multiple segments', () => {
-            const seg1 = new Int16Array([100, -100]).buffer;
-            const seg2 = new Int16Array([200, -200]).buffer;
-            const seg3 = new Int16Array([300, -300]).buffer;
+	it('should assemble WAV from multiple segments', () => {
+		const seg1 = new Int16Array([100, -100]).buffer;
+		const seg2 = new Int16Array([200, -200]).buffer;
+		const seg3 = new Int16Array([300, -300]).buffer;
 
-            const result = assembleWavFromPcmSegments([seg1, seg2, seg3], 1, 44100);
+		const result = assembleWavFromPcmSegments([seg1, seg2, seg3], 1, 44100);
 
-            const totalPcm = seg1.byteLength + seg2.byteLength + seg3.byteLength;
-            expect(result.byteLength).toBe(44 + totalPcm);
-        });
+		const totalPcm = seg1.byteLength + seg2.byteLength + seg3.byteLength;
+		expect(result.byteLength).toBe(44 + totalPcm);
+	});
 
-        it('should preserve PCM data in correct order', () => {
-            const seg1 = new Int16Array([1000, 2000]).buffer;
-            const seg2 = new Int16Array([3000, 4000]).buffer;
+	it('should preserve PCM data in correct order', () => {
+		const seg1 = new Int16Array([1000, 2000]).buffer;
+		const seg2 = new Int16Array([3000, 4000]).buffer;
 
-            const result = assembleWavFromPcmSegments([seg1, seg2], 1, 44100);
+		const result = assembleWavFromPcmSegments([seg1, seg2], 1, 44100);
 
-            const int16View = new Int16Array(result, 44);
-            expect(int16View[0]).toBe(1000);
-            expect(int16View[1]).toBe(2000);
-            expect(int16View[2]).toBe(3000);
-            expect(int16View[3]).toBe(4000);
-        });
+		const int16View = new Int16Array(result, 44);
+		expect(int16View[0]).toBe(1000);
+		expect(int16View[1]).toBe(2000);
+		expect(int16View[2]).toBe(3000);
+		expect(int16View[3]).toBe(4000);
+	});
 
-        it('should write correct WAV header for assembled data', () => {
-            const pcmData = new Int16Array(100).buffer;
-            const result = assembleWavFromPcmSegments([pcmData], 2, 48000);
+	it('should write correct WAV header for assembled data', () => {
+		const pcmData = new Int16Array(100).buffer;
+		const result = assembleWavFromPcmSegments([pcmData], 2, 48000);
 
-            const view = new DataView(result);
-            // Verify RIFF marker
-            expect(String.fromCharCode(view.getUint8(0), view.getUint8(1), view.getUint8(2), view.getUint8(3))).toBe('RIFF');
-            // Verify channels
-            expect(view.getUint16(22, true)).toBe(2);
-            // Verify sample rate
-            expect(view.getUint32(24, true)).toBe(48000);
-            // Verify data size
-            expect(view.getUint32(40, true)).toBe(pcmData.byteLength);
-        });
+		const view = new DataView(result);
+		// Verify RIFF marker
+		expect(
+			String.fromCharCode(
+				view.getUint8(0),
+				view.getUint8(1),
+				view.getUint8(2),
+				view.getUint8(3),
+			),
+		).toBe('RIFF');
+		// Verify channels
+		expect(view.getUint16(22, true)).toBe(2);
+		// Verify sample rate
+		expect(view.getUint32(24, true)).toBe(48000);
+		// Verify data size
+		expect(view.getUint32(40, true)).toBe(pcmData.byteLength);
+	});
 
-        it('should handle empty segments array', () => {
-            const result = assembleWavFromPcmSegments([], 1, 44100);
+	it('should handle empty segments array', () => {
+		const result = assembleWavFromPcmSegments([], 1, 44100);
 
-            // Header only, no data
-            expect(result.byteLength).toBe(44);
-            const view = new DataView(result);
-            expect(view.getUint32(40, true)).toBe(0);
-        });
-    });
+		// Header only, no data
+		expect(result.byteLength).toBe(44);
+		const view = new DataView(result);
+		expect(view.getUint32(40, true)).toBe(0);
+	});
+});
 
 /**
  * Creates a mock AudioBuffer for testing.
@@ -240,22 +288,22 @@ describe('WavEncoder', () => {
  * @returns Mock AudioBuffer object
  */
 function createMockAudioBuffer(
-    numberOfChannels: number,
-    length: number,
-    sampleRate: number
+	numberOfChannels: number,
+	length: number,
+	sampleRate: number,
 ): AudioBuffer {
-    const channels: Float32Array[] = [];
-    for (let i = 0; i < numberOfChannels; i++) {
-        channels.push(new Float32Array(length));
-    }
+	const channels: Float32Array[] = [];
+	for (let i = 0; i < numberOfChannels; i++) {
+		channels.push(new Float32Array(length));
+	}
 
-    return {
-        numberOfChannels,
-        length,
-        sampleRate,
-        duration: length / sampleRate,
-        getChannelData: (channel: number) => channels[channel],
-        copyFromChannel: jest.fn(),
-        copyToChannel: jest.fn(),
-    } as unknown as AudioBuffer;
+	return {
+		numberOfChannels,
+		length,
+		sampleRate,
+		duration: length / sampleRate,
+		getChannelData: (channel: number) => channels[channel],
+		copyFromChannel: jest.fn(),
+		copyToChannel: jest.fn(),
+	} as unknown as AudioBuffer;
 }

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true
+  },
+  "include": [
+    "src/**/*.ts",
+    "tests/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}


### PR DESCRIPTION
…icates

Functional changes:
- Fix duplicate "Audio file info" item in context menu when both editor-menu and file-menu events fire for the same Menu instance (WeakSet deduplication)
- Group all AAR context menu items under a dedicated 'aar' section
- Add interactive pause/resume and stop buttons to the status bar during recording, with accessible attributes (role, aria-label, tabindex)
- Add RecordingControls type with onPauseResume, onStop callbacks and isPaused flag
- Fix save progress text wrapping to single line (white-space: nowrap)

Refactoring changes:
- Extract renderRecordingState, renderSavingState, renderIdleState helpers from updateStatusBar for better separation of concerns
- Add buildRecordingControls method to main plugin class

Test changes:
- Add 12 new StatusBar tests for recording controls (buttons, clicks, propagation, accessibility, state transitions)
- Add ContextMenu tests for deduplication, onClick handlers, and null info
- Update section assertions from 'default'/'danger' to 'aar'
- Add setIcon mock to obsidian test mocks
- 100% coverage on all changed files (StatusBar, ContextMenu, types)