### PR TITLE
fix(recorder): merge multi-track compressed recordings via audio mixi…

### DIFF
--- a/src/recording/RecordingManager.ts
+++ b/src/recording/RecordingManager.ts
@@ -442,13 +442,18 @@ export class RecordingManager {
 						),
 					);
 				}
-				this.updateSaveProgress(40, 'Assembling audio...');
-				const mergedAudio =
-					this.settings.recordingFormat === FORMAT_WAV
-						? await this.mergeAudioTracks()
-						: await this.combineTracksWithoutConversion();
+				this.updateSaveProgress(40, 'Mixing tracks...');
+				if (this.settings.recordingFormat !== FORMAT_WAV) {
+					this.debugLogger.log(
+						'Multi-track single output overrides format to WAV for proper mixing',
+						{
+							requestedFormat: this.settings.recordingFormat,
+						},
+					);
+				}
+				const mergedAudio = await this.mergeAudioTracks();
 				this.updateSaveProgress(60, 'Writing file...');
-				const fileName = `${this.settings.filePrefix}-multitrack-${timestamp}.${this.settings.recordingFormat}`;
+				const fileName = `${this.settings.filePrefix}-multitrack-${timestamp}.${FORMAT_WAV}`;
 				const filePath = await this.saveAudioFile(
 					mergedAudio,
 					fileName,
@@ -528,28 +533,6 @@ export class RecordingManager {
 		const renderedBuffer = await offlineContext.startRendering();
 		await audioContext.close();
 		return bufferToWave(renderedBuffer, renderedBuffer.length);
-	}
-
-	private async combineTracksWithoutConversion(): Promise<Blob> {
-		const trackBlobs = await Promise.all(
-			this.chunkTargets.map((target) => this.buildTrackBlob(target)),
-		);
-		const nonEmptyTrackBlobs = trackBlobs.filter(
-			(blob): blob is Blob => blob !== null && blob.size > 0,
-		);
-		if (nonEmptyTrackBlobs.length === 0) {
-			throw new Error('No audio data recorded');
-		}
-		this.debugLogger.log(
-			'Combining multi-track data without WAV conversion',
-			{
-				trackCount: nonEmptyTrackBlobs.length,
-				format: this.settings.recordingFormat,
-			},
-		);
-		return new Blob(nonEmptyTrackBlobs, {
-			type: `${MIME_TYPE_AUDIO_PREFIX}${this.settings.recordingFormat}`,
-		});
 	}
 
 	private async handleChunk(index: number, data: Blob): Promise<void> {

--- a/src/recording/RecordingManager.ts
+++ b/src/recording/RecordingManager.ts
@@ -450,6 +450,9 @@ export class RecordingManager {
 							requestedFormat: this.settings.recordingFormat,
 						},
 					);
+					new Notice(
+						'Merged multi-track output saved as .wav for proper audio mixing.',
+					);
 				}
 				const mergedAudio = await this.mergeAudioTracks();
 				this.updateSaveProgress(60, 'Writing file...');

--- a/tests/unit/RecordingManager.test.ts
+++ b/tests/unit/RecordingManager.test.ts
@@ -949,6 +949,8 @@ describe('RecordingManager', () => {
 			expect(mockApp.vault.adapter.remove).toHaveBeenCalledWith(
 				expect.stringMatching(/-part\d+\.webm\.tmp$/),
 			);
+			// Verify proper audio mixing was used
+			expect(global.OfflineAudioContext).toHaveBeenCalled();
 		});
 
 		it('should rollback merged output when cleanup of temporary partial files fails', async () => {

--- a/tests/unit/RecordingManager.test.ts
+++ b/tests/unit/RecordingManager.test.ts
@@ -868,10 +868,10 @@ describe('RecordingManager', () => {
 
 	describe('single mode output format handling', () => {
 		/**
-		 * Verifies that single-file output in multi-track mode keeps compressed
-		 * MediaRecorder format and does not force WAV conversion.
+		 * Verifies that single-file output in multi-track mode always
+		 * produces WAV via proper audio mixing regardless of configured format.
 		 */
-		it('should save single-mode multi-track recording with configured extension', async () => {
+		it('should save single-mode multi-track recording as WAV regardless of configured format', async () => {
 			const { Platform } = jest.requireMock('obsidian');
 			Platform.isMobile = false;
 			Platform.isMobileApp = false;
@@ -941,12 +941,9 @@ describe('RecordingManager', () => {
 			await Promise.resolve();
 			await manager.stopRecording();
 
+			// Multi-track single output always produces WAV via mergeAudioTracks
 			expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
-				expect.stringMatching(/multitrack-.*\.webm$/),
-				expect.any(ArrayBuffer),
-			);
-			expect(mockApp.vault.createBinary).not.toHaveBeenCalledWith(
-				expect.stringMatching(/\.wav$/),
+				expect.stringMatching(/multitrack-.*\.wav$/),
 				expect.any(ArrayBuffer),
 			);
 			expect(mockApp.vault.adapter.remove).toHaveBeenCalledWith(
@@ -1039,11 +1036,11 @@ describe('RecordingManager', () => {
 			await manager.stopRecording();
 
 			expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
-				expect.stringMatching(/multitrack-.*\.webm$/),
+				expect.stringMatching(/multitrack-.*\.wav$/),
 				expect.any(ArrayBuffer),
 			);
 			expect(mockApp.vault.adapter.remove).toHaveBeenCalledWith(
-				expect.stringMatching(/multitrack-.*\.webm$/),
+				expect.stringMatching(/multitrack-.*\.wav$/),
 			);
 			expect(Notice).toHaveBeenCalledWith(
 				expect.stringContaining('Error stopping recording:'),
@@ -1058,6 +1055,93 @@ describe('RecordingManager', () => {
 			);
 
 			consoleWarnSpy.mockRestore();
+		});
+
+		/**
+		 * Regression: multi-track MP4 must produce a properly mixed WAV file
+		 * instead of broken concatenated MP4 containers.
+		 */
+		it('should merge MP4 multi-track recording into WAV with all tracks mixed', async () => {
+			const { Platform } = jest.requireMock('obsidian');
+			Platform.isMobile = false;
+			Platform.isMobileApp = false;
+
+			mockSettings = {
+				...DEFAULT_SETTINGS,
+				enableMultiTrack: true,
+				outputMode: 'single',
+				recordingFormat: 'mp4',
+			};
+			manager = new RecordingManager(
+				mockApp,
+				mockSettings,
+				statusChangeCallback,
+			);
+
+			const mockMediaRecorders = [0, 1].map(() => ({
+				start: jest.fn(),
+				stop: jest.fn(),
+				pause: jest.fn(),
+				resume: jest.fn(),
+				ondataavailable: null as ((event: BlobEvent) => void) | null,
+				onerror: null as ((event: Event) => void) | null,
+				addEventListener: jest.fn(
+					(event: string, handler: () => void) => {
+						if (event === 'stop') {
+							handler();
+						}
+					},
+				),
+			}));
+			let recorderIndex = 0;
+
+			(global as Record<string, unknown>).MediaRecorder = jest.fn(() => {
+				const recorder =
+					mockMediaRecorders[recorderIndex] ?? mockMediaRecorders[0];
+				recorderIndex += 1;
+				return recorder;
+			});
+			(global as Record<string, unknown>).MediaRecorder.isTypeSupported =
+				jest.fn().mockReturnValue(true);
+
+			const { getAudioStreams } = jest.requireMock(
+				'../../src/recording/AudioStreamHandler',
+			);
+			getAudioStreams.mockResolvedValue({
+				streams: [
+					{ getTracks: () => [{ stop: jest.fn() }] },
+					{ getTracks: () => [{ stop: jest.fn() }] },
+				],
+				trackOrder: [],
+			});
+
+			(mockApp.vault.adapter.readBinary as jest.Mock).mockResolvedValue(
+				new Uint8Array([1, 2, 3]).buffer,
+			);
+
+			await manager.startRecording();
+
+			const chunk = new Blob([new Uint8Array([1, 2, 3])], {
+				type: 'audio/mp4',
+			});
+			mockMediaRecorders.forEach((recorder) => {
+				recorder.ondataavailable?.({ data: chunk } as BlobEvent);
+			});
+
+			await Promise.resolve();
+			await manager.stopRecording();
+
+			// Must produce WAV (properly mixed) not MP4 (broken concatenation)
+			expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
+				expect.stringMatching(/multitrack-.*\.wav$/),
+				expect.any(ArrayBuffer),
+			);
+			expect(mockApp.vault.createBinary).not.toHaveBeenCalledWith(
+				expect.stringMatching(/multitrack-.*\.mp4$/),
+				expect.any(ArrayBuffer),
+			);
+			// OfflineAudioContext should have been used for mixing
+			expect(global.OfflineAudioContext).toHaveBeenCalled();
 		});
 
 		/**


### PR DESCRIPTION
…ng instead of blob concatenation

Functional changes:
- Replace combineTracksWithoutConversion() with mergeAudioTracks() for all multi-track single-output recordings regardless of selected format
- Multi-track merged output always saved as WAV to ensure all tracks are properly decoded, mixed via OfflineAudioContext, and rendered correctly
- Remove combineTracksWithoutConversion() method which produced broken audio by concatenating separate compressed containers (WebM/OGG/MP4)
- Add debug log when output format is overridden from compressed to WAV

Test changes:
- Update existing multi-track single-output test to expect WAV extension
- Update rollback test to match WAV file pattern for merged output
- Add regression test for MP4 multi-track confirming proper WAV mixing and OfflineAudioContext usage instead of broken container concatenation