### PR TITLE
fix(recording): fix MP4 saving hang and refactor RecordingManager

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,3 +27,15 @@ export const AUDIO_EXTENSIONS = [
 	FORMAT_AAC,
 	FORMAT_FLAC,
 ];
+
+/** Interval between MediaRecorder data chunks in milliseconds. */
+export const CHUNK_TIMESLICE_MS = 5000;
+
+/** Maximum in-memory buffer size for mobile recordings before flushing to disk. */
+export const MOBILE_BUFFER_LIMIT_BYTES = 50 * 1024 * 1024;
+
+/** PCM buffer flush threshold for WAV desktop recordings. */
+export const PCM_FLUSH_THRESHOLD_BYTES = 50 * 1024 * 1024;
+
+/** Common MIME type prefix for audio formats. */
+export const MIME_TYPE_AUDIO_PREFIX = 'audio/';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -37,5 +37,8 @@ export const MOBILE_BUFFER_LIMIT_BYTES = 50 * 1024 * 1024;
 /** PCM buffer flush threshold for WAV desktop recordings. */
 export const PCM_FLUSH_THRESHOLD_BYTES = 50 * 1024 * 1024;
 
+/** Desktop MediaRecorder chunk buffer flush threshold before writing to disk. */
+export const DESKTOP_FLUSH_THRESHOLD_BYTES = 50 * 1024 * 1024;
+
 /** Common MIME type prefix for audio formats. */
 export const MIME_TYPE_AUDIO_PREFIX = 'audio/';

--- a/src/recording/AudioFormatConverter.ts
+++ b/src/recording/AudioFormatConverter.ts
@@ -1,0 +1,246 @@
+/**
+ * Audio format conversion and track processing utilities.
+ * Handles format resolution, blob conversion, and multi-track merging.
+ * @module recording/AudioFormatConverter
+ */
+
+import type { RecordingTarget } from '../types';
+import type { AudioRecorderSettings } from '../settings/Settings';
+import { bufferToWave } from './WavEncoder';
+import { encodeAudioBuffer, isOfflineEncodingSupported } from './AudioEncoder';
+import { MIME_TYPE_AUDIO_PREFIX } from '../constants';
+import {
+	buildMimeType,
+	FORMAT_WEBM,
+	FORMAT_OGG,
+	FORMAT_WAV,
+} from './AudioCapabilityDetector';
+
+/**
+ * Progress callback receiving percentage (0-100).
+ */
+export type FormatProgressCallback = (percent: number) => void;
+
+/**
+ * Function that builds a Blob from a RecordingTarget.
+ */
+export type TrackBlobBuilder = (
+	target: RecordingTarget,
+) => Promise<Blob | null>;
+
+/**
+ * Resolves the recorder format and MIME type for MediaRecorder.
+ * If the output format is not natively supported, selects an
+ * intermediate compressed format (WebM or OGG).
+ * @param settings - Plugin settings
+ * @returns Recorder format string and MIME type
+ */
+export function resolveRecorderFormat(settings: AudioRecorderSettings): {
+	recorderFormat: string;
+	mimeType: string;
+} {
+	const outputFormat = settings.recordingFormat.toLowerCase();
+
+	// Check if MediaRecorder natively supports this format
+	const nativeMime = buildMimeType(outputFormat);
+	if (
+		outputFormat !== FORMAT_WAV &&
+		MediaRecorder.isTypeSupported(nativeMime)
+	) {
+		return { recorderFormat: outputFormat, mimeType: nativeMime };
+	}
+
+	// WAV and offline-only formats need an intermediate compressed format
+	const preferredCompressedFormats = [FORMAT_WEBM, FORMAT_OGG];
+	for (const format of preferredCompressedFormats) {
+		const mimeType = buildMimeType(format);
+		if (MediaRecorder.isTypeSupported(mimeType)) {
+			return { recorderFormat: format, mimeType };
+		}
+	}
+	throw new Error(
+		`Output format "${outputFormat}" requires an intermediate compressed format, but neither WebM nor OGG is supported in this browser.`,
+	);
+}
+
+/**
+ * Checks if a format requires offline encoding (not natively
+ * supported by MediaRecorder) and the recorder uses an intermediate format.
+ * @param format - Target output format
+ * @param activeRecorderFormat - Format currently used by MediaRecorder
+ * @returns true if offline-only encoding is needed
+ */
+export function isOfflineOnlyFormat(
+	format: string,
+	activeRecorderFormat: string,
+): boolean {
+	return (
+		format !== FORMAT_WAV &&
+		activeRecorderFormat !== format &&
+		isOfflineEncodingSupported(format)
+	);
+}
+
+/**
+ * Returns the MIME type string for the active recorder format.
+ * @param activeRecorderFormat - Format currently used by MediaRecorder
+ * @returns MIME type string (e.g., "audio/webm")
+ */
+export function getRecorderMediaType(activeRecorderFormat: string): string {
+	return `${MIME_TYPE_AUDIO_PREFIX}${activeRecorderFormat}`;
+}
+
+/**
+ * Decodes a compressed audio blob to WAV format.
+ * @param recordedBlob - Compressed audio blob
+ * @returns WAV blob
+ */
+export async function convertBlobToWav(recordedBlob: Blob): Promise<Blob> {
+	const audioContext = new AudioContext();
+	try {
+		const arrayBuffer = await recordedBlob.arrayBuffer();
+		const decodedBuffer = await audioContext.decodeAudioData(arrayBuffer);
+		return bufferToWave(decodedBuffer, decodedBuffer.length);
+	} finally {
+		await audioContext.close();
+	}
+}
+
+/**
+ * Decodes an intermediate blob and re-encodes it to the target format.
+ * Uses OfflineAudioContext at the native sample rate to avoid
+ * resampling artifacts.
+ * @param recordedBlob - Intermediate compressed blob
+ * @param targetFormat - Desired output format
+ * @param bitrate - Bitrate in bits per second
+ * @param onProgress - Optional encoding progress callback (0-100)
+ * @returns Re-encoded blob in the target format
+ */
+export async function convertBlobToFormat(
+	recordedBlob: Blob,
+	targetFormat: string,
+	bitrate: number,
+	onProgress?: FormatProgressCallback,
+): Promise<Blob> {
+	const arrayBuffer = await recordedBlob.arrayBuffer();
+
+	// Probe native sample rate
+	const probeCtx = new AudioContext();
+	const probeBuffer = await probeCtx.decodeAudioData(arrayBuffer.slice(0));
+	const nativeSampleRate = probeBuffer.sampleRate;
+	await probeCtx.close();
+
+	// Re-decode at native rate to avoid resampling
+	const offlineCtx = new OfflineAudioContext(
+		probeBuffer.numberOfChannels,
+		probeBuffer.length,
+		nativeSampleRate,
+	);
+	const decodedBuffer = await offlineCtx.decodeAudioData(arrayBuffer);
+
+	return encodeAudioBuffer(
+		decodedBuffer,
+		{ format: targetFormat, bitrate },
+		onProgress,
+	);
+}
+
+/**
+ * Combines buffered chunks into a single blob, optionally converting
+ * to WAV if the recording format requires it.
+ * @param chunks - Buffered audio chunks
+ * @param recorderMediaType - MIME type of the recorder
+ * @param recordingFormat - Target recording format from settings
+ * @returns Combined audio blob
+ */
+export async function buildOutputBlob(
+	chunks: Blob[],
+	recorderMediaType: string,
+	recordingFormat: string,
+): Promise<Blob> {
+	const recordedBlob = new Blob(chunks, { type: recorderMediaType });
+	if (recordingFormat !== FORMAT_WAV) {
+		return recordedBlob;
+	}
+	return convertBlobToWav(recordedBlob);
+}
+
+/**
+ * Merges multiple audio tracks into a single mixed audio blob.
+ * @param chunkTargets - Recording targets for each track
+ * @param settings - Plugin settings
+ * @param isWavPcmRecording - Whether recording uses PCM/WAV path
+ * @param buildPcmTrackWavBlob - Function to build WAV blob from PCM target
+ * @param buildTrackBlob - Function to build blob from MediaRecorder target
+ * @param onProgress - Optional progress callback (percent, description)
+ * @returns Merged audio blob in the target format
+ */
+export async function mergeAudioTracks(
+	chunkTargets: RecordingTarget[],
+	settings: AudioRecorderSettings,
+	isWavPcmRecording: boolean,
+	buildPcmTrackWavBlob: TrackBlobBuilder,
+	buildTrackBlob: TrackBlobBuilder,
+	onProgress?: (percent: number, description: string) => void,
+): Promise<Blob> {
+	const audioContext = new AudioContext();
+	const buffers = await Promise.all(
+		chunkTargets.map(async (target) => {
+			const blob = isWavPcmRecording
+				? await buildPcmTrackWavBlob(target)
+				: await buildTrackBlob(target);
+			if (!blob) {
+				return null;
+			}
+			const arrayBuffer = await blob.arrayBuffer();
+			return audioContext.decodeAudioData(arrayBuffer);
+		}),
+	);
+
+	const validBuffers = buffers.filter(
+		(buffer): buffer is AudioBuffer => buffer !== null,
+	);
+	if (validBuffers.length === 0) {
+		throw new Error('No audio data recorded');
+	}
+
+	const longestDuration = Math.max(
+		...validBuffers.map((buffer) => buffer.duration),
+	);
+	const offlineContext = new OfflineAudioContext(
+		2,
+		audioContext.sampleRate * longestDuration,
+		audioContext.sampleRate,
+	);
+
+	validBuffers.forEach((buffer) => {
+		const source = offlineContext.createBufferSource();
+		source.buffer = buffer;
+		source.connect(offlineContext.destination);
+		source.start(0);
+	});
+
+	const renderedBuffer = await offlineContext.startRendering();
+	await audioContext.close();
+
+	const targetFormat = settings.recordingFormat;
+	if (
+		targetFormat !== FORMAT_WAV &&
+		isOfflineEncodingSupported(targetFormat)
+	) {
+		return encodeAudioBuffer(
+			renderedBuffer,
+			{
+				format: targetFormat,
+				bitrate: settings.bitrate,
+			},
+			(percent) => {
+				onProgress?.(
+					40 + Math.round(percent * 0.2),
+					'Encoding audio...',
+				);
+			},
+		);
+	}
+	return bufferToWave(renderedBuffer, renderedBuffer.length);
+}

--- a/src/recording/NoteInserter.ts
+++ b/src/recording/NoteInserter.ts
@@ -1,0 +1,92 @@
+/**
+ * Note link insertion utilities for the recording pipeline.
+ * Handles capturing cursor context and inserting audio file links
+ * into Obsidian notes.
+ * @module recording/NoteInserter
+ */
+
+import { MarkdownView } from 'obsidian';
+import type { App } from 'obsidian';
+import type { InsertionContext } from '../types';
+import type { DebugLogger } from '../utils/DebugLogger';
+
+/**
+ * Captures the active note path and cursor position for later
+ * insertion of audio links.
+ * @param app - Obsidian App instance
+ * @param insertAtOriginalPosition - Whether to capture context
+ * @param debugLogger - Logger for debug output
+ * @returns Captured insertion context, or null if disabled or unavailable
+ */
+export function captureInsertionContext(
+	app: App,
+	insertAtOriginalPosition: boolean,
+	debugLogger: DebugLogger,
+): InsertionContext | null {
+	if (!insertAtOriginalPosition) {
+		return null;
+	}
+	const view = app.workspace.getActiveViewOfType(MarkdownView);
+	const filePath = view?.file?.path;
+	const cursor = view?.editor?.getCursor();
+	if (filePath && cursor) {
+		return {
+			filePath,
+			line: cursor.line,
+			ch: cursor.ch,
+		};
+	}
+	debugLogger.log(
+		'Could not capture insertion context: no active Markdown view',
+	);
+	return null;
+}
+
+/**
+ * Inserts Obsidian embed links for the given file paths into a note.
+ * Uses the captured insertion context if available, otherwise falls
+ * back to the currently active editor.
+ * @param fileLinks - Array of saved file paths
+ * @param insertionContext - Previously captured cursor context
+ * @param app - Obsidian App instance
+ */
+export function insertFileLinks(
+	fileLinks: string[],
+	insertionContext: InsertionContext | null,
+	app: App,
+): void {
+	const links = fileLinks
+		.map((path) => {
+			const fileName = path.split('/').pop() ?? path;
+			return `![[${fileName}]]`;
+		})
+		.join('\n');
+
+	if (insertionContext) {
+		const leaf = app.workspace.getLeavesOfType('markdown').find((l) => {
+			const leafView = l.view;
+			return (
+				leafView instanceof MarkdownView &&
+				leafView.file?.path === insertionContext.filePath
+			);
+		});
+
+		const leafView = leaf?.view;
+		if (leafView instanceof MarkdownView) {
+			const editor = leafView.editor;
+			const pos = {
+				line: insertionContext.line + 1,
+				ch: 0,
+			};
+			editor.replaceRange(links + '\n', pos);
+			return;
+		}
+	}
+
+	// Fallback: insert into the currently active note
+	const activeView = app.workspace.getActiveViewOfType(MarkdownView);
+	const editor = activeView?.editor;
+	if (editor) {
+		editor.replaceSelection(links);
+	}
+}

--- a/src/recording/RecordingFileManager.ts
+++ b/src/recording/RecordingFileManager.ts
@@ -1,0 +1,196 @@
+/**
+ * File I/O operations for the recording pipeline.
+ * Handles path resolution, saving, temporary file cleanup, and rollback.
+ * @module recording/RecordingFileManager
+ */
+
+import { normalizePath } from 'obsidian';
+import type { App } from 'obsidian';
+import type { AudioRecorderSettings } from '../settings/Settings';
+import type { RecordingTarget } from '../types';
+import { PLUGIN_LOG_PREFIX } from '../constants';
+
+/**
+ * Returns the directory of the currently active Markdown file.
+ * @param app - Obsidian App instance
+ * @returns Directory path or empty string if no active .md file
+ */
+export function getActiveFileDirectory(app: App): string {
+	const activeFile = app.workspace.getActiveFile();
+	if (!activeFile || !activeFile.path.toLowerCase().endsWith('.md')) {
+		return '';
+	}
+	const segments = activeFile.path.split('/');
+	segments.pop();
+	return segments.join('/');
+}
+
+/**
+ * Resolves the base save directory based on plugin settings.
+ * @param settings - Plugin settings
+ * @param app - Obsidian App instance
+ * @returns Normalized directory path
+ */
+export function getBaseSaveDirectory(
+	settings: AudioRecorderSettings,
+	app: App,
+): string {
+	if (settings.saveNearActiveFile) {
+		const activeDirectory = getActiveFileDirectory(app);
+		if (settings.activeFileSubfolder.trim() === '') {
+			return activeDirectory;
+		}
+		return normalizePath(
+			`${activeDirectory}/${settings.activeFileSubfolder}`,
+		);
+	}
+	return settings.saveFolder;
+}
+
+/**
+ * Creates a folder if it does not exist.
+ * @param path - Folder path to ensure
+ * @param app - Obsidian App instance
+ */
+export async function ensureFolderExists(
+	path: string,
+	app: App,
+): Promise<void> {
+	const normalizedPath = normalizePath(path).trim();
+	if (!normalizedPath) {
+		return;
+	}
+	if (await app.vault.adapter.exists(normalizedPath)) {
+		return;
+	}
+	await app.vault.createFolder(normalizedPath);
+}
+
+/**
+ * Resolves a unique file path, appending a counter suffix if needed.
+ * @param fileName - Desired file name
+ * @param app - Obsidian App instance
+ * @param settings - Plugin settings
+ * @returns Unique normalized file path
+ */
+export async function resolveUniquePath(
+	fileName: string,
+	app: App,
+	settings: AudioRecorderSettings,
+): Promise<string> {
+	let sanitizedFileName = fileName.replace(/[\\/:*?"<>|]/g, '-');
+	const baseDirectory = getBaseSaveDirectory(settings, app);
+	await ensureFolderExists(baseDirectory, app);
+	let filePath = normalizePath(`${baseDirectory}/${sanitizedFileName}`);
+
+	let counter = 1;
+	while (await app.vault.adapter.exists(filePath)) {
+		const parts = sanitizedFileName.split('.');
+		const ext = parts.pop() ?? '';
+		const name = parts.join('.');
+		sanitizedFileName = `${name}_${String(counter)}.${ext}`;
+		filePath = normalizePath(`${baseDirectory}/${sanitizedFileName}`);
+		counter++;
+	}
+
+	return filePath;
+}
+
+/**
+ * Saves an audio Blob as a binary file in the vault.
+ * @param audioBlob - Audio data to save
+ * @param fileName - Desired file name
+ * @param app - Obsidian App instance
+ * @param settings - Plugin settings
+ * @returns File path on success, null if blob is empty
+ */
+export async function saveAudioFile(
+	audioBlob: Blob,
+	fileName: string,
+	app: App,
+	settings: AudioRecorderSettings,
+): Promise<string | null> {
+	if (audioBlob.size === 0) {
+		console.debug(`${PLUGIN_LOG_PREFIX} Skipping empty file: ${fileName}`);
+		return null;
+	}
+
+	const arrayBuffer = await audioBlob.arrayBuffer();
+	const filePath = await resolveUniquePath(fileName, app, settings);
+
+	await app.vault.createBinary(filePath, arrayBuffer);
+	return filePath;
+}
+
+/**
+ * Removes temporary files from the vault, collecting any that fail.
+ * @param paths - File paths to remove
+ * @param logContext - Context message for warning logs on failure
+ * @param app - Obsidian App instance
+ * @returns Array of paths that could not be removed
+ */
+export async function removeTemporaryArtifacts(
+	paths: string[],
+	logContext: string,
+	app: App,
+): Promise<string[]> {
+	const failedPaths: string[] = [];
+
+	await Promise.all(
+		paths.map(async (path) => {
+			try {
+				await app.vault.adapter.remove(path);
+			} catch (error) {
+				failedPaths.push(path);
+				console.warn(`${PLUGIN_LOG_PREFIX} ${logContext}:`, {
+					path,
+					error,
+				});
+			}
+		}),
+	);
+
+	return failedPaths;
+}
+
+/**
+ * Attempts to remove a finalized file during rollback.
+ * @param filePath - Path of the file to remove
+ * @param logContext - Context message for error logs
+ * @param app - Obsidian App instance
+ */
+export async function rollbackFinalFile(
+	filePath: string,
+	logContext: string,
+	app: App,
+): Promise<void> {
+	try {
+		await app.vault.adapter.remove(filePath);
+	} catch (error) {
+		console.error(`${PLUGIN_LOG_PREFIX} ${logContext}:`, {
+			filePath,
+			error,
+		});
+	}
+}
+
+/**
+ * Removes all intermediate segment files across recording targets.
+ * @param chunkTargets - Recording targets with segment paths
+ * @param app - Obsidian App instance
+ * @returns Array of paths that could not be removed
+ */
+export async function cleanupIntermediateFiles(
+	chunkTargets: RecordingTarget[],
+	app: App,
+): Promise<string[]> {
+	const intermediatePaths = chunkTargets.flatMap(
+		(target) => target.segmentPaths,
+	);
+
+	return removeTemporaryArtifacts(
+		intermediatePaths,
+		'Failed to remove intermediate recording file',
+		app,
+	);
+}

--- a/src/recording/RecordingManager.ts
+++ b/src/recording/RecordingManager.ts
@@ -3,10 +3,10 @@
  * @module recording/RecordingManager
  */
 
-import { MarkdownView, normalizePath, Notice, Platform } from 'obsidian';
+import { Notice, Platform } from 'obsidian';
 import type { App } from 'obsidian';
 import { RecordingStatus } from '../types';
-import type { InsertionContext, SaveProgress } from '../types';
+import type { InsertionContext, RecordingTarget, SaveProgress } from '../types';
 import type { AudioRecorderSettings } from '../settings/Settings';
 import {
 	getAudioStreams,
@@ -14,37 +14,39 @@ import {
 	stopAllStreams,
 	validateSelectedDevices,
 } from './AudioStreamHandler';
-import { bufferToWave, assembleWavFromPcmSegments } from './WavEncoder';
-import { encodeAudioBuffer, isOfflineEncodingSupported } from './AudioEncoder';
-import { PLUGIN_LOG_PREFIX } from '../constants';
+import { assembleWavFromPcmSegments } from './WavEncoder';
+import {
+	PLUGIN_LOG_PREFIX,
+	CHUNK_TIMESLICE_MS,
+	MOBILE_BUFFER_LIMIT_BYTES,
+	PCM_FLUSH_THRESHOLD_BYTES,
+} from '../constants';
 import { DebugLogger } from '../utils/DebugLogger';
 import {
 	buildMimeType,
 	validateRecordingCapability,
 	FORMAT_WEBM,
-	FORMAT_OGG,
 	FORMAT_WAV,
 } from './AudioCapabilityDetector';
+import { isOfflineEncodingSupported } from './AudioEncoder';
 import { PcmStreamRecorder } from './PcmStreamRecorder';
-
-type RecordingTarget = {
-	fileBaseName: string;
-	sourceName: string;
-	bufferedChunks: Blob[];
-	bufferedBytes: number;
-	segmentIndex: number;
-	segmentPaths: string[];
-	pendingWrite: Promise<void>;
-	pcmBuffers: ArrayBuffer[];
-	pcmBufferedBytes: number;
-	pcmChannels: number;
-	pcmSampleRate: number;
-};
-
-const CHUNK_TIMESLICE_MS = 5000;
-const MOBILE_BUFFER_LIMIT_BYTES = 50 * 1024 * 1024;
-const PCM_FLUSH_THRESHOLD_BYTES = 50 * 1024 * 1024;
-const MIME_TYPE_AUDIO_PREFIX = 'audio/';
+import {
+	resolveUniquePath,
+	saveAudioFile,
+	removeTemporaryArtifacts,
+	rollbackFinalFile,
+	cleanupIntermediateFiles,
+} from './RecordingFileManager';
+import {
+	resolveRecorderFormat,
+	isOfflineOnlyFormat,
+	getRecorderMediaType,
+	convertBlobToWav,
+	convertBlobToFormat,
+	buildOutputBlob,
+	mergeAudioTracks,
+} from './AudioFormatConverter';
+import { captureInsertionContext, insertFileLinks } from './NoteInserter';
 
 /**
  * Manages the audio recording lifecycle.
@@ -125,8 +127,9 @@ export class RecordingManager {
 				!this.isMobileRecording;
 
 			if (!this.isWavPcmRecording) {
-				const { recorderFormat, mimeType } =
-					this.resolveRecorderFormat();
+				const { recorderFormat, mimeType } = resolveRecorderFormat(
+					this.settings,
+				);
 				this.activeRecorderFormat = recorderFormat;
 				this.debugLogger.logMimeType(mimeType);
 				this.debugLogger.log('Recording format configuration', {
@@ -166,7 +169,11 @@ export class RecordingManager {
 				await this.initMediaRecording();
 			}
 
-			this.captureInsertionContext();
+			this.insertionContext = captureInsertionContext(
+				this.app,
+				this.settings.insertAtOriginalPosition,
+				this.debugLogger,
+			);
 			this.setStatus(RecordingStatus.Recording);
 			new Notice('Recording started');
 		} catch (error) {
@@ -463,21 +470,35 @@ export class RecordingManager {
 						'Merged multi-track output saved as .wav (encoding unavailable for this format).',
 					);
 				}
-				const mergedAudio = await this.mergeAudioTracks();
+				const mergedAudio = await mergeAudioTracks(
+					this.chunkTargets,
+					this.settings,
+					this.isWavPcmRecording,
+					(target) => this.buildPcmTrackWavBlob(target),
+					(target) => this.buildTrackBlob(target),
+					(percent, description) => {
+						this.updateSaveProgress(percent, description);
+					},
+				);
 				this.updateSaveProgress(60, 'Writing file...');
 				const fileName = `${this.settings.filePrefix}-multitrack-${timestamp}.${targetFormat}`;
-				const filePath = await this.saveAudioFile(
+				const filePath = await saveAudioFile(
 					mergedAudio,
 					fileName,
+					this.app,
+					this.settings,
 				);
 				if (filePath) {
 					this.updateSaveProgress(80, 'Cleaning up...');
-					const failedCleanupPaths =
-						await this.cleanupIntermediateFiles();
+					const failedCleanupPaths = await cleanupIntermediateFiles(
+						this.chunkTargets,
+						this.app,
+					);
 					if (failedCleanupPaths.length > 0) {
-						await this.rollbackFinalFile(
+						await rollbackFinalFile(
 							filePath,
 							'Failed to finalize recording cleanup for merged output',
+							this.app,
 						);
 						throw new Error(
 							`Temporary recording artifacts were kept for recovery: ${failedCleanupPaths.join(', ')}`,
@@ -497,74 +518,11 @@ export class RecordingManager {
 		}
 
 		if (fileLinks.length > 0) {
-			this.insertFileLinks(fileLinks);
+			insertFileLinks(fileLinks, this.insertionContext, this.app);
 			new Notice(`Saved ${String(fileLinks.length)} audio file(s)`);
 		} else {
 			new Notice('No audio data recorded');
 		}
-	}
-
-	private async mergeAudioTracks(): Promise<Blob> {
-		const audioContext = new AudioContext();
-		const buffers = await Promise.all(
-			this.chunkTargets.map(async (target) => {
-				const blob = this.isWavPcmRecording
-					? await this.buildPcmTrackWavBlob(target)
-					: await this.buildTrackBlob(target);
-				if (!blob) {
-					return null;
-				}
-				const arrayBuffer = await blob.arrayBuffer();
-				return audioContext.decodeAudioData(arrayBuffer);
-			}),
-		);
-
-		const validBuffers = buffers.filter(
-			(buffer): buffer is AudioBuffer => buffer !== null,
-		);
-		if (validBuffers.length === 0) {
-			throw new Error('No audio data recorded');
-		}
-
-		const longestDuration = Math.max(
-			...validBuffers.map((buffer) => buffer.duration),
-		);
-		const offlineContext = new OfflineAudioContext(
-			2,
-			audioContext.sampleRate * longestDuration,
-			audioContext.sampleRate,
-		);
-
-		validBuffers.forEach((buffer) => {
-			const source = offlineContext.createBufferSource();
-			source.buffer = buffer;
-			source.connect(offlineContext.destination);
-			source.start(0);
-		});
-
-		const renderedBuffer = await offlineContext.startRendering();
-		await audioContext.close();
-
-		const targetFormat = this.settings.recordingFormat;
-		if (
-			targetFormat !== FORMAT_WAV &&
-			isOfflineEncodingSupported(targetFormat)
-		) {
-			return encodeAudioBuffer(
-				renderedBuffer,
-				{
-					format: targetFormat,
-					bitrate: this.settings.bitrate,
-				},
-				(percent) => {
-					this.updateSaveProgress(
-						40 + Math.round(percent * 0.2),
-						'Encoding audio...',
-					);
-				},
-			);
-		}
-		return bufferToWave(renderedBuffer, renderedBuffer.length);
 	}
 
 	private async handleChunk(index: number, data: Blob): Promise<void> {
@@ -586,7 +544,11 @@ export class RecordingManager {
 			try {
 				target.segmentIndex += 1;
 				const segmentName = `${target.fileBaseName}-part${String(target.segmentIndex)}.${this.activeRecorderFormat}.tmp`;
-				const segmentPath = await this.resolveUniquePath(segmentName);
+				const segmentPath = await resolveUniquePath(
+					segmentName,
+					this.app,
+					this.settings,
+				);
 				const arrayBuffer = await data.arrayBuffer();
 				await this.app.vault.createBinary(segmentPath, arrayBuffer);
 				target.segmentPaths.push(segmentPath);
@@ -633,7 +595,11 @@ export class RecordingManager {
 		}
 		target.segmentIndex += 1;
 		const segmentName = `${target.fileBaseName}-pcm-part${String(target.segmentIndex)}.tmp`;
-		const segmentPath = await this.resolveUniquePath(segmentName);
+		const segmentPath = await resolveUniquePath(
+			segmentName,
+			this.app,
+			this.settings,
+		);
 
 		const totalSize = target.pcmBuffers.reduce(
 			(sum, buf) => sum + buf.byteLength,
@@ -670,14 +636,16 @@ export class RecordingManager {
 
 		await this.app.vault.createBinary(filePath, wavBuffer);
 
-		const failedPaths = await this.removeTemporaryArtifacts(
+		const failedPaths = await removeTemporaryArtifacts(
 			target.segmentPaths,
 			'Failed to remove PCM segment file after WAV assembly',
+			this.app,
 		);
 		if (failedPaths.length > 0) {
-			await this.rollbackFinalFile(
+			await rollbackFinalFile(
 				filePath,
 				'Failed to rollback assembled WAV file',
+				this.app,
 			);
 			throw new Error(
 				`Temporary recording artifacts were kept for recovery: ${failedPaths.join(', ')}`,
@@ -724,8 +692,16 @@ export class RecordingManager {
 		const segmentName = `${target.fileBaseName}-part${String(
 			target.segmentIndex,
 		)}.${this.settings.recordingFormat}`;
-		const segmentPath = await this.resolveUniquePath(segmentName);
-		const outputBlob = await this.buildOutputBlob(target.bufferedChunks);
+		const segmentPath = await resolveUniquePath(
+			segmentName,
+			this.app,
+			this.settings,
+		);
+		const outputBlob = await buildOutputBlob(
+			target.bufferedChunks,
+			getRecorderMediaType(this.activeRecorderFormat),
+			this.settings.recordingFormat,
+		);
 		await this.app.vault.createBinary(
 			segmentPath,
 			await outputBlob.arrayBuffer(),
@@ -745,7 +721,7 @@ export class RecordingManager {
 			return null;
 		}
 
-		const type = this.getRecorderMediaType();
+		const type = getRecorderMediaType(this.activeRecorderFormat);
 		const segmentBuffers = await Promise.all(
 			target.segmentPaths.map((path) =>
 				this.app.vault.adapter.readBinary(path),
@@ -755,54 +731,6 @@ export class RecordingManager {
 		return new Blob([...segmentBuffers, ...target.bufferedChunks], {
 			type,
 		});
-	}
-
-	private async cleanupIntermediateFiles(): Promise<string[]> {
-		const intermediatePaths = this.chunkTargets.flatMap(
-			(target) => target.segmentPaths,
-		);
-
-		return this.removeTemporaryArtifacts(
-			intermediatePaths,
-			'Failed to remove intermediate recording file',
-		);
-	}
-
-	private async removeTemporaryArtifacts(
-		paths: string[],
-		logContext: string,
-	): Promise<string[]> {
-		const failedPaths: string[] = [];
-
-		await Promise.all(
-			paths.map(async (path) => {
-				try {
-					await this.app.vault.adapter.remove(path);
-				} catch (error) {
-					failedPaths.push(path);
-					console.warn(`${PLUGIN_LOG_PREFIX} ${logContext}:`, {
-						path,
-						error,
-					});
-				}
-			}),
-		);
-
-		return failedPaths;
-	}
-
-	private async rollbackFinalFile(
-		filePath: string,
-		logContext: string,
-	): Promise<void> {
-		try {
-			await this.app.vault.adapter.remove(filePath);
-		} catch (error) {
-			console.error(`${PLUGIN_LOG_PREFIX} ${logContext}:`, {
-				filePath,
-				error,
-			});
-		}
 	}
 
 	private async finalizeTrackFiles(
@@ -824,7 +752,11 @@ export class RecordingManager {
 			}
 			this.updateSaveProgress(40, 'Assembling audio...');
 			const fileName = `${this.settings.filePrefix}-${target.sourceName}-${timestamp}.wav`;
-			const filePath = await this.resolveUniquePath(fileName);
+			const filePath = await resolveUniquePath(
+				fileName,
+				this.app,
+				this.settings,
+			);
 			this.updateSaveProgress(60, 'Writing file...');
 			await this.assembleWavFile(target, filePath);
 			fileLinks.push(filePath);
@@ -838,22 +770,35 @@ export class RecordingManager {
 
 		const outputFormat = this.settings.recordingFormat;
 		const fileName = `${this.settings.filePrefix}-${target.sourceName}-${timestamp}.${outputFormat}`;
-		const filePath = await this.resolveUniquePath(fileName);
+		const filePath = await resolveUniquePath(
+			fileName,
+			this.app,
+			this.settings,
+		);
 
 		if (this.settings.recordingFormat === FORMAT_WAV) {
 			this.updateSaveProgress(40, 'Assembling audio...');
-			const wavBlob = await this.convertBlobToWav(blob);
+			const wavBlob = await convertBlobToWav(blob);
 			this.updateSaveProgress(60, 'Writing file...');
 			await this.app.vault.createBinary(
 				filePath,
 				await wavBlob.arrayBuffer(),
 			);
-		} else if (this.isOfflineOnlyFormat(outputFormat)) {
+		} else if (
+			isOfflineOnlyFormat(outputFormat, this.activeRecorderFormat)
+		) {
 			// Offline-only format: decode intermediate blob, re-encode to target
-			this.updateSaveProgress(40, 'Decoding intermediate audio...');
-			const outputBlob = await this.convertBlobToFormat(
+			this.updateSaveProgress(40, 'Encoding audio...');
+			const outputBlob = await convertBlobToFormat(
 				blob,
 				outputFormat,
+				this.settings.bitrate,
+				(percent) => {
+					this.updateSaveProgress(
+						40 + Math.round(percent * 0.2),
+						'Encoding audio...',
+					);
+				},
 			);
 			this.updateSaveProgress(60, 'Writing file...');
 			await this.app.vault.createBinary(
@@ -869,14 +814,16 @@ export class RecordingManager {
 		}
 
 		this.updateSaveProgress(80, 'Cleaning up...');
-		const failedCleanupPaths = await this.removeTemporaryArtifacts(
+		const failedCleanupPaths = await removeTemporaryArtifacts(
 			target.segmentPaths,
 			'Failed to remove segment file after finalization',
+			this.app,
 		);
 		if (failedCleanupPaths.length > 0) {
-			await this.rollbackFinalFile(
+			await rollbackFinalFile(
 				filePath,
 				'Failed to rollback finalized track',
+				this.app,
 			);
 			throw new Error(
 				`Temporary recording artifacts were kept for recovery: ${failedCleanupPaths.join(', ')}`,
@@ -885,238 +832,5 @@ export class RecordingManager {
 
 		fileLinks.push(filePath);
 		return fileLinks;
-	}
-
-	private getActiveFileDirectory(): string {
-		const activeFile = this.app.workspace.getActiveFile();
-		if (!activeFile || !activeFile.path.toLowerCase().endsWith('.md')) {
-			return '';
-		}
-		const segments = activeFile.path.split('/');
-		segments.pop();
-		return segments.join('/');
-	}
-
-	private getBaseSaveDirectory(): string {
-		if (this.settings.saveNearActiveFile) {
-			const activeDirectory = this.getActiveFileDirectory();
-			if (this.settings.activeFileSubfolder.trim() === '') {
-				return activeDirectory;
-			}
-			return normalizePath(
-				`${activeDirectory}/${this.settings.activeFileSubfolder}`,
-			);
-		}
-		return this.settings.saveFolder;
-	}
-
-	private async ensureFolderExists(path: string): Promise<void> {
-		const normalizedPath = normalizePath(path).trim();
-		if (!normalizedPath) {
-			return;
-		}
-		if (await this.app.vault.adapter.exists(normalizedPath)) {
-			return;
-		}
-		await this.app.vault.createFolder(normalizedPath);
-	}
-
-	private async resolveUniquePath(fileName: string): Promise<string> {
-		let sanitizedFileName = fileName.replace(/[\\/:*?"<>|]/g, '-');
-		const baseDirectory = this.getBaseSaveDirectory();
-		await this.ensureFolderExists(baseDirectory);
-		let filePath = normalizePath(`${baseDirectory}/${sanitizedFileName}`);
-
-		let counter = 1;
-		while (await this.app.vault.adapter.exists(filePath)) {
-			const parts = sanitizedFileName.split('.');
-			const ext = parts.pop() ?? '';
-			const name = parts.join('.');
-			sanitizedFileName = `${name}_${String(counter)}.${ext}`;
-			filePath = normalizePath(`${baseDirectory}/${sanitizedFileName}`);
-			counter++;
-		}
-
-		return filePath;
-	}
-
-	private async saveAudioFile(
-		audioBlob: Blob,
-		fileName: string,
-	): Promise<string | null> {
-		if (audioBlob.size === 0) {
-			console.debug(
-				`${PLUGIN_LOG_PREFIX} Skipping empty file: ${fileName}`,
-			);
-			return null;
-		}
-
-		const arrayBuffer = await audioBlob.arrayBuffer();
-		const filePath = await this.resolveUniquePath(fileName);
-
-		await this.app.vault.createBinary(filePath, arrayBuffer);
-		return filePath;
-	}
-
-	private resolveRecorderFormat(): {
-		recorderFormat: string;
-		mimeType: string;
-	} {
-		const outputFormat = this.settings.recordingFormat.toLowerCase();
-
-		// Check if MediaRecorder natively supports this format
-		const nativeMime = buildMimeType(outputFormat);
-		if (
-			outputFormat !== FORMAT_WAV &&
-			MediaRecorder.isTypeSupported(nativeMime)
-		) {
-			return { recorderFormat: outputFormat, mimeType: nativeMime };
-		}
-
-		// WAV and offline-only formats need an intermediate compressed format
-		const preferredCompressedFormats = [FORMAT_WEBM, FORMAT_OGG];
-		for (const format of preferredCompressedFormats) {
-			const mimeType = buildMimeType(format);
-			if (MediaRecorder.isTypeSupported(mimeType)) {
-				return { recorderFormat: format, mimeType };
-			}
-		}
-		throw new Error(
-			`Output format "${outputFormat}" requires an intermediate compressed format, but neither WebM nor OGG is supported in this browser.`,
-		);
-	}
-
-	private getRecorderMediaType(): string {
-		return `${MIME_TYPE_AUDIO_PREFIX}${this.activeRecorderFormat}`;
-	}
-
-	private async buildOutputBlob(chunks: Blob[]): Promise<Blob> {
-		const recordedBlob = new Blob(chunks, {
-			type: this.getRecorderMediaType(),
-		});
-		const isWav = this.settings.recordingFormat === FORMAT_WAV;
-		if (!isWav) {
-			return recordedBlob;
-		}
-		return this.convertBlobToWav(recordedBlob);
-	}
-
-	private async convertBlobToWav(recordedBlob: Blob): Promise<Blob> {
-		const audioContext = new AudioContext();
-		try {
-			const arrayBuffer = await recordedBlob.arrayBuffer();
-			const decodedBuffer =
-				await audioContext.decodeAudioData(arrayBuffer);
-			return bufferToWave(decodedBuffer, decodedBuffer.length);
-		} finally {
-			await audioContext.close();
-		}
-	}
-
-	/**
-	 * Checks if a format requires offline encoding (not natively
-	 * supported by MediaRecorder) and the recorder uses an intermediate format.
-	 */
-	private isOfflineOnlyFormat(format: string): boolean {
-		return (
-			format !== FORMAT_WAV &&
-			this.activeRecorderFormat !== format &&
-			isOfflineEncodingSupported(format)
-		);
-	}
-
-	/**
-	 * Decodes an intermediate blob and re-encodes it to the target format.
-	 * Uses OfflineAudioContext at the native sample rate to avoid
-	 * resampling artifacts.
-	 */
-	private async convertBlobToFormat(
-		recordedBlob: Blob,
-		targetFormat: string,
-	): Promise<Blob> {
-		const arrayBuffer = await recordedBlob.arrayBuffer();
-
-		// Probe native sample rate
-		const probeCtx = new AudioContext();
-		const probeBuffer = await probeCtx.decodeAudioData(
-			arrayBuffer.slice(0),
-		);
-		const nativeSampleRate = probeBuffer.sampleRate;
-		await probeCtx.close();
-
-		// Re-decode at native rate to avoid resampling
-		const offlineCtx = new OfflineAudioContext(
-			probeBuffer.numberOfChannels,
-			probeBuffer.length,
-			nativeSampleRate,
-		);
-		const decodedBuffer = await offlineCtx.decodeAudioData(arrayBuffer);
-
-		return encodeAudioBuffer(decodedBuffer, {
-			format: targetFormat,
-			bitrate: this.settings.bitrate,
-		});
-	}
-
-	/**
-	 * Captures the active note and cursor position for later insertion.
-	 */
-	private captureInsertionContext(): void {
-		if (!this.settings.insertAtOriginalPosition) {
-			return;
-		}
-		const view = this.app.workspace.getActiveViewOfType(MarkdownView);
-		const filePath = view?.file?.path;
-		const cursor = view?.editor?.getCursor();
-		if (filePath && cursor) {
-			this.insertionContext = {
-				filePath,
-				line: cursor.line,
-				ch: cursor.ch,
-			};
-		} else {
-			this.debugLogger.log(
-				'Could not capture insertion context: no active Markdown view',
-			);
-		}
-	}
-
-	private insertFileLinks(fileLinks: string[]): void {
-		const links = fileLinks
-			.map((path) => {
-				const fileName = path.split('/').pop() ?? path;
-				return `![[${fileName}]]`;
-			})
-			.join('\n');
-
-		if (this.insertionContext) {
-			const leaf = this.app.workspace
-				.getLeavesOfType('markdown')
-				.find((l) => {
-					const leafView = l.view;
-					return (
-						leafView instanceof MarkdownView &&
-						leafView.file?.path === this.insertionContext?.filePath
-					);
-				});
-
-			const leafView = leaf?.view;
-			if (leafView instanceof MarkdownView) {
-				const editor = leafView.editor;
-				const pos = {
-					line: this.insertionContext.line + 1,
-					ch: 0,
-				};
-				editor.replaceRange(links + '\n', pos);
-				return;
-			}
-		}
-
-		// Fallback: insert into the currently active note
-		const activeView = this.app.workspace.getActiveViewOfType(MarkdownView);
-		const editor = activeView?.editor;
-		if (editor) {
-			editor.replaceSelection(links);
-		}
 	}
 }

--- a/src/recording/RecordingManager.ts
+++ b/src/recording/RecordingManager.ts
@@ -20,6 +20,7 @@ import {
 	CHUNK_TIMESLICE_MS,
 	MOBILE_BUFFER_LIMIT_BYTES,
 	PCM_FLUSH_THRESHOLD_BYTES,
+	DESKTOP_FLUSH_THRESHOLD_BYTES,
 } from '../constants';
 import { DebugLogger } from '../utils/DebugLogger';
 import {
@@ -436,10 +437,10 @@ export class RecordingManager {
 				);
 				fileLinks.push(...paths);
 			} else {
-				if (this.isMobileRecording) {
+				if (!this.isWavPcmRecording) {
 					await Promise.all(
 						this.chunkTargets.map((target) =>
-							this.flushMobileBuffer(target),
+							this.flushChunkBuffer(target),
 						),
 					);
 				}
@@ -531,35 +532,15 @@ export class RecordingManager {
 			return;
 		}
 		this.totalChunks += 1;
-		const enqueue = async (): Promise<void> => {
-			if (this.isMobileRecording) {
-				target.bufferedChunks.push(data);
-				target.bufferedBytes += data.size;
-				if (target.bufferedBytes >= MOBILE_BUFFER_LIMIT_BYTES) {
-					await this.flushMobileBuffer(target);
-				}
-				return;
-			}
+		const flushThreshold = this.isMobileRecording
+			? MOBILE_BUFFER_LIMIT_BYTES
+			: DESKTOP_FLUSH_THRESHOLD_BYTES;
 
-			try {
-				target.segmentIndex += 1;
-				const segmentName = `${target.fileBaseName}-part${String(target.segmentIndex)}.${this.activeRecorderFormat}.tmp`;
-				const segmentPath = await resolveUniquePath(
-					segmentName,
-					this.app,
-					this.settings,
-				);
-				const arrayBuffer = await data.arrayBuffer();
-				await this.app.vault.createBinary(segmentPath, arrayBuffer);
-				target.segmentPaths.push(segmentPath);
-			} catch (error) {
-				console.error(
-					`${PLUGIN_LOG_PREFIX} Failed to write segment:`,
-					error,
-				);
-				new Notice(
-					'Failed to save recording chunk. Check console for details.',
-				);
+		const enqueue = async (): Promise<void> => {
+			target.bufferedChunks.push(data);
+			target.bufferedBytes += data.size;
+			if (target.bufferedBytes >= flushThreshold) {
+				await this.flushChunkBuffer(target);
 			}
 		};
 
@@ -684,29 +665,50 @@ export class RecordingManager {
 		return new Blob([wavBuffer], { type: 'audio/wav' });
 	}
 
-	private async flushMobileBuffer(target: RecordingTarget): Promise<void> {
+	private async flushChunkBuffer(target: RecordingTarget): Promise<void> {
 		if (target.bufferedChunks.length === 0) {
 			return;
 		}
 		target.segmentIndex += 1;
-		const segmentName = `${target.fileBaseName}-part${String(
-			target.segmentIndex,
-		)}.${this.settings.recordingFormat}`;
-		const segmentPath = await resolveUniquePath(
-			segmentName,
-			this.app,
-			this.settings,
-		);
-		const outputBlob = await buildOutputBlob(
-			target.bufferedChunks,
-			getRecorderMediaType(this.activeRecorderFormat),
-			this.settings.recordingFormat,
-		);
-		await this.app.vault.createBinary(
-			segmentPath,
-			await outputBlob.arrayBuffer(),
-		);
-		target.segmentPaths.push(segmentPath);
+
+		if (this.isMobileRecording) {
+			// Mobile: encode/convert chunks via buildOutputBlob pipeline
+			const segmentName = `${target.fileBaseName}-part${String(
+				target.segmentIndex,
+			)}.${this.settings.recordingFormat}`;
+			const segmentPath = await resolveUniquePath(
+				segmentName,
+				this.app,
+				this.settings,
+			);
+			const outputBlob = await buildOutputBlob(
+				target.bufferedChunks,
+				getRecorderMediaType(this.activeRecorderFormat),
+				this.settings.recordingFormat,
+			);
+			await this.app.vault.createBinary(
+				segmentPath,
+				await outputBlob.arrayBuffer(),
+			);
+			target.segmentPaths.push(segmentPath);
+		} else {
+			// Desktop: write raw chunks as a single segment file
+			const segmentName = `${target.fileBaseName}-part${String(target.segmentIndex)}.${this.activeRecorderFormat}.tmp`;
+			const segmentPath = await resolveUniquePath(
+				segmentName,
+				this.app,
+				this.settings,
+			);
+			const combined = new Blob(target.bufferedChunks, {
+				type: getRecorderMediaType(this.activeRecorderFormat),
+			});
+			await this.app.vault.createBinary(
+				segmentPath,
+				await combined.arrayBuffer(),
+			);
+			target.segmentPaths.push(segmentPath);
+		}
+
 		target.bufferedChunks = [];
 		target.bufferedBytes = 0;
 	}
@@ -739,7 +741,7 @@ export class RecordingManager {
 	): Promise<string[]> {
 		const fileLinks: string[] = [];
 		if (this.isMobileRecording) {
-			await this.flushMobileBuffer(target);
+			await this.flushChunkBuffer(target);
 			fileLinks.push(...target.segmentPaths);
 			return fileLinks;
 		}
@@ -763,6 +765,7 @@ export class RecordingManager {
 			return fileLinks;
 		}
 
+		await this.flushChunkBuffer(target);
 		const blob = await this.buildTrackBlob(target);
 		if (!blob || blob.size === 0) {
 			return fileLinks;

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,3 +41,20 @@ export interface InsertionContext {
 	/** Cursor character offset at recording start. */
 	ch: number;
 }
+
+/**
+ * State for a single recording track (audio source).
+ */
+export type RecordingTarget = {
+	fileBaseName: string;
+	sourceName: string;
+	bufferedChunks: Blob[];
+	bufferedBytes: number;
+	segmentIndex: number;
+	segmentPaths: string[];
+	pendingWrite: Promise<void>;
+	pcmBuffers: ArrayBuffer[];
+	pcmBufferedBytes: number;
+	pcmChannels: number;
+	pcmSampleRate: number;
+};

--- a/tests/unit/AudioFormatConverter.test.ts
+++ b/tests/unit/AudioFormatConverter.test.ts
@@ -1,0 +1,802 @@
+/**
+ * Unit tests for AudioFormatConverter module.
+ * Tests format resolution, blob conversion, offline encoding, and track merging.
+ * @module tests/unit/AudioFormatConverter.test
+ */
+/** @jest-environment jsdom */
+
+import type { AudioRecorderSettings } from '../../src/settings/Settings';
+import { DEFAULT_SETTINGS } from '../../src/settings/Settings';
+import type { RecordingTarget } from '../../src/types';
+
+// Mock obsidian module
+jest.mock('obsidian', () => ({
+	normalizePath: (path: string) => path.replace(/\\/g, '/'),
+}));
+
+// Mock AudioEncoder module
+jest.mock('../../src/recording/AudioEncoder', () => ({
+	encodeAudioBuffer: jest
+		.fn()
+		.mockResolvedValue(new Blob(['encoded'], { type: 'audio/mp4' })),
+	isOfflineEncodingSupported: jest.fn((format: string) => {
+		return ['webm', 'ogg', 'mp4', 'm4a', 'aac', 'flac', 'mp3'].includes(
+			format,
+		);
+	}),
+}));
+
+// Mock WavEncoder
+jest.mock('../../src/recording/WavEncoder', () => ({
+	bufferToWave: jest
+		.fn()
+		.mockReturnValue(new Blob(['wav-data'], { type: 'audio/wav' })),
+}));
+
+// Mock AudioBuffer shape used across tests
+const createMockAudioBuffer = (
+	overrides?: Partial<{
+		duration: number;
+		length: number;
+		sampleRate: number;
+		numberOfChannels: number;
+	}>,
+) => ({
+	duration: overrides?.duration ?? 1,
+	length: overrides?.length ?? 44100,
+	sampleRate: overrides?.sampleRate ?? 44100,
+	numberOfChannels: overrides?.numberOfChannels ?? 1,
+	getChannelData: jest.fn().mockReturnValue(new Float32Array(44100)),
+});
+
+// Mock AudioContext
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- required for global mock
+(global as any).AudioContext = jest.fn().mockImplementation(() => ({
+	decodeAudioData: jest.fn().mockResolvedValue(createMockAudioBuffer()),
+	createBufferSource: jest.fn().mockImplementation(() => ({
+		connect: jest.fn(),
+		start: jest.fn(),
+		buffer: null,
+	})),
+	destination: {},
+	close: jest.fn().mockResolvedValue(undefined),
+	sampleRate: 44100,
+}));
+
+// Mock OfflineAudioContext
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- required for global mock
+(global as any).OfflineAudioContext = jest.fn().mockImplementation(() => ({
+	decodeAudioData: jest.fn().mockResolvedValue(createMockAudioBuffer()),
+	createBufferSource: jest.fn().mockImplementation(() => ({
+		connect: jest.fn(),
+		start: jest.fn(),
+		buffer: null,
+	})),
+	startRendering: jest.fn().mockResolvedValue(createMockAudioBuffer()),
+	destination: {},
+}));
+
+// Polyfill Blob.prototype.arrayBuffer for jsdom
+if (!Blob.prototype.arrayBuffer) {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- test polyfill for jsdom
+	(Blob.prototype as any).arrayBuffer = function (): Promise<ArrayBuffer> {
+		return Promise.resolve(new ArrayBuffer(0));
+	};
+}
+
+// Mock MediaRecorder.isTypeSupported — default: support webm and ogg
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- required for global mock
+(global as any).MediaRecorder = {
+	isTypeSupported: jest.fn((mime: string) => {
+		return mime === 'audio/webm' || mime === 'audio/ogg';
+	}),
+};
+
+import {
+	resolveRecorderFormat,
+	isOfflineOnlyFormat,
+	getRecorderMediaType,
+	convertBlobToWav,
+	convertBlobToFormat,
+	buildOutputBlob,
+	mergeAudioTracks,
+} from '../../src/recording/AudioFormatConverter';
+
+describe('AudioFormatConverter', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		// Reset MediaRecorder.isTypeSupported to default
+		(MediaRecorder.isTypeSupported as jest.Mock).mockImplementation(
+			(mime: string) => mime === 'audio/webm' || mime === 'audio/ogg',
+		);
+	});
+
+	// ---------------------------------------------------------------
+	// resolveRecorderFormat
+	// ---------------------------------------------------------------
+	describe('resolveRecorderFormat', () => {
+		it('should return native format when MediaRecorder supports it', () => {
+			const settings: AudioRecorderSettings = {
+				...DEFAULT_SETTINGS,
+				recordingFormat: 'webm',
+			};
+			const result = resolveRecorderFormat(settings);
+			expect(result).toEqual({
+				recorderFormat: 'webm',
+				mimeType: 'audio/webm',
+			});
+		});
+
+		it('should return native format for OGG when supported', () => {
+			const settings: AudioRecorderSettings = {
+				...DEFAULT_SETTINGS,
+				recordingFormat: 'ogg',
+			};
+			const result = resolveRecorderFormat(settings);
+			expect(result).toEqual({
+				recorderFormat: 'ogg',
+				mimeType: 'audio/ogg',
+			});
+		});
+
+		it('should fall back to WebM when native format is not supported', () => {
+			const settings: AudioRecorderSettings = {
+				...DEFAULT_SETTINGS,
+				recordingFormat: 'mp4',
+			};
+			// mp4 not supported natively, but webm is
+			(MediaRecorder.isTypeSupported as jest.Mock).mockImplementation(
+				(mime: string) => mime === 'audio/webm',
+			);
+			const result = resolveRecorderFormat(settings);
+			expect(result).toEqual({
+				recorderFormat: 'webm',
+				mimeType: 'audio/webm',
+			});
+		});
+
+		it('should fall back to OGG when WebM is not supported', () => {
+			const settings: AudioRecorderSettings = {
+				...DEFAULT_SETTINGS,
+				recordingFormat: 'mp4',
+			};
+			(MediaRecorder.isTypeSupported as jest.Mock).mockImplementation(
+				(mime: string) => mime === 'audio/ogg',
+			);
+			const result = resolveRecorderFormat(settings);
+			expect(result).toEqual({
+				recorderFormat: 'ogg',
+				mimeType: 'audio/ogg',
+			});
+		});
+
+		it('should always use intermediate format for WAV (never native)', () => {
+			const settings: AudioRecorderSettings = {
+				...DEFAULT_SETTINGS,
+				recordingFormat: 'wav',
+			};
+			const result = resolveRecorderFormat(settings);
+			// WAV always falls through to intermediate compressed format
+			expect(result.recorderFormat).toBe('webm');
+			expect(result.mimeType).toBe('audio/webm');
+		});
+
+		it('should throw when neither WebM nor OGG is supported', () => {
+			const settings: AudioRecorderSettings = {
+				...DEFAULT_SETTINGS,
+				recordingFormat: 'mp4',
+			};
+			(MediaRecorder.isTypeSupported as jest.Mock).mockReturnValue(false);
+			expect(() => resolveRecorderFormat(settings)).toThrow(
+				/neither WebM nor OGG is supported/,
+			);
+		});
+
+		it('should treat format case-insensitively', () => {
+			const settings: AudioRecorderSettings = {
+				...DEFAULT_SETTINGS,
+				recordingFormat: 'WEBM',
+			};
+			const result = resolveRecorderFormat(settings);
+			expect(result).toEqual({
+				recorderFormat: 'webm',
+				mimeType: 'audio/webm',
+			});
+		});
+	});
+
+	// ---------------------------------------------------------------
+	// isOfflineOnlyFormat
+	// ---------------------------------------------------------------
+	describe('isOfflineOnlyFormat', () => {
+		it('should return true when format differs from recorder format and supports offline encoding', () => {
+			// mp4 is offline-encodable and recorder uses webm
+			expect(isOfflineOnlyFormat('mp4', 'webm')).toBe(true);
+		});
+
+		it('should return true for mp3 with webm recorder', () => {
+			expect(isOfflineOnlyFormat('mp3', 'webm')).toBe(true);
+		});
+
+		it('should return true for flac with ogg recorder', () => {
+			expect(isOfflineOnlyFormat('flac', 'ogg')).toBe(true);
+		});
+
+		it('should return true for aac with webm recorder', () => {
+			expect(isOfflineOnlyFormat('aac', 'webm')).toBe(true);
+		});
+
+		it('should return true for m4a with webm recorder', () => {
+			expect(isOfflineOnlyFormat('m4a', 'webm')).toBe(true);
+		});
+
+		it('should return false when format matches recorder format', () => {
+			expect(isOfflineOnlyFormat('webm', 'webm')).toBe(false);
+		});
+
+		it('should return false for wav (always handled separately)', () => {
+			expect(isOfflineOnlyFormat('wav', 'webm')).toBe(false);
+		});
+
+		it('should return false when format is not offline-encoding-supported', () => {
+			const { isOfflineEncodingSupported } = jest.requireMock(
+				'../../src/recording/AudioEncoder',
+			);
+			isOfflineEncodingSupported.mockReturnValueOnce(false);
+			expect(isOfflineOnlyFormat('unknownformat', 'webm')).toBe(false);
+		});
+	});
+
+	// ---------------------------------------------------------------
+	// getRecorderMediaType
+	// ---------------------------------------------------------------
+	describe('getRecorderMediaType', () => {
+		it('should return correct MIME type for webm', () => {
+			expect(getRecorderMediaType('webm')).toBe('audio/webm');
+		});
+
+		it('should return correct MIME type for ogg', () => {
+			expect(getRecorderMediaType('ogg')).toBe('audio/ogg');
+		});
+
+		it('should return correct MIME type for mp4', () => {
+			expect(getRecorderMediaType('mp4')).toBe('audio/mp4');
+		});
+
+		it('should return correct MIME type for wav', () => {
+			expect(getRecorderMediaType('wav')).toBe('audio/wav');
+		});
+
+		it('should handle arbitrary format string', () => {
+			expect(getRecorderMediaType('flac')).toBe('audio/flac');
+		});
+	});
+
+	// ---------------------------------------------------------------
+	// convertBlobToWav
+	// ---------------------------------------------------------------
+	describe('convertBlobToWav', () => {
+		it('should decode audio blob and return WAV blob', async () => {
+			const inputBlob = new Blob(['audio-data'], { type: 'audio/webm' });
+			const result = await convertBlobToWav(inputBlob);
+
+			expect(result).toBeInstanceOf(Blob);
+			expect(result.type).toBe('audio/wav');
+		});
+
+		it('should create an AudioContext and close it after conversion', async () => {
+			const inputBlob = new Blob(['audio-data'], { type: 'audio/webm' });
+			await convertBlobToWav(inputBlob);
+
+			expect(AudioContext).toHaveBeenCalledTimes(1);
+			// Verify AudioContext.close() was called
+			const ctxInstance = (AudioContext as unknown as jest.Mock).mock
+				.results[0].value;
+			expect(ctxInstance.close).toHaveBeenCalledTimes(1);
+		});
+
+		it('should call bufferToWave with decoded buffer', async () => {
+			const { bufferToWave } = jest.requireMock(
+				'../../src/recording/WavEncoder',
+			);
+			const inputBlob = new Blob(['audio-data'], { type: 'audio/webm' });
+			await convertBlobToWav(inputBlob);
+
+			expect(bufferToWave).toHaveBeenCalledTimes(1);
+			expect(bufferToWave).toHaveBeenCalledWith(
+				expect.objectContaining({ length: 44100 }),
+				44100,
+			);
+		});
+
+		it('should close AudioContext even when decodeAudioData throws', async () => {
+			const decodeError = new Error('decode failed');
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- required for mock override
+			(AudioContext as any).mockImplementationOnce(() => ({
+				decodeAudioData: jest.fn().mockRejectedValue(decodeError),
+				close: jest.fn().mockResolvedValue(undefined),
+			}));
+
+			const inputBlob = new Blob(['audio-data'], { type: 'audio/webm' });
+			await expect(convertBlobToWav(inputBlob)).rejects.toThrow(
+				'decode failed',
+			);
+
+			// Verify close was still called (finally block)
+			const ctxInstance = (AudioContext as unknown as jest.Mock).mock
+				.results[0].value;
+			expect(ctxInstance.close).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	// ---------------------------------------------------------------
+	// convertBlobToFormat
+	// ---------------------------------------------------------------
+	describe('convertBlobToFormat', () => {
+		it('should decode blob and re-encode to target format', async () => {
+			const { encodeAudioBuffer } = jest.requireMock(
+				'../../src/recording/AudioEncoder',
+			);
+			const blob = new Blob(['test'], { type: 'audio/webm' });
+
+			const result = await convertBlobToFormat(blob, 'mp4', 128000);
+
+			expect(result).toBeInstanceOf(Blob);
+			expect(encodeAudioBuffer).toHaveBeenCalledTimes(1);
+			expect(encodeAudioBuffer).toHaveBeenCalledWith(
+				expect.objectContaining({ sampleRate: 44100 }),
+				{ format: 'mp4', bitrate: 128000 },
+				undefined,
+			);
+		});
+
+		it('should probe native sample rate with AudioContext first', async () => {
+			const blob = new Blob(['test'], { type: 'audio/webm' });
+			await convertBlobToFormat(blob, 'mp4', 128000);
+
+			// First AudioContext call is the probe context
+			expect(AudioContext).toHaveBeenCalledTimes(1);
+			const probeCtx = (AudioContext as unknown as jest.Mock).mock
+				.results[0].value;
+			expect(probeCtx.decodeAudioData).toHaveBeenCalledTimes(1);
+			expect(probeCtx.close).toHaveBeenCalledTimes(1);
+		});
+
+		it('should create OfflineAudioContext with native sample rate', async () => {
+			const blob = new Blob(['test'], { type: 'audio/webm' });
+			await convertBlobToFormat(blob, 'flac', 192000);
+
+			expect(OfflineAudioContext).toHaveBeenCalledWith(1, 44100, 44100);
+		});
+
+		it('should forward onProgress callback to encodeAudioBuffer', async () => {
+			const progressFn = jest.fn();
+			const blob = new Blob(['test'], { type: 'audio/webm' });
+			await convertBlobToFormat(blob, 'mp4', 128000, progressFn);
+
+			const { encodeAudioBuffer } = jest.requireMock(
+				'../../src/recording/AudioEncoder',
+			);
+			expect(encodeAudioBuffer).toHaveBeenCalledWith(
+				expect.anything(),
+				{ format: 'mp4', bitrate: 128000 },
+				progressFn,
+			);
+		});
+
+		it('should pass undefined when onProgress is not provided', async () => {
+			const blob = new Blob(['test'], { type: 'audio/webm' });
+			await convertBlobToFormat(blob, 'mp3', 320000);
+
+			const { encodeAudioBuffer } = jest.requireMock(
+				'../../src/recording/AudioEncoder',
+			);
+			expect(encodeAudioBuffer).toHaveBeenCalledWith(
+				expect.anything(),
+				{ format: 'mp3', bitrate: 320000 },
+				undefined,
+			);
+		});
+
+		it('should handle different target formats', async () => {
+			const { encodeAudioBuffer } = jest.requireMock(
+				'../../src/recording/AudioEncoder',
+			);
+			const blob = new Blob(['test'], { type: 'audio/webm' });
+
+			await convertBlobToFormat(blob, 'aac', 256000);
+			expect(encodeAudioBuffer).toHaveBeenCalledWith(
+				expect.anything(),
+				{ format: 'aac', bitrate: 256000 },
+				undefined,
+			);
+		});
+	});
+
+	// ---------------------------------------------------------------
+	// buildOutputBlob
+	// ---------------------------------------------------------------
+	describe('buildOutputBlob', () => {
+		it('should return raw blob for non-WAV format', async () => {
+			const chunks = [
+				new Blob(['chunk1'], { type: 'audio/webm' }),
+				new Blob(['chunk2'], { type: 'audio/webm' }),
+			];
+			const result = await buildOutputBlob(chunks, 'audio/webm', 'webm');
+			expect(result.type).toBe('audio/webm');
+		});
+
+		it('should combine multiple chunks into a single blob', async () => {
+			const chunks = [
+				new Blob(['chunk1'], { type: 'audio/ogg' }),
+				new Blob(['chunk2'], { type: 'audio/ogg' }),
+			];
+			const result = await buildOutputBlob(chunks, 'audio/ogg', 'ogg');
+			// Blob should have the combined size
+			expect(result.size).toBe(chunks[0].size + chunks[1].size);
+		});
+
+		it('should convert to WAV when recording format is wav', async () => {
+			const { bufferToWave } = jest.requireMock(
+				'../../src/recording/WavEncoder',
+			);
+			const chunks = [new Blob(['audio-data'], { type: 'audio/webm' })];
+			const result = await buildOutputBlob(chunks, 'audio/webm', 'wav');
+
+			expect(bufferToWave).toHaveBeenCalledTimes(1);
+			expect(result.type).toBe('audio/wav');
+		});
+
+		it('should not convert to WAV for mp4 format', async () => {
+			const { bufferToWave } = jest.requireMock(
+				'../../src/recording/WavEncoder',
+			);
+			const chunks = [new Blob(['data'], { type: 'audio/mp4' })];
+			await buildOutputBlob(chunks, 'audio/mp4', 'mp4');
+			expect(bufferToWave).not.toHaveBeenCalled();
+		});
+
+		it('should handle empty chunks array for non-WAV', async () => {
+			const result = await buildOutputBlob([], 'audio/webm', 'webm');
+			expect(result.size).toBe(0);
+			expect(result.type).toBe('audio/webm');
+		});
+	});
+
+	// ---------------------------------------------------------------
+	// mergeAudioTracks
+	// ---------------------------------------------------------------
+	describe('mergeAudioTracks', () => {
+		const createMockTarget = (name: string): RecordingTarget => ({
+			fileBaseName: name,
+			sourceName: name,
+			bufferedChunks: [],
+			bufferedBytes: 0,
+			segmentIndex: 0,
+			segmentPaths: [],
+			pendingWrite: Promise.resolve(),
+			pcmBuffers: [],
+			pcmBufferedBytes: 0,
+			pcmChannels: 1,
+			pcmSampleRate: 44100,
+		});
+
+		it('should merge multiple tracks using buildTrackBlob', async () => {
+			const targets = [
+				createMockTarget('track1'),
+				createMockTarget('track2'),
+			];
+			const buildPcmTrackWavBlob = jest.fn();
+			const buildTrackBlob = jest
+				.fn()
+				.mockResolvedValue(new Blob(['audio'], { type: 'audio/webm' }));
+
+			const settings: AudioRecorderSettings = {
+				...DEFAULT_SETTINGS,
+				recordingFormat: 'mp4',
+				bitrate: 128000,
+			};
+
+			const result = await mergeAudioTracks(
+				targets,
+				settings,
+				false,
+				buildPcmTrackWavBlob,
+				buildTrackBlob,
+			);
+
+			expect(buildTrackBlob).toHaveBeenCalledTimes(2);
+			expect(buildPcmTrackWavBlob).not.toHaveBeenCalled();
+			expect(result).toBeInstanceOf(Blob);
+		});
+
+		it('should merge multiple tracks using buildPcmTrackWavBlob for WAV PCM recordings', async () => {
+			const targets = [
+				createMockTarget('track1'),
+				createMockTarget('track2'),
+			];
+			const buildPcmTrackWavBlob = jest
+				.fn()
+				.mockResolvedValue(
+					new Blob(['pcm-wav'], { type: 'audio/wav' }),
+				);
+			const buildTrackBlob = jest.fn();
+
+			const settings: AudioRecorderSettings = {
+				...DEFAULT_SETTINGS,
+				recordingFormat: 'wav',
+				bitrate: 128000,
+			};
+
+			await mergeAudioTracks(
+				targets,
+				settings,
+				true,
+				buildPcmTrackWavBlob,
+				buildTrackBlob,
+			);
+
+			expect(buildPcmTrackWavBlob).toHaveBeenCalledTimes(2);
+			expect(buildTrackBlob).not.toHaveBeenCalled();
+		});
+
+		it('should encode merged result for offline-encodable formats', async () => {
+			const { encodeAudioBuffer } = jest.requireMock(
+				'../../src/recording/AudioEncoder',
+			);
+			const targets = [createMockTarget('track1')];
+			const buildTrackBlob = jest
+				.fn()
+				.mockResolvedValue(new Blob(['audio'], { type: 'audio/webm' }));
+
+			const settings: AudioRecorderSettings = {
+				...DEFAULT_SETTINGS,
+				recordingFormat: 'mp4',
+				bitrate: 128000,
+			};
+
+			await mergeAudioTracks(
+				targets,
+				settings,
+				false,
+				jest.fn(),
+				buildTrackBlob,
+			);
+
+			expect(encodeAudioBuffer).toHaveBeenCalledTimes(1);
+			expect(encodeAudioBuffer).toHaveBeenCalledWith(
+				expect.objectContaining({ sampleRate: 44100 }),
+				{ format: 'mp4', bitrate: 128000 },
+				expect.any(Function),
+			);
+		});
+
+		it('should fall back to WAV when format is wav', async () => {
+			const { bufferToWave } = jest.requireMock(
+				'../../src/recording/WavEncoder',
+			);
+			const { encodeAudioBuffer } = jest.requireMock(
+				'../../src/recording/AudioEncoder',
+			);
+			const targets = [createMockTarget('track1')];
+			const buildTrackBlob = jest
+				.fn()
+				.mockResolvedValue(new Blob(['audio'], { type: 'audio/webm' }));
+
+			const settings: AudioRecorderSettings = {
+				...DEFAULT_SETTINGS,
+				recordingFormat: 'wav',
+				bitrate: 128000,
+			};
+
+			const result = await mergeAudioTracks(
+				targets,
+				settings,
+				false,
+				jest.fn(),
+				buildTrackBlob,
+			);
+
+			expect(bufferToWave).toHaveBeenCalledTimes(1);
+			expect(encodeAudioBuffer).not.toHaveBeenCalled();
+			expect(result.type).toBe('audio/wav');
+		});
+
+		it('should throw when no audio data is recorded (all blobs null)', async () => {
+			const targets = [createMockTarget('track1')];
+			const buildTrackBlob = jest.fn().mockResolvedValue(null);
+
+			const settings: AudioRecorderSettings = {
+				...DEFAULT_SETTINGS,
+				recordingFormat: 'webm',
+			};
+
+			await expect(
+				mergeAudioTracks(
+					targets,
+					settings,
+					false,
+					jest.fn(),
+					buildTrackBlob,
+				),
+			).rejects.toThrow('No audio data recorded');
+		});
+
+		it('should skip null blobs and merge remaining valid tracks', async () => {
+			const targets = [
+				createMockTarget('track1'),
+				createMockTarget('track2'),
+				createMockTarget('track3'),
+			];
+			// First and third return blobs, second returns null
+			const buildTrackBlob = jest
+				.fn()
+				.mockResolvedValueOnce(
+					new Blob(['audio1'], { type: 'audio/webm' }),
+				)
+				.mockResolvedValueOnce(null)
+				.mockResolvedValueOnce(
+					new Blob(['audio3'], { type: 'audio/webm' }),
+				);
+
+			const settings: AudioRecorderSettings = {
+				...DEFAULT_SETTINGS,
+				recordingFormat: 'mp4',
+				bitrate: 128000,
+			};
+
+			const result = await mergeAudioTracks(
+				targets,
+				settings,
+				false,
+				jest.fn(),
+				buildTrackBlob,
+			);
+
+			expect(result).toBeInstanceOf(Blob);
+			// 2 valid buffers decoded, null one skipped
+			const ctxInstance = (AudioContext as unknown as jest.Mock).mock
+				.results[0].value;
+			expect(ctxInstance.decodeAudioData).toHaveBeenCalledTimes(2);
+		});
+
+		it('should create OfflineAudioContext with stereo channels and longest duration', async () => {
+			const targets = [createMockTarget('track1')];
+			const buildTrackBlob = jest
+				.fn()
+				.mockResolvedValue(new Blob(['audio'], { type: 'audio/webm' }));
+
+			const settings: AudioRecorderSettings = {
+				...DEFAULT_SETTINGS,
+				recordingFormat: 'mp4',
+				bitrate: 128000,
+			};
+
+			await mergeAudioTracks(
+				targets,
+				settings,
+				false,
+				jest.fn(),
+				buildTrackBlob,
+			);
+
+			// OfflineAudioContext(channels=2, length=sampleRate*duration, sampleRate)
+			expect(OfflineAudioContext).toHaveBeenCalledWith(
+				2,
+				44100 * 1, // sampleRate * duration(1)
+				44100,
+			);
+		});
+
+		it('should forward progress callback with adjusted percentage', async () => {
+			const { encodeAudioBuffer } = jest.requireMock(
+				'../../src/recording/AudioEncoder',
+			);
+
+			// Capture the progress callback passed to encodeAudioBuffer
+			let capturedProgressFn: ((percent: number) => void) | undefined;
+			encodeAudioBuffer.mockImplementation(
+				(
+					_buffer: unknown,
+					_options: unknown,
+					onProgress?: (percent: number) => void,
+				) => {
+					capturedProgressFn = onProgress;
+					return Promise.resolve(
+						new Blob(['encoded'], { type: 'audio/mp4' }),
+					);
+				},
+			);
+
+			const targets = [createMockTarget('track1')];
+			const buildTrackBlob = jest
+				.fn()
+				.mockResolvedValue(new Blob(['audio'], { type: 'audio/webm' }));
+			const onProgress = jest.fn();
+
+			const settings: AudioRecorderSettings = {
+				...DEFAULT_SETTINGS,
+				recordingFormat: 'mp4',
+				bitrate: 128000,
+			};
+
+			await mergeAudioTracks(
+				targets,
+				settings,
+				false,
+				jest.fn(),
+				buildTrackBlob,
+				onProgress,
+			);
+
+			// Simulate encoding progress
+			expect(capturedProgressFn).toBeDefined();
+			capturedProgressFn!(50);
+			// 40 + Math.round(50 * 0.2) = 40 + 10 = 50
+			expect(onProgress).toHaveBeenCalledWith(50, 'Encoding audio...');
+
+			capturedProgressFn!(100);
+			// 40 + Math.round(100 * 0.2) = 40 + 20 = 60
+			expect(onProgress).toHaveBeenCalledWith(60, 'Encoding audio...');
+		});
+
+		it('should close AudioContext after merging', async () => {
+			const targets = [createMockTarget('track1')];
+			const buildTrackBlob = jest
+				.fn()
+				.mockResolvedValue(new Blob(['audio'], { type: 'audio/webm' }));
+
+			const settings: AudioRecorderSettings = {
+				...DEFAULT_SETTINGS,
+				recordingFormat: 'wav',
+			};
+
+			await mergeAudioTracks(
+				targets,
+				settings,
+				false,
+				jest.fn(),
+				buildTrackBlob,
+			);
+
+			const ctxInstance = (AudioContext as unknown as jest.Mock).mock
+				.results[0].value;
+			expect(ctxInstance.close).toHaveBeenCalledTimes(1);
+		});
+
+		it('should use bufferToWave when format is not offline-encodable and not wav-like', async () => {
+			const { isOfflineEncodingSupported } = jest.requireMock(
+				'../../src/recording/AudioEncoder',
+			);
+			const { bufferToWave } = jest.requireMock(
+				'../../src/recording/WavEncoder',
+			);
+
+			// Make the target format NOT offline-encodable
+			isOfflineEncodingSupported.mockReturnValue(false);
+
+			const targets = [createMockTarget('track1')];
+			const buildTrackBlob = jest
+				.fn()
+				.mockResolvedValue(new Blob(['audio'], { type: 'audio/webm' }));
+
+			const settings: AudioRecorderSettings = {
+				...DEFAULT_SETTINGS,
+				recordingFormat: 'someformat',
+				bitrate: 128000,
+			};
+
+			await mergeAudioTracks(
+				targets,
+				settings,
+				false,
+				jest.fn(),
+				buildTrackBlob,
+			);
+
+			// Falls back to bufferToWave since format is not wav and not offline-encodable
+			expect(bufferToWave).toHaveBeenCalledTimes(1);
+		});
+	});
+});

--- a/tests/unit/NoteInserter.test.ts
+++ b/tests/unit/NoteInserter.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Unit tests for NoteInserter module.
+ * Tests cursor context capture and audio link insertion into notes.
+ * @module tests/unit/NoteInserter.test
+ */
+/** @jest-environment jsdom */
+
+import type { InsertionContext } from '../../src/types';
+import type { App } from 'obsidian';
+
+// Mock MarkdownView class used for instanceof checks
+class MockMarkdownView {
+	file: { path: string } | null = null;
+	editor: {
+		getCursor: jest.Mock;
+		replaceRange: jest.Mock;
+		replaceSelection: jest.Mock;
+	} | null = null;
+}
+
+jest.mock('obsidian', () => ({
+	MarkdownView: MockMarkdownView,
+}));
+
+import {
+	captureInsertionContext,
+	insertFileLinks,
+} from '../../src/recording/NoteInserter';
+
+// DebugLogger mock
+function createMockDebugLogger(): { log: jest.Mock } {
+	return { log: jest.fn() };
+}
+
+// Helper to create a mock App with workspace methods
+function createMockApp(overrides?: {
+	activeView?: MockMarkdownView | null;
+	leaves?: Array<{ view: MockMarkdownView }>;
+}): App {
+	const activeView = overrides?.activeView ?? null;
+	const leaves = overrides?.leaves ?? [];
+
+	return {
+		workspace: {
+			getActiveViewOfType: jest.fn().mockReturnValue(activeView),
+			getLeavesOfType: jest.fn().mockReturnValue(leaves),
+		},
+	} as unknown as App;
+}
+
+// Helper to create a MockMarkdownView with file and editor
+function createMockView(
+	filePath: string | null,
+	cursorLine?: number,
+	cursorCh?: number,
+): MockMarkdownView {
+	const view = new MockMarkdownView();
+	view.file = filePath ? { path: filePath } : null;
+	if (cursorLine !== undefined && cursorCh !== undefined) {
+		view.editor = {
+			getCursor: jest
+				.fn()
+				.mockReturnValue({ line: cursorLine, ch: cursorCh }),
+			replaceRange: jest.fn(),
+			replaceSelection: jest.fn(),
+		};
+	}
+	return view;
+}
+
+describe('NoteInserter', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('captureInsertionContext', () => {
+		it('returns null when insertAtOriginalPosition is false', () => {
+			const app = createMockApp();
+			const logger = createMockDebugLogger();
+
+			const result = captureInsertionContext(app, false, logger);
+
+			expect(result).toBeNull();
+			// Should not attempt to access workspace at all
+			expect(app.workspace.getActiveViewOfType).not.toHaveBeenCalled();
+		});
+
+		it('returns InsertionContext when active MarkdownView has file and cursor', () => {
+			const view = createMockView('notes/test.md', 10, 5);
+			const app = createMockApp({ activeView: view });
+			const logger = createMockDebugLogger();
+
+			const result = captureInsertionContext(app, true, logger);
+
+			expect(result).toEqual({
+				filePath: 'notes/test.md',
+				line: 10,
+				ch: 5,
+			});
+			expect(logger.log).not.toHaveBeenCalled();
+		});
+
+		it('returns null and logs when no active MarkdownView', () => {
+			const app = createMockApp({ activeView: null });
+			const logger = createMockDebugLogger();
+
+			const result = captureInsertionContext(app, true, logger);
+
+			expect(result).toBeNull();
+			expect(logger.log).toHaveBeenCalledWith(
+				'Could not capture insertion context: no active Markdown view',
+			);
+		});
+
+		it('returns null and logs when view has no file', () => {
+			const view = createMockView(null, 3, 0);
+			const app = createMockApp({ activeView: view });
+			const logger = createMockDebugLogger();
+
+			const result = captureInsertionContext(app, true, logger);
+
+			expect(result).toBeNull();
+			expect(logger.log).toHaveBeenCalledWith(
+				'Could not capture insertion context: no active Markdown view',
+			);
+		});
+
+		it('returns null and logs when view has no editor (no cursor)', () => {
+			// View with file but no editor
+			const view = new MockMarkdownView();
+			view.file = { path: 'notes/test.md' };
+			view.editor = null;
+			const app = createMockApp({ activeView: view });
+			const logger = createMockDebugLogger();
+
+			const result = captureInsertionContext(app, true, logger);
+
+			expect(result).toBeNull();
+			expect(logger.log).toHaveBeenCalledWith(
+				'Could not capture insertion context: no active Markdown view',
+			);
+		});
+
+		it('captures cursor at line 0 ch 0 correctly', () => {
+			const view = createMockView('notes/test.md', 0, 0);
+			const app = createMockApp({ activeView: view });
+			const logger = createMockDebugLogger();
+
+			const result = captureInsertionContext(app, true, logger);
+
+			expect(result).toEqual({
+				filePath: 'notes/test.md',
+				line: 0,
+				ch: 0,
+			});
+		});
+	});
+
+	describe('insertFileLinks', () => {
+		it('inserts at insertion context position when context and matching leaf exist', () => {
+			const view = createMockView('notes/daily.md', 5, 0);
+			const leaf = { view };
+			const context: InsertionContext = {
+				filePath: 'notes/daily.md',
+				line: 7,
+				ch: 3,
+			};
+			const app = createMockApp({ leaves: [leaf] });
+
+			insertFileLinks(['recordings/audio.webm'], context, app);
+
+			expect(app.workspace.getLeavesOfType).toHaveBeenCalledWith(
+				'markdown',
+			);
+
+			expect(view.editor!.replaceRange).toHaveBeenCalledWith(
+				'![[audio.webm]]\n',
+				{ line: 8, ch: 0 },
+			);
+			// Should not fall back to active editor
+			expect(app.workspace.getActiveViewOfType).not.toHaveBeenCalled();
+		});
+
+		it('falls back to active editor when insertion context leaf not found', () => {
+			const activeView = createMockView('notes/other.md', 2, 0);
+			const context: InsertionContext = {
+				filePath: 'notes/daily.md',
+				line: 7,
+				ch: 3,
+			};
+			// No leaves match the context filePath
+			const app = createMockApp({ activeView, leaves: [] });
+
+			insertFileLinks(['recordings/audio.webm'], context, app);
+
+			expect(activeView.editor!.replaceSelection).toHaveBeenCalledWith(
+				'![[audio.webm]]',
+			);
+		});
+
+		it('falls back to active editor when insertionContext is null', () => {
+			const activeView = createMockView('notes/other.md', 2, 0);
+			const app = createMockApp({ activeView });
+
+			insertFileLinks(['recordings/audio.webm'], null, app);
+
+			expect(activeView.editor!.replaceSelection).toHaveBeenCalledWith(
+				'![[audio.webm]]',
+			);
+		});
+
+		it('does nothing when no editor is available and no context match', () => {
+			const app = createMockApp({ activeView: null, leaves: [] });
+			const context: InsertionContext = {
+				filePath: 'notes/missing.md',
+				line: 0,
+				ch: 0,
+			};
+
+			// Should not throw
+			expect(() =>
+				insertFileLinks(['recordings/audio.webm'], context, app),
+			).not.toThrow();
+		});
+
+		it('does nothing when no editor is available and context is null', () => {
+			const app = createMockApp({ activeView: null });
+
+			// Should not throw
+			expect(() =>
+				insertFileLinks(['recordings/audio.webm'], null, app),
+			).not.toThrow();
+		});
+
+		it('formats links correctly as ![[filename]]', () => {
+			const activeView = createMockView('notes/test.md', 0, 0);
+			const app = createMockApp({ activeView });
+
+			insertFileLinks(
+				['path/to/deep/folder/my-recording.mp3'],
+				null,
+				app,
+			);
+
+			expect(activeView.editor!.replaceSelection).toHaveBeenCalledWith(
+				'![[my-recording.mp3]]',
+			);
+		});
+
+		it('handles multiple file links joined with newlines', () => {
+			const activeView = createMockView('notes/test.md', 0, 0);
+			const app = createMockApp({ activeView });
+
+			insertFileLinks(
+				[
+					'recordings/audio1.webm',
+					'recordings/audio2.mp3',
+					'recordings/audio3.wav',
+				],
+				null,
+				app,
+			);
+
+			expect(activeView.editor!.replaceSelection).toHaveBeenCalledWith(
+				'![[audio1.webm]]\n![[audio2.mp3]]\n![[audio3.wav]]',
+			);
+		});
+
+		it('handles multiple file links at insertion context with newline suffix', () => {
+			const view = createMockView('notes/daily.md', 5, 0);
+			const leaf = { view };
+			const context: InsertionContext = {
+				filePath: 'notes/daily.md',
+				line: 3,
+				ch: 0,
+			};
+			const app = createMockApp({ leaves: [leaf] });
+
+			insertFileLinks(
+				['recordings/audio1.webm', 'recordings/audio2.mp3'],
+				context,
+				app,
+			);
+
+			expect(view.editor!.replaceRange).toHaveBeenCalledWith(
+				'![[audio1.webm]]\n![[audio2.mp3]]\n',
+				{ line: 4, ch: 0 },
+			);
+		});
+
+		it('uses filename only, stripping directory path', () => {
+			const activeView = createMockView('notes/test.md', 0, 0);
+			const app = createMockApp({ activeView });
+
+			insertFileLinks(['a/b/c/d/recording.flac'], null, app);
+
+			expect(activeView.editor!.replaceSelection).toHaveBeenCalledWith(
+				'![[recording.flac]]',
+			);
+		});
+
+		it('handles file path without directory separators', () => {
+			const activeView = createMockView('notes/test.md', 0, 0);
+			const app = createMockApp({ activeView });
+
+			insertFileLinks(['recording.webm'], null, app);
+
+			expect(activeView.editor!.replaceSelection).toHaveBeenCalledWith(
+				'![[recording.webm]]',
+			);
+		});
+
+		it('skips non-matching leaves and finds the correct one', () => {
+			const wrongView = createMockView('notes/wrong.md', 0, 0);
+			const correctView = createMockView('notes/target.md', 0, 0);
+			const wrongLeaf = { view: wrongView };
+			const correctLeaf = { view: correctView };
+			const context: InsertionContext = {
+				filePath: 'notes/target.md',
+				line: 5,
+				ch: 0,
+			};
+			const app = createMockApp({ leaves: [wrongLeaf, correctLeaf] });
+
+			insertFileLinks(['recordings/audio.webm'], context, app);
+
+			expect(correctView.editor!.replaceRange).toHaveBeenCalledWith(
+				'![[audio.webm]]\n',
+				{ line: 6, ch: 0 },
+			);
+			// Wrong view should not be touched
+
+			expect(wrongView.editor!.replaceRange).not.toHaveBeenCalled();
+		});
+
+		it('handles empty file links array', () => {
+			const activeView = createMockView('notes/test.md', 0, 0);
+			const app = createMockApp({ activeView });
+
+			insertFileLinks([], null, app);
+
+			expect(activeView.editor!.replaceSelection).toHaveBeenCalledWith(
+				'',
+			);
+		});
+	});
+});

--- a/tests/unit/RecordingFileManager.test.ts
+++ b/tests/unit/RecordingFileManager.test.ts
@@ -1,0 +1,725 @@
+/**
+ * Unit tests for RecordingFileManager module.
+ * Tests file I/O operations: path resolution, saving, cleanup, and rollback.
+ * @module tests/unit/RecordingFileManager.test
+ */
+/** @jest-environment jsdom */
+
+import type { App } from 'obsidian';
+import {
+	DEFAULT_SETTINGS,
+	AudioRecorderSettings,
+} from '../../src/settings/Settings';
+import type { RecordingTarget } from '../../src/types';
+import {
+	getActiveFileDirectory,
+	getBaseSaveDirectory,
+	ensureFolderExists,
+	resolveUniquePath,
+	saveAudioFile,
+	removeTemporaryArtifacts,
+	rollbackFinalFile,
+	cleanupIntermediateFiles,
+} from '../../src/recording/RecordingFileManager';
+
+// Mock obsidian module
+jest.mock('obsidian', () => ({
+	normalizePath: (path: string) => path.replace(/\\/g, '/'),
+}));
+
+// Polyfill Blob.arrayBuffer for jsdom if missing
+if (!Blob.prototype.arrayBuffer) {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- jsdom polyfill required for test environment
+	(Blob.prototype as any).arrayBuffer = function (): Promise<ArrayBuffer> {
+		return new Promise((resolve, reject) => {
+			const reader = new FileReader();
+			reader.onload = (): void => resolve(reader.result as ArrayBuffer);
+			reader.onerror = (): void => reject(reader.error);
+			reader.readAsArrayBuffer(this as Blob);
+		});
+	};
+}
+
+describe('RecordingFileManager', () => {
+	let mockApp: App;
+	let mockSettings: AudioRecorderSettings;
+	let consoleDebugSpy: jest.SpyInstance;
+	let consoleWarnSpy: jest.SpyInstance;
+	let consoleErrorSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		consoleDebugSpy = jest.spyOn(console, 'debug').mockImplementation();
+		consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+		consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+		// Create mock App with all required vault and workspace methods
+		mockApp = {
+			vault: {
+				adapter: {
+					exists: jest.fn().mockResolvedValue(false),
+					remove: jest.fn().mockResolvedValue(undefined),
+				},
+				createBinary: jest.fn().mockResolvedValue(undefined),
+				createFolder: jest.fn().mockResolvedValue(undefined),
+			},
+			workspace: {
+				getActiveFile: jest.fn().mockReturnValue(null),
+				getActiveViewOfType: jest.fn().mockReturnValue(null),
+			},
+		} as unknown as App;
+
+		// Use default settings with a defined saveFolder
+		mockSettings = {
+			...DEFAULT_SETTINGS,
+			saveFolder: 'Recordings',
+		};
+	});
+
+	afterEach(() => {
+		consoleDebugSpy.mockRestore();
+		consoleWarnSpy.mockRestore();
+		consoleErrorSpy.mockRestore();
+	});
+
+	// -----------------------------------------------------------------------
+	// getActiveFileDirectory
+	// -----------------------------------------------------------------------
+	describe('getActiveFileDirectory', () => {
+		it('should return the directory of the active .md file', () => {
+			(mockApp.workspace.getActiveFile as jest.Mock).mockReturnValue({
+				path: 'Notes/Daily/2024-01-01.md',
+			});
+
+			const result = getActiveFileDirectory(mockApp);
+
+			expect(result).toBe('Notes/Daily');
+		});
+
+		it('should handle .MD extension (case-insensitive)', () => {
+			(mockApp.workspace.getActiveFile as jest.Mock).mockReturnValue({
+				path: 'Notes/README.MD',
+			});
+
+			const result = getActiveFileDirectory(mockApp);
+
+			expect(result).toBe('Notes');
+		});
+
+		it('should return empty string for a non-.md active file', () => {
+			(mockApp.workspace.getActiveFile as jest.Mock).mockReturnValue({
+				path: 'Assets/image.png',
+			});
+
+			const result = getActiveFileDirectory(mockApp);
+
+			expect(result).toBe('');
+		});
+
+		it('should return empty string when no file is active', () => {
+			(mockApp.workspace.getActiveFile as jest.Mock).mockReturnValue(
+				null,
+			);
+
+			const result = getActiveFileDirectory(mockApp);
+
+			expect(result).toBe('');
+		});
+
+		it('should return empty string for a root-level .md file', () => {
+			(mockApp.workspace.getActiveFile as jest.Mock).mockReturnValue({
+				path: 'note.md',
+			});
+
+			const result = getActiveFileDirectory(mockApp);
+
+			expect(result).toBe('');
+		});
+
+		it('should return deeply nested directory path', () => {
+			(mockApp.workspace.getActiveFile as jest.Mock).mockReturnValue({
+				path: 'a/b/c/d/note.md',
+			});
+
+			const result = getActiveFileDirectory(mockApp);
+
+			expect(result).toBe('a/b/c/d');
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// getBaseSaveDirectory
+	// -----------------------------------------------------------------------
+	describe('getBaseSaveDirectory', () => {
+		it('should return saveFolder when saveNearActiveFile is false', () => {
+			mockSettings.saveNearActiveFile = false;
+			mockSettings.saveFolder = 'MyRecordings';
+
+			const result = getBaseSaveDirectory(mockSettings, mockApp);
+
+			expect(result).toBe('MyRecordings');
+		});
+
+		it('should return active file directory when saveNearActiveFile is true and subfolder is empty', () => {
+			mockSettings.saveNearActiveFile = true;
+			mockSettings.activeFileSubfolder = '';
+			(mockApp.workspace.getActiveFile as jest.Mock).mockReturnValue({
+				path: 'Notes/Daily/today.md',
+			});
+
+			const result = getBaseSaveDirectory(mockSettings, mockApp);
+
+			expect(result).toBe('Notes/Daily');
+		});
+
+		it('should return active file directory + subfolder when saveNearActiveFile is true and subfolder set', () => {
+			mockSettings.saveNearActiveFile = true;
+			mockSettings.activeFileSubfolder = 'audio';
+			(mockApp.workspace.getActiveFile as jest.Mock).mockReturnValue({
+				path: 'Notes/Daily/today.md',
+			});
+
+			const result = getBaseSaveDirectory(mockSettings, mockApp);
+
+			expect(result).toBe('Notes/Daily/audio');
+		});
+
+		it('should handle whitespace-only subfolder as empty', () => {
+			mockSettings.saveNearActiveFile = true;
+			mockSettings.activeFileSubfolder = '   ';
+			(mockApp.workspace.getActiveFile as jest.Mock).mockReturnValue({
+				path: 'Notes/today.md',
+			});
+
+			const result = getBaseSaveDirectory(mockSettings, mockApp);
+
+			expect(result).toBe('Notes');
+		});
+
+		it('should return subfolder relative to root when no active .md file', () => {
+			mockSettings.saveNearActiveFile = true;
+			mockSettings.activeFileSubfolder = 'recordings';
+			(mockApp.workspace.getActiveFile as jest.Mock).mockReturnValue(
+				null,
+			);
+
+			const result = getBaseSaveDirectory(mockSettings, mockApp);
+
+			// activeDir = '', so result = '/recordings' normalized
+			expect(result).toBe('/recordings');
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// ensureFolderExists
+	// -----------------------------------------------------------------------
+	describe('ensureFolderExists', () => {
+		it('should not create folder if it already exists', async () => {
+			(mockApp.vault.adapter.exists as jest.Mock).mockResolvedValue(true);
+
+			await ensureFolderExists('Recordings', mockApp);
+
+			expect(mockApp.vault.adapter.exists).toHaveBeenCalledWith(
+				'Recordings',
+			);
+			expect(mockApp.vault.createFolder).not.toHaveBeenCalled();
+		});
+
+		it('should create folder if it does not exist', async () => {
+			(mockApp.vault.adapter.exists as jest.Mock).mockResolvedValue(
+				false,
+			);
+
+			await ensureFolderExists('Recordings/new', mockApp);
+
+			expect(mockApp.vault.adapter.exists).toHaveBeenCalledWith(
+				'Recordings/new',
+			);
+			expect(mockApp.vault.createFolder).toHaveBeenCalledWith(
+				'Recordings/new',
+			);
+		});
+
+		it('should skip creation for empty path', async () => {
+			await ensureFolderExists('', mockApp);
+
+			expect(mockApp.vault.adapter.exists).not.toHaveBeenCalled();
+			expect(mockApp.vault.createFolder).not.toHaveBeenCalled();
+		});
+
+		it('should skip creation for whitespace-only path', async () => {
+			await ensureFolderExists('   ', mockApp);
+
+			expect(mockApp.vault.adapter.exists).not.toHaveBeenCalled();
+			expect(mockApp.vault.createFolder).not.toHaveBeenCalled();
+		});
+
+		it('should normalize backslashes in path', async () => {
+			(mockApp.vault.adapter.exists as jest.Mock).mockResolvedValue(
+				false,
+			);
+
+			await ensureFolderExists('Recordings\\subfolder', mockApp);
+
+			// normalizePath converts backslashes to forward slashes
+			expect(mockApp.vault.adapter.exists).toHaveBeenCalledWith(
+				'Recordings/subfolder',
+			);
+			expect(mockApp.vault.createFolder).toHaveBeenCalledWith(
+				'Recordings/subfolder',
+			);
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// resolveUniquePath
+	// -----------------------------------------------------------------------
+	describe('resolveUniquePath', () => {
+		it('should return the path directly when no collision', async () => {
+			mockSettings.saveFolder = 'Recordings';
+			(mockApp.vault.adapter.exists as jest.Mock).mockResolvedValue(
+				false,
+			);
+
+			const result = await resolveUniquePath(
+				'test.webm',
+				mockApp,
+				mockSettings,
+			);
+
+			expect(result).toBe('Recordings/test.webm');
+		});
+
+		it('should append counter when file already exists', async () => {
+			mockSettings.saveFolder = 'Recordings';
+			(mockApp.vault.adapter.exists as jest.Mock)
+				.mockResolvedValueOnce(false) // ensureFolderExists check
+				.mockResolvedValueOnce(true) // first path exists
+				.mockResolvedValueOnce(false); // counter path does not exist
+
+			const result = await resolveUniquePath(
+				'test.webm',
+				mockApp,
+				mockSettings,
+			);
+
+			expect(result).toBe('Recordings/test_1.webm');
+		});
+
+		it('should increment counter multiple times until unique path found', async () => {
+			// The implementation mutates sanitizedFileName each iteration,
+			// so counters accumulate: test -> test_1 -> test_1_2 -> test_1_2_3
+			mockSettings.saveFolder = 'Recordings';
+			(mockApp.vault.adapter.exists as jest.Mock)
+				.mockResolvedValueOnce(false) // ensureFolderExists check
+				.mockResolvedValueOnce(true) // Recordings/test.webm exists
+				.mockResolvedValueOnce(true) // Recordings/test_1.webm exists
+				.mockResolvedValueOnce(true) // Recordings/test_1_2.webm exists
+				.mockResolvedValueOnce(false); // Recordings/test_1_2_3.webm free
+
+			const result = await resolveUniquePath(
+				'test.webm',
+				mockApp,
+				mockSettings,
+			);
+
+			expect(result).toBe('Recordings/test_1_2_3.webm');
+		});
+
+		it('should sanitize special characters in filename', async () => {
+			mockSettings.saveFolder = 'Recordings';
+			(mockApp.vault.adapter.exists as jest.Mock).mockResolvedValue(
+				false,
+			);
+
+			const result = await resolveUniquePath(
+				'test:file*name?.webm',
+				mockApp,
+				mockSettings,
+			);
+
+			expect(result).toBe('Recordings/test-file-name-.webm');
+		});
+
+		it('should ensure folder is created before resolving path', async () => {
+			mockSettings.saveFolder = 'NewFolder';
+			(mockApp.vault.adapter.exists as jest.Mock).mockResolvedValue(
+				false,
+			);
+
+			await resolveUniquePath('file.mp3', mockApp, mockSettings);
+
+			expect(mockApp.vault.createFolder).toHaveBeenCalledWith(
+				'NewFolder',
+			);
+		});
+
+		it('should handle filename with multiple dots', async () => {
+			mockSettings.saveFolder = 'Recordings';
+			(mockApp.vault.adapter.exists as jest.Mock)
+				.mockResolvedValueOnce(false) // ensureFolderExists
+				.mockResolvedValueOnce(true) // first attempt exists
+				.mockResolvedValueOnce(false); // counter path free
+
+			const result = await resolveUniquePath(
+				'my.recording.2024.webm',
+				mockApp,
+				mockSettings,
+			);
+
+			expect(result).toBe('Recordings/my.recording.2024_1.webm');
+		});
+
+		it('should sanitize all invalid characters from filename', async () => {
+			mockSettings.saveFolder = '';
+			(mockApp.vault.adapter.exists as jest.Mock).mockResolvedValue(
+				false,
+			);
+
+			const result = await resolveUniquePath(
+				'a\\b/c:d*e?f"g<h>i|j.ogg',
+				mockApp,
+				mockSettings,
+			);
+
+			expect(result).toBe('/a-b-c-d-e-f-g-h-i-j.ogg');
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// saveAudioFile
+	// -----------------------------------------------------------------------
+	describe('saveAudioFile', () => {
+		it('should save a non-empty blob and return the file path', async () => {
+			mockSettings.saveFolder = 'Recordings';
+			(mockApp.vault.adapter.exists as jest.Mock).mockResolvedValue(
+				false,
+			);
+			const blob = new Blob(['audio data'], { type: 'audio/webm' });
+
+			const result = await saveAudioFile(
+				blob,
+				'test.webm',
+				mockApp,
+				mockSettings,
+			);
+
+			expect(result).toBe('Recordings/test.webm');
+			expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
+				'Recordings/test.webm',
+				expect.any(ArrayBuffer),
+			);
+		});
+
+		it('should return null for an empty blob', async () => {
+			const emptyBlob = new Blob([], { type: 'audio/webm' });
+
+			const result = await saveAudioFile(
+				emptyBlob,
+				'empty.webm',
+				mockApp,
+				mockSettings,
+			);
+
+			expect(result).toBeNull();
+			expect(consoleDebugSpy).toHaveBeenCalledWith(
+				expect.stringContaining('Skipping empty file'),
+			);
+			expect(mockApp.vault.createBinary).not.toHaveBeenCalled();
+		});
+
+		it('should use resolveUniquePath to determine the final path', async () => {
+			mockSettings.saveFolder = 'Recordings';
+			(mockApp.vault.adapter.exists as jest.Mock)
+				.mockResolvedValueOnce(false) // ensureFolderExists
+				.mockResolvedValueOnce(true) // first path collision
+				.mockResolvedValueOnce(false); // counter path free
+			const blob = new Blob(['data'], { type: 'audio/webm' });
+
+			const result = await saveAudioFile(
+				blob,
+				'recording.webm',
+				mockApp,
+				mockSettings,
+			);
+
+			expect(result).toBe('Recordings/recording_1.webm');
+			expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
+				'Recordings/recording_1.webm',
+				expect.any(ArrayBuffer),
+			);
+		});
+
+		it('should convert blob to ArrayBuffer before saving', async () => {
+			mockSettings.saveFolder = '';
+			(mockApp.vault.adapter.exists as jest.Mock).mockResolvedValue(
+				false,
+			);
+			const blob = new Blob(['hello world'], { type: 'audio/wav' });
+
+			await saveAudioFile(blob, 'test.wav', mockApp, mockSettings);
+
+			const createBinaryCall = (mockApp.vault.createBinary as jest.Mock)
+				.mock.calls[0];
+			expect(createBinaryCall[1]).toBeInstanceOf(ArrayBuffer);
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// removeTemporaryArtifacts
+	// -----------------------------------------------------------------------
+	describe('removeTemporaryArtifacts', () => {
+		it('should remove all paths successfully and return empty array', async () => {
+			(mockApp.vault.adapter.remove as jest.Mock).mockResolvedValue(
+				undefined,
+			);
+
+			const result = await removeTemporaryArtifacts(
+				['path/a.tmp', 'path/b.tmp', 'path/c.tmp'],
+				'cleanup context',
+				mockApp,
+			);
+
+			expect(result).toEqual([]);
+			expect(mockApp.vault.adapter.remove).toHaveBeenCalledTimes(3);
+			expect(mockApp.vault.adapter.remove).toHaveBeenCalledWith(
+				'path/a.tmp',
+			);
+			expect(mockApp.vault.adapter.remove).toHaveBeenCalledWith(
+				'path/b.tmp',
+			);
+			expect(mockApp.vault.adapter.remove).toHaveBeenCalledWith(
+				'path/c.tmp',
+			);
+		});
+
+		it('should return failed paths when some removals fail', async () => {
+			(mockApp.vault.adapter.remove as jest.Mock)
+				.mockResolvedValueOnce(undefined) // a.tmp succeeds
+				.mockRejectedValueOnce(new Error('ENOENT')) // b.tmp fails
+				.mockResolvedValueOnce(undefined); // c.tmp succeeds
+
+			const result = await removeTemporaryArtifacts(
+				['path/a.tmp', 'path/b.tmp', 'path/c.tmp'],
+				'cleanup context',
+				mockApp,
+			);
+
+			expect(result).toEqual(['path/b.tmp']);
+			expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+			expect(consoleWarnSpy).toHaveBeenCalledWith(
+				expect.stringContaining('cleanup context'),
+				expect.objectContaining({
+					path: 'path/b.tmp',
+					error: expect.any(Error),
+				}),
+			);
+		});
+
+		it('should return all paths when all removals fail', async () => {
+			(mockApp.vault.adapter.remove as jest.Mock).mockRejectedValue(
+				new Error('Permission denied'),
+			);
+
+			const result = await removeTemporaryArtifacts(
+				['x.tmp', 'y.tmp'],
+				'total failure',
+				mockApp,
+			);
+
+			expect(result).toEqual(expect.arrayContaining(['x.tmp', 'y.tmp']));
+			expect(result).toHaveLength(2);
+			expect(consoleWarnSpy).toHaveBeenCalledTimes(2);
+		});
+
+		it('should return empty array for empty input', async () => {
+			const result = await removeTemporaryArtifacts(
+				[],
+				'no paths',
+				mockApp,
+			);
+
+			expect(result).toEqual([]);
+			expect(mockApp.vault.adapter.remove).not.toHaveBeenCalled();
+		});
+
+		it('should include log prefix in warning messages', async () => {
+			(mockApp.vault.adapter.remove as jest.Mock).mockRejectedValue(
+				new Error('fail'),
+			);
+
+			await removeTemporaryArtifacts(
+				['file.tmp'],
+				'removal failed',
+				mockApp,
+			);
+
+			expect(consoleWarnSpy).toHaveBeenCalledWith(
+				expect.stringContaining('[AudioRecorder]'),
+				expect.anything(),
+			);
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// rollbackFinalFile
+	// -----------------------------------------------------------------------
+	describe('rollbackFinalFile', () => {
+		it('should remove the file successfully', async () => {
+			(mockApp.vault.adapter.remove as jest.Mock).mockResolvedValue(
+				undefined,
+			);
+
+			await rollbackFinalFile(
+				'Recordings/final.webm',
+				'rollback context',
+				mockApp,
+			);
+
+			expect(mockApp.vault.adapter.remove).toHaveBeenCalledWith(
+				'Recordings/final.webm',
+			);
+			expect(consoleErrorSpy).not.toHaveBeenCalled();
+		});
+
+		it('should log error when removal fails', async () => {
+			(mockApp.vault.adapter.remove as jest.Mock).mockRejectedValue(
+				new Error('Cannot delete'),
+			);
+
+			await rollbackFinalFile(
+				'Recordings/final.webm',
+				'rollback failed',
+				mockApp,
+			);
+
+			expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+			expect(consoleErrorSpy).toHaveBeenCalledWith(
+				expect.stringContaining('rollback failed'),
+				expect.objectContaining({
+					filePath: 'Recordings/final.webm',
+					error: expect.any(Error),
+				}),
+			);
+		});
+
+		it('should include log prefix in error message', async () => {
+			(mockApp.vault.adapter.remove as jest.Mock).mockRejectedValue(
+				new Error('fail'),
+			);
+
+			await rollbackFinalFile('file.webm', 'context', mockApp);
+
+			expect(consoleErrorSpy).toHaveBeenCalledWith(
+				expect.stringContaining('[AudioRecorder]'),
+				expect.anything(),
+			);
+		});
+
+		it('should not throw even when removal fails', async () => {
+			(mockApp.vault.adapter.remove as jest.Mock).mockRejectedValue(
+				new Error('Catastrophic failure'),
+			);
+
+			await expect(
+				rollbackFinalFile('file.webm', 'context', mockApp),
+			).resolves.toBeUndefined();
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// cleanupIntermediateFiles
+	// -----------------------------------------------------------------------
+	describe('cleanupIntermediateFiles', () => {
+		function createMockTarget(segmentPaths: string[]): RecordingTarget {
+			return {
+				fileBaseName: 'recording',
+				sourceName: 'TestDevice',
+				bufferedChunks: [],
+				bufferedBytes: 0,
+				segmentIndex: 0,
+				segmentPaths,
+				pendingWrite: Promise.resolve(),
+				pcmBuffers: [],
+				pcmBufferedBytes: 0,
+				pcmChannels: 1,
+				pcmSampleRate: 44100,
+			};
+		}
+
+		it('should collect segment paths from all targets and remove them', async () => {
+			(mockApp.vault.adapter.remove as jest.Mock).mockResolvedValue(
+				undefined,
+			);
+
+			const targets = [
+				createMockTarget(['seg1.webm', 'seg2.webm']),
+				createMockTarget(['seg3.webm']),
+			];
+
+			const result = await cleanupIntermediateFiles(targets, mockApp);
+
+			expect(result).toEqual([]);
+			expect(mockApp.vault.adapter.remove).toHaveBeenCalledTimes(3);
+			expect(mockApp.vault.adapter.remove).toHaveBeenCalledWith(
+				'seg1.webm',
+			);
+			expect(mockApp.vault.adapter.remove).toHaveBeenCalledWith(
+				'seg2.webm',
+			);
+			expect(mockApp.vault.adapter.remove).toHaveBeenCalledWith(
+				'seg3.webm',
+			);
+		});
+
+		it('should return failed paths from multiple targets', async () => {
+			(mockApp.vault.adapter.remove as jest.Mock)
+				.mockResolvedValueOnce(undefined) // seg1 ok
+				.mockRejectedValueOnce(new Error('fail')) // seg2 fail
+				.mockResolvedValueOnce(undefined); // seg3 ok
+
+			const targets = [
+				createMockTarget(['seg1.webm', 'seg2.webm']),
+				createMockTarget(['seg3.webm']),
+			];
+
+			const result = await cleanupIntermediateFiles(targets, mockApp);
+
+			expect(result).toEqual(['seg2.webm']);
+		});
+
+		it('should handle empty targets array', async () => {
+			const result = await cleanupIntermediateFiles([], mockApp);
+
+			expect(result).toEqual([]);
+			expect(mockApp.vault.adapter.remove).not.toHaveBeenCalled();
+		});
+
+		it('should handle targets with empty segmentPaths', async () => {
+			const targets = [createMockTarget([]), createMockTarget([])];
+
+			const result = await cleanupIntermediateFiles(targets, mockApp);
+
+			expect(result).toEqual([]);
+			expect(mockApp.vault.adapter.remove).not.toHaveBeenCalled();
+		});
+
+		it('should use correct log context for failed removals', async () => {
+			(mockApp.vault.adapter.remove as jest.Mock).mockRejectedValue(
+				new Error('fail'),
+			);
+
+			const targets = [createMockTarget(['seg.webm'])];
+
+			await cleanupIntermediateFiles(targets, mockApp);
+
+			expect(consoleWarnSpy).toHaveBeenCalledWith(
+				expect.stringContaining(
+					'Failed to remove intermediate recording file',
+				),
+				expect.anything(),
+			);
+		});
+	});
+});

--- a/tests/unit/RecordingManager.test.ts
+++ b/tests/unit/RecordingManager.test.ts
@@ -465,7 +465,7 @@ describe('RecordingManager', () => {
 			expect(mockApp.vault.createBinary).toHaveBeenCalled();
 		});
 
-		it('should write multiple chunks as separate segment files and clean up after finalization', async () => {
+		it('should buffer multiple chunks into a single segment file and clean up after finalization', async () => {
 			const { Platform } = jest.requireMock('obsidian');
 			Platform.isMobile = false;
 			Platform.isMobileApp = false;
@@ -510,7 +510,7 @@ describe('RecordingManager', () => {
 
 			await manager.startRecording();
 
-			// Send 3 chunks
+			// Send 3 small chunks — all buffered in memory, flushed as 1 segment on stop
 			for (let i = 0; i < 3; i++) {
 				const chunk = new Blob([new Uint8Array([1, 2, 3])], {
 					type: 'audio/webm',
@@ -523,21 +523,13 @@ describe('RecordingManager', () => {
 
 			await manager.stopRecording();
 
-			// 3 segment files + 1 final file
+			// 1 combined segment file + 1 final file (instead of 3 + 1 before buffering)
 			expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
 				expect.stringMatching(/-part1\.webm\.tmp$/),
 				expect.any(ArrayBuffer),
 			);
-			expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
-				expect.stringMatching(/-part2\.webm\.tmp$/),
-				expect.any(ArrayBuffer),
-			);
-			expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
-				expect.stringMatching(/-part3\.webm\.tmp$/),
-				expect.any(ArrayBuffer),
-			);
-			// Segments cleaned up
-			expect(mockApp.vault.adapter.remove).toHaveBeenCalledTimes(3);
+			// Only 1 segment to clean up
+			expect(mockApp.vault.adapter.remove).toHaveBeenCalledTimes(1);
 		});
 
 		it('should save multi-track WAV via PCM capture and merge', async () => {


### PR DESCRIPTION
## Summary

- **Fix MP4 progress feedback**: Forward `onProgress` callback through `convertBlobToFormat()` to `encodeAudioBuffer()`, so single-track MP4/M4A/AAC encoding shows live progress (40-60% range) instead of a static "Decoding intermediate audio..." message
- **Fix slow cleanup**: Buffer desktop MediaRecorder chunks in memory (50MB threshold) and flush as a single segment file, reducing temp files from ~360 to ~1 for a 30-min recording — dramatically faster finalization and cleanup
- **Refactor RecordingManager.ts** (1122 → 820 lines): Extract `RecordingFileManager.ts` (file I/O), `AudioFormatConverter.ts` (audio conversion), `NoteInserter.ts` (note link insertion) as focused modules with 104 new unit tests

## Test plan

- [x] All 434 tests pass (`npm test -- --no-coverage`)
- [x] ESLint: 0 errors (`npm run lint`)
- [x] Build: success (`npm run build`)
- [ ] Manual: record 20-30 min MP4, verify progress bar updates during encoding
- [ ] Manual: verify temp file count in save directory during recording (should be ~1 instead of hundreds)
- [ ] Manual: verify multi-track single output mode still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)