### PR TITLE
feat(recording): add audio splitting into fixed-duration parts

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,9 @@ Opens a dialog to split the audio file into parts of a fixed duration. Options:
 - **Part name suffix** appended with the part number (e.g., `recording-part1.wav`).
 - **Bitrate** used when re-encoding parts of compressed formats (hidden for WAV sources).
 - **Delete source file** toggle to remove the original after a successful split.
-- **Update links in notes**: `Do nothing`, `Replace source link`, or `Insert after source link`. Links are updated in all notes of the vault, including notes that are not open.
+- **Update links in notes**: `Do nothing`, `Replace source link`, or `Insert after source link`. Links are updated in all notes of the vault, including notes that are not open. Both wikilinks (`![[...]]`) and Markdown links (`![](...)`) are covered, and new links follow your link-format preferences.
 
-WAV files are split losslessly at the byte level without re-encoding. Compressed formats are decoded once and re-encoded per part, so minor quality loss is possible. Part files are saved next to the source file, and the split is aborted if any target part file already exists. If writing fails midway, already-written parts are removed and the source file is kept.
+WAV files are split losslessly at the byte level without re-encoding, building one part at a time so even multi-gigabyte files are handled. Compressed formats are decoded once into memory and re-encoded per part, so minor quality loss is possible and very long compressed files need enough free memory for the decoded audio. Part files are saved next to the source file, and the split is aborted if any target part file already exists. If writing fails midway, already-written parts are removed and the source file is kept.
 
 ### Delete recording
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Notes on precision and behavior:
 - **WAV recordings** are split sample-exactly at the configured boundary.
 - **Compressed formats** (WebM, OGG, MP3, ...) restart the recorder at each boundary, so parts are approximately the configured length (within a few seconds) and a sub-second capture gap may occur between parts.
 - **Merged multi-track recordings** (output mode `Single file` with several tracks) are not auto-split; the plugin shows a notice and saves one merged file.
+- **Desktop only**: auto-split is not available in the mobile app; a notice is shown when a mobile recording starts with the option enabled.
 - Split settings changed during an active recording apply to the next session.
 
 ## Context menu actions
@@ -136,7 +137,7 @@ Opens a dialog to split the audio file into parts of a fixed duration. Options:
 - **Part name suffix** appended with the part number (e.g., `recording-part1.wav`).
 - **Bitrate** used when re-encoding parts of compressed formats (hidden for WAV sources).
 - **Delete source file** toggle to remove the original after a successful split.
-- **Update links in notes**: `Do nothing`, `Replace source link`, or `Insert after source link`. Links are updated in all notes of the vault, including notes that are not open. Both wikilinks (`![[...]]`) and Markdown links (`![](...)`) are covered, and new links follow your link-format preferences.
+- **Update links in notes**: `Do nothing`, `Replace source link`, or `Insert after source link`. Links in note bodies are updated across the whole vault, including notes that are not open. Both wikilinks (`![[...]]`) and Markdown links (`![](...)`) are covered, and new links follow your link-format preferences. Links inside frontmatter properties are **not** rewritten (a property cannot hold several links); the plugin shows a notice when such links exist. When a link shares a line with other content (for example a table row), the part links are separated with spaces instead of line breaks so the layout stays intact.
 
 WAV files are split losslessly at the byte level without re-encoding, building one part at a time so even multi-gigabyte files are handled. Compressed formats are decoded once into memory and re-encoded per part, so minor quality loss is possible and very long compressed files need enough free memory for the decoded audio. Part files are saved next to the source file, and the split is aborted if any target part file already exists. If writing fails midway, already-written parts are removed and the source file is kept.
 
@@ -223,7 +224,7 @@ Open **Settings > Advanced Audio Recorder** to configure the plugin.
 
 | Setting                            | Description                                                                                                                      | Default |
 | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| **Split recordings automatically** | Save the recording as separate part files of fixed duration. Not applied to merged multi-track recordings.                       | Off     |
+| **Split recordings automatically** | Save the recording as separate part files of fixed duration. Desktop only; not applied to merged multi-track recordings.         | Off     |
 | **Part duration**                  | Length of each part in minutes (1-180). Also the default part duration for manual splitting.                                     | 15      |
 | **Part name suffix**               | Suffix appended with the part number (e.g., `part` produces `-part1`, `-part2`). Letters, digits, hyphens, and underscores only. | `part`  |
 | **Delete source after split**      | Default state of the delete source file option in the manual split dialog.                                                       | Off     |

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ An advanced audio recording plugin for [Obsidian](https://obsidian.md) with conf
 - **Multi-track recording** from up to 8 input devices simultaneously.
 - **8 output formats**: WAV, WebM, OGG, MP3, MP4, M4A, AAC, FLAC.
 - **Audio format conversion** between supported formats via context menu.
+- **Audio splitting**: automatic splitting of recordings into fixed-duration parts and manual splitting of existing files via context menu.
 - **Audio file info** viewer showing duration, bitrate, sample rate, codec, and more.
 - **Configurable save location** with vault folder or near-active-file mode.
 - **Insert at original position** to place the audio link where recording started.
@@ -87,6 +88,17 @@ For longer recordings, saving may take noticeable time. The status bar shows a p
 
 The ribbon icon switches to a **save** icon while saving is in progress.
 
+### Automatic splitting
+
+When **Split recordings automatically** is enabled in settings, the recording is saved as separate part files of the configured duration (`recording-...-part1.webm`, `recording-...-part2.webm`, ...) instead of one long file. Each finished part is written to disk while the recording continues, and the remainder recorded after the last boundary becomes the final part. Links to all parts are inserted into the note when the recording stops.
+
+Notes on precision and behavior:
+
+- **WAV recordings** are split sample-exactly at the configured boundary.
+- **Compressed formats** (WebM, OGG, MP3, ...) restart the recorder at each boundary, so parts are approximately the configured length (within a few seconds) and a sub-second capture gap may occur between parts.
+- **Merged multi-track recordings** (output mode `Single file` with several tracks) are not auto-split; the plugin shows a notice and saves one merged file.
+- Split settings changed during an active recording apply to the next session.
+
 ## Context menu actions
 
 Right-click on an audio file in the **File Explorer**, on an audio **embed link** in the editor, or on an **embedded audio player** to access these actions:
@@ -115,6 +127,18 @@ Opens a conversion dialog to transcode the audio file to a different format. Opt
 - **Update links in notes**: `Do nothing`, `Replace source link`, or `Insert after source link`.
 
 The conversion reads the source file, decodes it at its native sample rate (to avoid resampling artifacts), re-encodes it in the target format, and saves the new file alongside the original.
+
+### Split audio into parts
+
+Opens a dialog to split the audio file into parts of a fixed duration. Options:
+
+- **Part duration** in minutes (1-180).
+- **Part name suffix** appended with the part number (e.g., `recording-part1.wav`).
+- **Bitrate** used when re-encoding parts of compressed formats (hidden for WAV sources).
+- **Delete source file** toggle to remove the original after a successful split.
+- **Update links in notes**: `Do nothing`, `Replace source link`, or `Insert after source link`. Links are updated in all notes of the vault, including notes that are not open.
+
+WAV files are split losslessly at the byte level without re-encoding. Compressed formats are decoded once and re-encoded per part, so minor quality loss is possible. Part files are saved next to the source file, and the split is aborted if any target part file already exists. If writing fails midway, already-written parts are removed and the source file is kept.
 
 ### Delete recording
 
@@ -194,6 +218,15 @@ Open **Settings > Advanced Audio Recorder** to configure the plugin.
 | **Active file subfolder** | Optional subfolder relative to the active file directory (e.g., `audio`). Created automatically if it does not exist. Only visible when "Save near active file" is enabled. | — |
 | **File prefix** | Filename prefix for recordings (e.g., `recording` produces `recording-1710000000000.webm`). | `recording` |
 | **Insert at original position** | Remember the note and cursor position when recording starts. The audio link is inserted at that location, even if you navigate away during recording. | Off |
+
+### Audio splitting
+
+| Setting                            | Description                                                                                                                      | Default |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| **Split recordings automatically** | Save the recording as separate part files of fixed duration. Not applied to merged multi-track recordings.                       | Off     |
+| **Part duration**                  | Length of each part in minutes (1-180). Also the default part duration for manual splitting.                                     | 15      |
+| **Part name suffix**               | Suffix appended with the part number (e.g., `part` produces `-part1`, `-part2`). Letters, digits, hyphens, and underscores only. | `part`  |
+| **Delete source after split**      | Default state of the delete source file option in the manual split dialog.                                                       | Off     |
 
 ### Multi-track recording
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -42,3 +42,22 @@ export const DESKTOP_FLUSH_THRESHOLD_BYTES = 50 * 1024 * 1024;
 
 /** Common MIME type prefix for audio formats. */
 export const MIME_TYPE_AUDIO_PREFIX = 'audio/';
+
+/** Default duration of one split part in minutes. */
+export const DEFAULT_SPLIT_CHUNK_MINUTES = 15;
+
+/** Minimum allowed split part duration in minutes. */
+export const MIN_SPLIT_CHUNK_MINUTES = 1;
+
+/** Maximum allowed split part duration in minutes. */
+export const MAX_SPLIT_CHUNK_MINUTES = 180;
+
+/** Default filename suffix for split parts (e.g. "-part1", "-part2"). */
+export const DEFAULT_SPLIT_PART_SUFFIX = 'part';
+
+/**
+ * Allowed characters for the split part suffix. The suffix ends up in
+ * file names and in link-matching regular expressions, so it must stay
+ * free of path separators and regex metacharacters.
+ */
+export const SPLIT_PART_SUFFIX_PATTERN = /^[A-Za-z0-9_-]+$/;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -43,6 +43,12 @@ export const DESKTOP_FLUSH_THRESHOLD_BYTES = 50 * 1024 * 1024;
 /** Common MIME type prefix for audio formats. */
 export const MIME_TYPE_AUDIO_PREFIX = 'audio/';
 
+/** Seconds in one minute. */
+export const SECONDS_PER_MINUTE = 60;
+
+/** Milliseconds in one minute. */
+export const MS_PER_MINUTE = 60_000;
+
 /** Default duration of one split part in minutes. */
 export const DEFAULT_SPLIT_CHUNK_MINUTES = 15;
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -61,3 +61,7 @@ export const DEFAULT_SPLIT_PART_SUFFIX = 'part';
  * free of path separators and regex metacharacters.
  */
 export const SPLIT_PART_SUFFIX_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+/** User-facing description of the split part suffix character rule. */
+export const SPLIT_PART_SUFFIX_RULE_TEXT =
+	'Part suffix may contain only letters, digits, hyphens, and underscores.';

--- a/src/recording/AudioFormatConverter.ts
+++ b/src/recording/AudioFormatConverter.ts
@@ -107,6 +107,31 @@ export async function convertBlobToWav(recordedBlob: Blob): Promise<Blob> {
 }
 
 /**
+ * Decodes compressed audio bytes preserving the native sample rate.
+ * First probes with a temporary AudioContext to discover the native
+ * rate, then re-decodes with an OfflineAudioContext at that rate to
+ * avoid resampling artifacts. The probe uses a copy of the buffer
+ * because decodeAudioData detaches its input.
+ * @param arrayBuffer - Encoded audio file bytes
+ * @returns Decoded AudioBuffer at the native sample rate
+ */
+export async function decodeAudioDataAtNativeRate(
+	arrayBuffer: ArrayBuffer,
+): Promise<AudioBuffer> {
+	const probeCtx = new AudioContext();
+	const probeBuffer = await probeCtx.decodeAudioData(arrayBuffer.slice(0));
+	const nativeSampleRate = probeBuffer.sampleRate;
+	await probeCtx.close();
+
+	const offlineCtx = new OfflineAudioContext(
+		probeBuffer.numberOfChannels,
+		probeBuffer.length,
+		nativeSampleRate,
+	);
+	return offlineCtx.decodeAudioData(arrayBuffer);
+}
+
+/**
  * Decodes an intermediate blob and re-encodes it to the target format.
  * Uses OfflineAudioContext at the native sample rate to avoid
  * resampling artifacts.
@@ -123,20 +148,7 @@ export async function convertBlobToFormat(
 	onProgress?: FormatProgressCallback,
 ): Promise<Blob> {
 	const arrayBuffer = await recordedBlob.arrayBuffer();
-
-	// Probe native sample rate
-	const probeCtx = new AudioContext();
-	const probeBuffer = await probeCtx.decodeAudioData(arrayBuffer.slice(0));
-	const nativeSampleRate = probeBuffer.sampleRate;
-	await probeCtx.close();
-
-	// Re-decode at native rate to avoid resampling
-	const offlineCtx = new OfflineAudioContext(
-		probeBuffer.numberOfChannels,
-		probeBuffer.length,
-		nativeSampleRate,
-	);
-	const decodedBuffer = await offlineCtx.decodeAudioData(arrayBuffer);
+	const decodedBuffer = await decodeAudioDataAtNativeRate(arrayBuffer);
 
 	return encodeAudioBuffer(
 		decodedBuffer,

--- a/src/recording/AudioFormatConverter.ts
+++ b/src/recording/AudioFormatConverter.ts
@@ -119,14 +119,19 @@ export async function decodeAudioDataAtNativeRate(
 	arrayBuffer: ArrayBuffer,
 ): Promise<AudioBuffer> {
 	const probeCtx = new AudioContext();
-	const probeBuffer = await probeCtx.decodeAudioData(arrayBuffer.slice(0));
-	const nativeSampleRate = probeBuffer.sampleRate;
-	await probeCtx.close();
+	let probeBuffer: AudioBuffer;
+	try {
+		probeBuffer = await probeCtx.decodeAudioData(arrayBuffer.slice(0));
+	} finally {
+		// Close even when decoding fails (corrupted/unsupported input),
+		// otherwise the AudioContext leaks
+		await probeCtx.close();
+	}
 
 	const offlineCtx = new OfflineAudioContext(
 		probeBuffer.numberOfChannels,
 		probeBuffer.length,
-		nativeSampleRate,
+		probeBuffer.sampleRate,
 	);
 	return offlineCtx.decodeAudioData(arrayBuffer);
 }

--- a/src/recording/AudioSplitter.ts
+++ b/src/recording/AudioSplitter.ts
@@ -10,14 +10,12 @@ import {
 	DEFAULT_SPLIT_PART_SUFFIX,
 	MAX_SPLIT_CHUNK_MINUTES,
 	MIN_SPLIT_CHUNK_MINUTES,
+	SECONDS_PER_MINUTE,
 	SPLIT_PART_SUFFIX_PATTERN,
 } from '../constants';
 
 /** Bytes per sample for 16-bit PCM data captured by PcmStreamRecorder. */
 export const PCM_BYTES_PER_SAMPLE = 2;
-
-/** Seconds in one minute. */
-const SECONDS_PER_MINUTE = 60;
 
 /** Byte length of a RIFF chunk header (4-byte id + 4-byte size). */
 const RIFF_CHUNK_HEADER_SIZE = 8;

--- a/src/recording/AudioSplitter.ts
+++ b/src/recording/AudioSplitter.ts
@@ -1,0 +1,255 @@
+/**
+ * Audio splitting utilities for dividing recordings into time-based parts.
+ * Provides lossless byte-level splitting for PCM WAV files and
+ * AudioBuffer slicing for compressed formats that require re-encoding.
+ * @module recording/AudioSplitter
+ */
+
+import {
+	DEFAULT_SPLIT_PART_SUFFIX,
+	SPLIT_PART_SUFFIX_PATTERN,
+} from '../constants';
+
+/** Bytes per sample for 16-bit PCM data captured by PcmStreamRecorder. */
+export const PCM_BYTES_PER_SAMPLE = 2;
+
+/** Seconds in one minute. */
+const SECONDS_PER_MINUTE = 60;
+
+/** Byte length of a RIFF chunk header (4-byte id + 4-byte size). */
+const RIFF_CHUNK_HEADER_SIZE = 8;
+
+/** Byte offset where RIFF chunks start (after "RIFF<size>WAVE"). */
+const RIFF_FIRST_CHUNK_OFFSET = 12;
+
+/** WAVE format codes that store raw, byte-sliceable sample frames. */
+const SLICEABLE_WAV_FORMATS = new Set([
+	0x0001, // PCM
+	0x0003, // IEEE float
+	0xfffe, // WAVE_FORMAT_EXTENSIBLE (PCM/float subformats)
+]);
+
+/**
+ * Layout of a RIFF/WAVE file required for lossless byte-level splitting.
+ */
+export interface WavLayout {
+	/** Byte offset where raw sample data starts (after the data chunk header). */
+	dataOffset: number;
+	/** Length of the sample data in bytes. */
+	dataLength: number;
+	/** Bytes of sample data per second of audio. */
+	byteRate: number;
+	/** Bytes per sample frame across all channels. */
+	blockAlign: number;
+}
+
+/**
+ * Reads a four-character ASCII chunk identifier.
+ */
+function readChunkId(view: DataView, offset: number): string {
+	let id = '';
+	for (let i = 0; i < 4; i++) {
+		id += String.fromCharCode(view.getUint8(offset + i));
+	}
+	return id;
+}
+
+/**
+ * Parses the RIFF/WAVE structure of a file and returns the layout needed
+ * for byte-level splitting. Walks chunks instead of assuming a fixed
+ * 44-byte header, so WAV files produced by other tools are handled too.
+ * @param buffer - Raw WAV file bytes
+ * @returns Layout, or null when the file cannot be split losslessly
+ */
+export function parseWavLayout(buffer: ArrayBuffer): WavLayout | null {
+	if (buffer.byteLength < RIFF_FIRST_CHUNK_OFFSET) {
+		return null;
+	}
+	const view = new DataView(buffer);
+	if (readChunkId(view, 0) !== 'RIFF' || readChunkId(view, 8) !== 'WAVE') {
+		return null;
+	}
+
+	let byteRate = 0;
+	let blockAlign = 0;
+	let formatCode = 0;
+	let offset = RIFF_FIRST_CHUNK_OFFSET;
+
+	while (offset + RIFF_CHUNK_HEADER_SIZE <= buffer.byteLength) {
+		const chunkId = readChunkId(view, offset);
+		const chunkSize = view.getUint32(offset + 4, true);
+		const chunkDataOffset = offset + RIFF_CHUNK_HEADER_SIZE;
+
+		if (chunkId === 'fmt ') {
+			if (chunkDataOffset + 16 > buffer.byteLength) {
+				return null;
+			}
+			formatCode = view.getUint16(chunkDataOffset, true);
+			byteRate = view.getUint32(chunkDataOffset + 8, true);
+			blockAlign = view.getUint16(chunkDataOffset + 12, true);
+		} else if (chunkId === 'data') {
+			const dataLength = Math.min(
+				chunkSize,
+				buffer.byteLength - chunkDataOffset,
+			);
+			if (
+				!SLICEABLE_WAV_FORMATS.has(formatCode) ||
+				byteRate <= 0 ||
+				blockAlign <= 0
+			) {
+				return null;
+			}
+			return {
+				dataOffset: chunkDataOffset,
+				dataLength,
+				byteRate,
+				blockAlign,
+			};
+		}
+
+		// Chunks are word-aligned: odd sizes are padded with one byte
+		offset = chunkDataOffset + chunkSize + (chunkSize % 2);
+	}
+
+	return null;
+}
+
+/**
+ * Splits raw WAV file bytes into standalone WAV files of the given
+ * duration without decoding. Each part reuses the original header
+ * (everything before the sample data) with patched RIFF and data chunk
+ * sizes, so sample format, channels, and rate are preserved exactly.
+ * Trailing chunks after the data chunk are dropped.
+ * @param buffer - Raw WAV file bytes
+ * @param layout - Parsed WAV layout from parseWavLayout
+ * @param partDurationSec - Duration of each part in seconds
+ * @returns Array of complete WAV files, one per part
+ */
+export function splitWavBuffer(
+	buffer: ArrayBuffer,
+	layout: WavLayout,
+	partDurationSec: number,
+): ArrayBuffer[] {
+	const rawPartBytes = Math.floor(layout.byteRate * partDurationSec);
+	const partBytes =
+		Math.floor(rawPartBytes / layout.blockAlign) * layout.blockAlign;
+	if (partBytes <= 0) {
+		return [];
+	}
+
+	const parts: ArrayBuffer[] = [];
+	const headerLength = layout.dataOffset;
+
+	for (let start = 0; start < layout.dataLength; start += partBytes) {
+		const length = Math.min(partBytes, layout.dataLength - start);
+		const part = new ArrayBuffer(headerLength + length);
+		const partBytesView = new Uint8Array(part);
+		partBytesView.set(new Uint8Array(buffer, 0, headerLength), 0);
+		partBytesView.set(
+			new Uint8Array(buffer, layout.dataOffset + start, length),
+			headerLength,
+		);
+
+		const view = new DataView(part);
+		// RIFF chunk size: total file length minus the 8-byte RIFF header
+		view.setUint32(4, headerLength + length - RIFF_CHUNK_HEADER_SIZE, true);
+		// data chunk size: immediately precedes the sample data
+		view.setUint32(headerLength - 4, length, true);
+
+		parts.push(part);
+	}
+
+	return parts;
+}
+
+/**
+ * Copies a sample range of all channels into a new AudioBuffer.
+ * @param source - Source buffer to slice
+ * @param startSample - First sample index (inclusive)
+ * @param endSample - Last sample index (exclusive), clamped to length
+ * @returns New AudioBuffer containing the requested range
+ */
+export function sliceAudioBuffer(
+	source: AudioBuffer,
+	startSample: number,
+	endSample: number,
+): AudioBuffer {
+	const start = Math.max(0, startSample);
+	const end = Math.min(source.length, endSample);
+	const part = new AudioBuffer({
+		numberOfChannels: source.numberOfChannels,
+		length: Math.max(0, end - start),
+		sampleRate: source.sampleRate,
+	});
+	for (let channel = 0; channel < source.numberOfChannels; channel++) {
+		const channelData = source.getChannelData(channel);
+		part.copyToChannel(channelData.subarray(start, end), channel);
+	}
+	return part;
+}
+
+/**
+ * Computes how many parts a recording of the given size yields.
+ * @param totalUnits - Total size (samples, bytes, etc.)
+ * @param unitsPerPart - Size of one part in the same units
+ * @returns Number of parts (the last one may be shorter)
+ */
+export function computePartCount(
+	totalUnits: number,
+	unitsPerPart: number,
+): number {
+	if (unitsPerPart <= 0 || totalUnits <= 0) {
+		return 0;
+	}
+	return Math.ceil(totalUnits / unitsPerPart);
+}
+
+/**
+ * Computes the byte limit of one auto-split part for raw int16 PCM capture.
+ * @param partMinutes - Part duration in minutes
+ * @param sampleRate - Sample rate in Hz
+ * @param channels - Number of audio channels
+ * @returns Part size in bytes (always a multiple of the PCM frame size)
+ */
+export function computePcmPartLimitBytes(
+	partMinutes: number,
+	sampleRate: number,
+	channels: number,
+): number {
+	return (
+		partMinutes *
+		SECONDS_PER_MINUTE *
+		sampleRate *
+		channels *
+		PCM_BYTES_PER_SAMPLE
+	);
+}
+
+/**
+ * Builds a part file name: `${baseName}-${suffix}${partNumber}.${extension}`.
+ * @param baseName - File name without extension
+ * @param suffix - Part suffix (validated/sanitized by the caller)
+ * @param partNumber - 1-based part number
+ * @param extension - File extension without the dot
+ * @returns Complete part file name
+ */
+export function buildPartFileName(
+	baseName: string,
+	suffix: string,
+	partNumber: number,
+	extension: string,
+): string {
+	return `${baseName}-${suffix}${String(partNumber)}.${extension}`;
+}
+
+/**
+ * Returns the suffix when it is safe for file names and regex patterns,
+ * otherwise falls back to the default suffix.
+ * @param suffix - User-configured part suffix
+ * @returns Safe part suffix
+ */
+export function sanitizePartSuffix(suffix: string): string {
+	return SPLIT_PART_SUFFIX_PATTERN.test(suffix)
+		? suffix
+		: DEFAULT_SPLIT_PART_SUFFIX;
+}

--- a/src/recording/AudioSplitter.ts
+++ b/src/recording/AudioSplitter.ts
@@ -6,7 +6,10 @@
  */
 
 import {
+	DEFAULT_SPLIT_CHUNK_MINUTES,
 	DEFAULT_SPLIT_PART_SUFFIX,
+	MAX_SPLIT_CHUNK_MINUTES,
+	MIN_SPLIT_CHUNK_MINUTES,
 	SPLIT_PART_SUFFIX_PATTERN,
 } from '../constants';
 
@@ -115,51 +118,58 @@ export function parseWavLayout(buffer: ArrayBuffer): WavLayout | null {
 }
 
 /**
- * Splits raw WAV file bytes into standalone WAV files of the given
- * duration without decoding. Each part reuses the original header
- * (everything before the sample data) with patched RIFF and data chunk
- * sizes, so sample format, channels, and rate are preserved exactly.
- * Trailing chunks after the data chunk are dropped.
- * @param buffer - Raw WAV file bytes
+ * Computes the byte length of one lossless WAV part, aligned down to a
+ * whole sample frame so parts never cut a frame in half.
  * @param layout - Parsed WAV layout from parseWavLayout
  * @param partDurationSec - Duration of each part in seconds
- * @returns Array of complete WAV files, one per part
+ * @returns Part size in bytes (multiple of blockAlign, possibly 0)
  */
-export function splitWavBuffer(
-	buffer: ArrayBuffer,
+export function computeWavPartBytes(
 	layout: WavLayout,
 	partDurationSec: number,
-): ArrayBuffer[] {
+): number {
 	const rawPartBytes = Math.floor(layout.byteRate * partDurationSec);
-	const partBytes =
-		Math.floor(rawPartBytes / layout.blockAlign) * layout.blockAlign;
-	if (partBytes <= 0) {
-		return [];
-	}
+	return Math.floor(rawPartBytes / layout.blockAlign) * layout.blockAlign;
+}
 
-	const parts: ArrayBuffer[] = [];
+/**
+ * Builds one standalone WAV part of a byte-level split without decoding.
+ * The part reuses the original header (everything before the sample
+ * data) with patched RIFF and data chunk sizes, so sample format,
+ * channels, and rate are preserved exactly. Trailing chunks after the
+ * data chunk are dropped. Parts are built one at a time so callers can
+ * keep at most one part buffer alive while writing multi-gigabyte files.
+ * @param buffer - Raw WAV file bytes
+ * @param layout - Parsed WAV layout from parseWavLayout
+ * @param partBytes - Part size in bytes from computeWavPartBytes
+ * @param partIndex - 0-based part index
+ * @returns Complete WAV file for the requested part
+ */
+export function buildWavPart(
+	buffer: ArrayBuffer,
+	layout: WavLayout,
+	partBytes: number,
+	partIndex: number,
+): ArrayBuffer {
+	const start = partIndex * partBytes;
+	const length = Math.max(0, Math.min(partBytes, layout.dataLength - start));
 	const headerLength = layout.dataOffset;
 
-	for (let start = 0; start < layout.dataLength; start += partBytes) {
-		const length = Math.min(partBytes, layout.dataLength - start);
-		const part = new ArrayBuffer(headerLength + length);
-		const partBytesView = new Uint8Array(part);
-		partBytesView.set(new Uint8Array(buffer, 0, headerLength), 0);
-		partBytesView.set(
-			new Uint8Array(buffer, layout.dataOffset + start, length),
-			headerLength,
-		);
+	const part = new ArrayBuffer(headerLength + length);
+	const partView = new Uint8Array(part);
+	partView.set(new Uint8Array(buffer, 0, headerLength), 0);
+	partView.set(
+		new Uint8Array(buffer, layout.dataOffset + start, length),
+		headerLength,
+	);
 
-		const view = new DataView(part);
-		// RIFF chunk size: total file length minus the 8-byte RIFF header
-		view.setUint32(4, headerLength + length - RIFF_CHUNK_HEADER_SIZE, true);
-		// data chunk size: immediately precedes the sample data
-		view.setUint32(headerLength - 4, length, true);
+	const view = new DataView(part);
+	// RIFF chunk size: total file length minus the 8-byte RIFF header
+	view.setUint32(4, headerLength + length - RIFF_CHUNK_HEADER_SIZE, true);
+	// data chunk size: immediately precedes the sample data
+	view.setUint32(headerLength - 4, length, true);
 
-		parts.push(part);
-	}
-
-	return parts;
+	return part;
 }
 
 /**
@@ -252,4 +262,62 @@ export function sanitizePartSuffix(suffix: string): string {
 	return SPLIT_PART_SUFFIX_PATTERN.test(suffix)
 		? suffix
 		: DEFAULT_SPLIT_PART_SUFFIX;
+}
+
+/**
+ * Clamps a configured part duration to the supported range.
+ * validateSettings is not invoked on the production load path, so
+ * persisted settings may carry out-of-range or non-numeric values.
+ * @param minutes - User-configured part duration in minutes
+ * @returns Whole minutes within [MIN, MAX], or the default for
+ * non-finite input
+ */
+export function clampSplitMinutes(minutes: number): number {
+	if (!Number.isFinite(minutes)) {
+		return DEFAULT_SPLIT_CHUNK_MINUTES;
+	}
+	return Math.min(
+		MAX_SPLIT_CHUNK_MINUTES,
+		Math.max(MIN_SPLIT_CHUNK_MINUTES, Math.floor(minutes)),
+	);
+}
+
+/**
+ * Sums the byte lengths of a list of buffers.
+ * @param buffers - Buffers to measure
+ * @returns Total byte length
+ */
+export function totalByteLength(buffers: ArrayBuffer[]): number {
+	return buffers.reduce((sum, buffer) => sum + buffer.byteLength, 0);
+}
+
+/**
+ * Detaches the trailing `trailingBytes` from the end of a buffer list,
+ * mutating the list in place so it keeps only the leading remainder.
+ * The boundary may fall inside one buffer or span several buffers.
+ * Used to carry auto-split overshoot into the next part.
+ * @param buffers - Buffer list to split; mutated in place
+ * @param trailingBytes - Number of bytes to detach from the end
+ * @returns Detached trailing buffers in their original order
+ */
+export function detachTrailingBytes(
+	buffers: ArrayBuffer[],
+	trailingBytes: number,
+): ArrayBuffer[] {
+	const carry: ArrayBuffer[] = [];
+	let remaining = trailingBytes;
+	while (remaining > 0 && buffers.length > 0) {
+		const last = buffers[buffers.length - 1];
+		if (last.byteLength <= remaining) {
+			buffers.pop();
+			carry.unshift(last);
+			remaining -= last.byteLength;
+		} else {
+			const keepBytes = last.byteLength - remaining;
+			buffers[buffers.length - 1] = last.slice(0, keepBytes);
+			carry.unshift(last.slice(keepBytes));
+			remaining = 0;
+		}
+	}
+	return carry;
 }

--- a/src/recording/RecordingManager.ts
+++ b/src/recording/RecordingManager.ts
@@ -23,6 +23,7 @@ import {
 	DESKTOP_FLUSH_THRESHOLD_BYTES,
 	DEFAULT_SPLIT_CHUNK_MINUTES,
 	DEFAULT_SPLIT_PART_SUFFIX,
+	MS_PER_MINUTE,
 } from '../constants';
 import { DebugLogger } from '../utils/DebugLogger';
 import {
@@ -59,9 +60,6 @@ import {
 	totalByteLength,
 } from './AudioSplitter';
 import { captureInsertionContext, insertFileLinks } from './NoteInserter';
-
-/** Milliseconds in one minute. */
-const MS_PER_MINUTE = 60_000;
 
 /**
  * Manages the audio recording lifecycle.
@@ -242,6 +240,9 @@ export class RecordingManager {
 		);
 		this.sessionSplitEnabled =
 			this.settings.autoSplitEnabled && !this.isMobileRecording;
+		if (this.settings.autoSplitEnabled && this.isMobileRecording) {
+			new Notice('Auto-split is not available in the mobile app.');
+		}
 
 		if (
 			this.sessionSplitEnabled &&
@@ -569,7 +570,7 @@ export class RecordingManager {
 		if (this.settings.outputMode === 'single') {
 			if (this.chunkTargets.length === 1) {
 				const target = this.chunkTargets[0];
-				const paths = await this.finalizeTrackFiles(target, timestamp);
+				const paths = await this.finalizeTrackFiles(target);
 				fileLinks.push(...target.partPaths, ...paths);
 			} else {
 				if (!this.isWavPcmRecording) {
@@ -646,7 +647,7 @@ export class RecordingManager {
 		} else {
 			for (let i = 0; i < this.chunkTargets.length; i++) {
 				const target = this.chunkTargets[i];
-				const paths = await this.finalizeTrackFiles(target, timestamp);
+				const paths = await this.finalizeTrackFiles(target);
 				fileLinks.push(...target.partPaths, ...paths);
 			}
 		}
@@ -1018,13 +1019,16 @@ export class RecordingManager {
 			this.app,
 		);
 		if (failedPaths.length > 0) {
-			await rollbackFinalFile(
-				filePath,
-				'Failed to rollback assembled WAV file',
-				this.app,
+			// Keep the assembled file: it already contains all captured
+			// audio, while segments that were removed exist nowhere else.
+			// Rolling it back would lose their audio permanently and leave
+			// part bookkeeping pointing at missing segment files.
+			console.error(
+				`${PLUGIN_LOG_PREFIX} Temporary segment files could not be removed:`,
+				failedPaths,
 			);
-			throw new Error(
-				`Temporary recording artifacts were kept for recovery: ${failedPaths.join(', ')}`,
+			new Notice(
+				`Recording saved, but temporary files could not be removed: ${failedPaths.join(', ')}`,
 			);
 		}
 	}
@@ -1133,31 +1137,29 @@ export class RecordingManager {
 	/**
 	 * Builds the final track file name, appending the part suffix when
 	 * the session was auto-split (the residual after the last rotation
-	 * becomes the next part number).
+	 * becomes the next part number). Uses the base name snapshotted at
+	 * session start so the residual matches its sibling part files even
+	 * when the file prefix setting changed mid-recording.
 	 * @param target - Recording target
-	 * @param timestamp - Recording timestamp string
 	 * @param extension - File extension without the dot
 	 */
 	private buildTrackFileName(
 		target: RecordingTarget,
-		timestamp: string,
 		extension: string,
 	): string {
-		const baseName = `${this.settings.filePrefix}-${target.sourceName}-${timestamp}`;
 		if (target.partIndex > 0) {
 			return buildPartFileName(
-				baseName,
+				target.fileBaseName,
 				this.sessionPartSuffix,
 				target.partIndex + 1,
 				extension,
 			);
 		}
-		return `${baseName}.${extension}`;
+		return `${target.fileBaseName}.${extension}`;
 	}
 
 	private async finalizeTrackFiles(
 		target: RecordingTarget,
-		timestamp: string,
 	): Promise<string[]> {
 		const fileLinks: string[] = [];
 		if (this.isMobileRecording) {
@@ -1173,11 +1175,7 @@ export class RecordingManager {
 				return fileLinks;
 			}
 			this.updateSaveProgress(40, 'Assembling audio...');
-			const fileName = this.buildTrackFileName(
-				target,
-				timestamp,
-				FORMAT_WAV,
-			);
+			const fileName = this.buildTrackFileName(target, FORMAT_WAV);
 			const filePath = await resolveUniquePath(
 				fileName,
 				this.app,
@@ -1191,7 +1189,6 @@ export class RecordingManager {
 
 		const fileName = this.buildTrackFileName(
 			target,
-			timestamp,
 			this.sessionOutputFormat,
 		);
 		const filePath = await this.finalizeMediaTrackToFile(
@@ -1236,9 +1233,10 @@ export class RecordingManager {
 	/**
 	 * Transcodes and writes a list of raw segment files into one final
 	 * audio file in the session output format, then removes the
-	 * temporary segments (rolling the final file back when cleanup
-	 * fails). Operates on an explicit segment list so part rotation can
-	 * finalize a detached snapshot while the next part is recording.
+	 * temporary segments (segments that cannot be removed are reported
+	 * and left on disk; the final file is always kept). Operates on an
+	 * explicit segment list so part rotation can finalize a detached
+	 * snapshot while the next part is recording.
 	 * @param segmentPaths - Segment files in capture order
 	 * @param fileName - Final file name
 	 * @param reportProgress - Whether to emit save-progress status
@@ -1329,13 +1327,16 @@ export class RecordingManager {
 			this.app,
 		);
 		if (failedCleanupPaths.length > 0) {
-			await rollbackFinalFile(
-				filePath,
-				'Failed to rollback finalized track',
-				this.app,
+			// Keep the final file: it already contains all captured audio,
+			// while segments that were removed exist nowhere else. Rolling
+			// it back would lose their audio permanently and leave part
+			// bookkeeping pointing at missing segment files.
+			console.error(
+				`${PLUGIN_LOG_PREFIX} Temporary segment files could not be removed:`,
+				failedCleanupPaths,
 			);
-			throw new Error(
-				`Temporary recording artifacts were kept for recovery: ${failedCleanupPaths.join(', ')}`,
+			new Notice(
+				`Recording saved, but temporary files could not be removed: ${failedCleanupPaths.join(', ')}`,
 			);
 		}
 

--- a/src/recording/RecordingManager.ts
+++ b/src/recording/RecordingManager.ts
@@ -23,12 +23,12 @@ import {
 	DESKTOP_FLUSH_THRESHOLD_BYTES,
 	DEFAULT_SPLIT_CHUNK_MINUTES,
 	DEFAULT_SPLIT_PART_SUFFIX,
-	MIN_SPLIT_CHUNK_MINUTES,
 } from '../constants';
 import { DebugLogger } from '../utils/DebugLogger';
 import {
 	buildMimeType,
 	validateRecordingCapability,
+	DEFAULT_BITRATE,
 	FORMAT_WEBM,
 	FORMAT_WAV,
 } from './AudioCapabilityDetector';
@@ -52,8 +52,11 @@ import {
 } from './AudioFormatConverter';
 import {
 	buildPartFileName,
+	clampSplitMinutes,
 	computePcmPartLimitBytes,
+	detachTrailingBytes,
 	sanitizePartSuffix,
+	totalByteLength,
 } from './AudioSplitter';
 import { captureInsertionContext, insertFileLinks } from './NoteInserter';
 
@@ -88,12 +91,18 @@ export class RecordingManager {
 	private sessionPartMinutes: number = DEFAULT_SPLIT_CHUNK_MINUTES;
 	/** Part name suffix for the current session (snapshot). */
 	private sessionPartSuffix: string = DEFAULT_SPLIT_PART_SUFFIX;
+	/** Output format for the current session (snapshot). */
+	private sessionOutputFormat: string = FORMAT_WEBM;
+	/** Encoder bitrate for the current session (snapshot). */
+	private sessionBitrate: number = DEFAULT_BITRATE;
 	/** Active (unpaused) milliseconds accumulated in the current part. */
 	private partActiveMs: number = 0;
 	/** Timestamp of the last start/resume/rotation for active-time tracking. */
 	private activeAnchor: number = 0;
 	/** In-flight MediaRecorder part rotation, if any. */
 	private rotationPromise: Promise<void> | null = null;
+	/** Whether the session is being stopped (blocks new part rotations). */
+	private isStopping: boolean = false;
 
 	/**
 	 * Creates a new RecordingManager.
@@ -145,6 +154,7 @@ export class RecordingManager {
 	 */
 	async startRecording(): Promise<void> {
 		try {
+			this.isStopping = false;
 			this.isMobileRecording = Platform.isMobileApp || Platform.isMobile;
 			this.isWavPcmRecording =
 				this.settings.recordingFormat === FORMAT_WAV &&
@@ -181,7 +191,7 @@ export class RecordingManager {
 			this.streams = streams;
 			this.trackOrder = trackOrder;
 
-			this.snapshotSplitSession(streams.length);
+			this.snapshotSessionSettings(streams.length);
 
 			this.recordingStartTime = Date.now();
 			this.recordingTimestamp = new Date()
@@ -210,16 +220,22 @@ export class RecordingManager {
 	}
 
 	/**
-	 * Snapshots auto-split settings for the current session so that
-	 * settings changes made mid-recording do not alter its behavior.
-	 * Auto-split is skipped for merged multi-track output because the
-	 * tracks are mixed only once at stop.
+	 * Snapshots the session-scoped settings (output format, bitrate,
+	 * auto-split configuration) used by the per-track part and
+	 * finalization paths, which read them repeatedly during the
+	 * session: updateSettings swaps the settings reference while
+	 * recording, and without the snapshot each rotation could produce
+	 * a part in a different format. The mobile flush and merged
+	 * multi-track stop paths still read live settings, matching their
+	 * pre-split behavior. Auto-split is skipped for merged multi-track
+	 * output because the tracks are mixed only once at stop.
 	 * @param streamCount - Number of acquired audio streams
 	 */
-	private snapshotSplitSession(streamCount: number): void {
-		this.sessionPartMinutes = Math.max(
-			MIN_SPLIT_CHUNK_MINUTES,
-			Math.floor(this.settings.splitChunkMinutes),
+	private snapshotSessionSettings(streamCount: number): void {
+		this.sessionOutputFormat = this.settings.recordingFormat;
+		this.sessionBitrate = this.settings.bitrate;
+		this.sessionPartMinutes = clampSplitMinutes(
+			this.settings.splitChunkMinutes,
 		);
 		this.sessionPartSuffix = sanitizePartSuffix(
 			this.settings.splitPartSuffix,
@@ -332,7 +348,7 @@ export class RecordingManager {
 			(stream) =>
 				new MediaRecorder(stream, {
 					mimeType,
-					audioBitsPerSecond: this.settings.bitrate,
+					audioBitsPerSecond: this.sessionBitrate,
 				}),
 		);
 
@@ -383,33 +399,29 @@ export class RecordingManager {
 	 * Stops the current recording and saves the files.
 	 */
 	async stopRecording(): Promise<void> {
-		// Let an in-flight part rotation finish before tearing down,
-		// otherwise the recorders it recreates would leak
-		if (this.rotationPromise) {
-			await this.rotationPromise;
+		if (this.isStopping) {
+			return;
 		}
-
-		const recordersToStop = [...this.recorders];
-		const pcmRecordersToStop = [...this.pcmRecorders];
-		const streamsToStop = [...this.streams];
+		// Block new part rotations from starting while stopping
+		// (shouldRotateMediaParts checks this flag)
+		this.isStopping = true;
 
 		try {
+			// Let an in-flight part rotation finish before tearing down:
+			// it replaces this.recorders, and its part files must be
+			// written before the residual is saved
+			if (this.rotationPromise) {
+				await this.rotationPromise;
+			}
+
 			if (this.isWavPcmRecording) {
 				await Promise.all(
-					pcmRecordersToStop.map((recorder) => recorder.stop()),
+					this.pcmRecorders.map((recorder) => recorder.stop()),
 				);
 			} else {
 				await Promise.all(
-					recordersToStop.map(
-						(recorder) =>
-							new Promise<void>((resolve) => {
-								recorder.addEventListener(
-									'stop',
-									() => resolve(),
-									{ once: true },
-								);
-								recorder.stop();
-							}),
+					this.recorders.map((recorder) =>
+						this.stopMediaRecorder(recorder),
 					),
 				);
 			}
@@ -435,7 +447,7 @@ export class RecordingManager {
 				error,
 			);
 		} finally {
-			stopAllStreams(streamsToStop);
+			stopAllStreams(this.streams);
 			this.streams = [];
 			this.recorders = [];
 			this.pcmRecorders = [];
@@ -448,8 +460,30 @@ export class RecordingManager {
 			this.sessionSplitEnabled = false;
 			this.partActiveMs = 0;
 			this.rotationPromise = null;
+			this.isStopping = false;
 			this.setStatus(RecordingStatus.Idle);
 		}
+	}
+
+	/**
+	 * Stops a MediaRecorder and resolves once its stop event has fired,
+	 * which guarantees the final dataavailable chunk was delivered.
+	 * Resolves immediately for recorders that are already inactive
+	 * (e.g. stopped by an in-flight part rotation), because calling
+	 * stop() on an inactive recorder throws.
+	 * @param recorder - Recorder to stop
+	 */
+	private stopMediaRecorder(recorder: MediaRecorder): Promise<void> {
+		return new Promise<void>((resolve) => {
+			if (recorder.state === 'inactive') {
+				resolve();
+				return;
+			}
+			recorder.addEventListener('stop', () => resolve(), {
+				once: true,
+			});
+			recorder.stop();
+		});
 	}
 
 	/**
@@ -460,7 +494,14 @@ export class RecordingManager {
 			if (this.isWavPcmRecording) {
 				this.pcmRecorders.forEach((recorder) => recorder.pause());
 			} else {
-				this.recorders.forEach((recorder) => recorder.pause());
+				// During a part rotation the recorders are momentarily
+				// inactive and pausing them would throw; the rotation
+				// re-applies the paused status when it restarts capture
+				this.recorders.forEach((recorder) => {
+					if (recorder.state !== 'inactive') {
+						recorder.pause();
+					}
+				});
 			}
 			// Freeze active-time accounting used by auto-split rotation
 			this.partActiveMs += Date.now() - this.activeAnchor;
@@ -470,7 +511,13 @@ export class RecordingManager {
 			if (this.isWavPcmRecording) {
 				this.pcmRecorders.forEach((recorder) => recorder.resume());
 			} else {
-				this.recorders.forEach((recorder) => recorder.resume());
+				// Skip recorders stopped by an in-flight part rotation;
+				// they are recreated in the resumed state
+				this.recorders.forEach((recorder) => {
+					if (recorder.state !== 'inactive') {
+						recorder.resume();
+					}
+				});
 			}
 			this.activeAnchor = Date.now();
 			this.setStatus(RecordingStatus.Recording);
@@ -484,6 +531,10 @@ export class RecordingManager {
 	 * Cleans up resources on unload.
 	 */
 	cleanup(): void {
+		// Prevent an in-flight part rotation from recreating recorders
+		// on the released streams after unload
+		this.isStopping = true;
+		this.sessionSplitEnabled = false;
 		stopAllStreams(this.streams);
 		this.recorders = [];
 		this.pcmRecorders = [];
@@ -632,11 +683,20 @@ export class RecordingManager {
 		// Rotation spans all tracks and restarts the recorders, so it runs
 		// outside the per-target pendingWrite chain, guarded against reentry
 		if (this.shouldRotateMediaParts()) {
-			this.rotationPromise = this.rotateMediaRecorderParts().finally(
-				() => {
+			this.rotationPromise = this.rotateMediaRecorderParts()
+				.catch((error: unknown) => {
+					// Backstop: the rotation contains its own error
+					// handling, but an unexpected rejection must not
+					// become unhandled or poison a concurrent
+					// stopRecording awaiting this promise
+					console.error(
+						`${PLUGIN_LOG_PREFIX} Unexpected error during part rotation:`,
+						error,
+					);
+				})
+				.finally(() => {
 					this.rotationPromise = null;
-				},
-			);
+				});
 		}
 	}
 
@@ -682,6 +742,7 @@ export class RecordingManager {
 		if (
 			!this.sessionSplitEnabled ||
 			this.isWavPcmRecording ||
+			this.isStopping ||
 			this.rotationPromise !== null ||
 			this.status !== RecordingStatus.Recording
 		) {
@@ -706,16 +767,10 @@ export class RecordingManager {
 		partLimitBytes: number,
 	): Promise<void> {
 		const overshoot = target.partPcmBytes - partLimitBytes;
-		let carry: ArrayBuffer | null = null;
-		if (overshoot > 0 && target.pcmBuffers.length > 0) {
-			const last = target.pcmBuffers[target.pcmBuffers.length - 1];
-			const keepBytes = last.byteLength - overshoot;
-			target.pcmBuffers[target.pcmBuffers.length - 1] = last.slice(
-				0,
-				keepBytes,
-			);
-			carry = last.slice(keepBytes);
-		}
+		const carry =
+			overshoot > 0
+				? detachTrailingBytes(target.pcmBuffers, overshoot)
+				: [];
 
 		target.partIndex += 1;
 		try {
@@ -740,8 +795,16 @@ export class RecordingManager {
 			target.segmentPaths = [];
 			target.segmentIndex = 0;
 		} catch (error) {
-			// Keep recording: data stays in segments and lands in the next part
+			// Keep recording without losing audio: whatever was not
+			// flushed stays buffered (with the carry re-attached in
+			// capture order), flushed segments stay on disk, and all of
+			// it lands in the next part. Part accounting restarts from
+			// zero so the failed save is retried one part length later,
+			// not on every chunk.
 			target.partIndex -= 1;
+			target.pcmBuffers.push(...carry);
+			target.pcmBufferedBytes = totalByteLength(target.pcmBuffers);
+			target.partPcmBytes = 0;
 			console.error(
 				`${PLUGIN_LOG_PREFIX} Failed to finalize recording part:`,
 				error,
@@ -749,70 +812,62 @@ export class RecordingManager {
 			new Notice(
 				'Failed to save recording part. Recording continues; data is kept for the next part.',
 			);
-		} finally {
-			target.pcmBuffers = carry ? [carry] : [];
-			target.pcmBufferedBytes = carry ? carry.byteLength : 0;
-			target.partPcmBytes = carry ? carry.byteLength : 0;
+			return;
 		}
+		target.pcmBuffers = carry;
+		target.pcmBufferedBytes = totalByteLength(carry);
+		target.partPcmBytes = target.pcmBufferedBytes;
 	}
 
 	/**
 	 * Rotates MediaRecorder-based recording at an auto-split boundary:
-	 * stops the recorders to obtain a complete container, finalizes the
-	 * buffered data as a part file per track, and restarts the recorders
-	 * on the same streams. The recording status stays Recording the whole
-	 * time. Errors are contained so the session keeps recording.
+	 * stops the recorders to obtain a complete container, detaches the
+	 * buffered data of each track as a snapshot of plain segment files,
+	 * restarts the recorders on the same streams, and only then
+	 * transcodes the snapshots into part files. Restarting before the
+	 * potentially slow transcoding keeps the capture gap limited to
+	 * recorder stop plus raw buffer flush time. The recording status
+	 * stays Recording the whole time. Errors are contained so the
+	 * session keeps recording.
 	 */
 	private async rotateMediaRecorderParts(): Promise<void> {
+		const snapshots: {
+			target: RecordingTarget;
+			segmentPaths: string[];
+		}[] = [];
 		try {
 			const recordersToStop = [...this.recorders];
 			await Promise.all(
-				recordersToStop.map(
-					(recorder) =>
-						new Promise<void>((resolve) => {
-							recorder.addEventListener('stop', () => resolve(), {
-								once: true,
-							});
-							recorder.stop();
-						}),
+				recordersToStop.map((recorder) =>
+					this.stopMediaRecorder(recorder),
 				),
 			);
 			await Promise.all(this.chunkTargets.map((t) => t.pendingWrite));
 
 			for (const target of this.chunkTargets) {
-				target.partIndex += 1;
 				try {
-					const fileName = buildPartFileName(
-						target.fileBaseName,
-						this.sessionPartSuffix,
-						target.partIndex,
-						this.settings.recordingFormat,
-					);
-					const filePath = await this.finalizeMediaTrackToFile(
-						target,
-						fileName,
-					);
-					if (filePath) {
-						target.partPaths.push(filePath);
-						this.debugLogger.log('Auto-split part saved', {
-							filePath,
-						});
-						new Notice(
-							`Recording part ${String(target.partIndex)} saved`,
-						);
-					} else {
-						target.partIndex -= 1;
-					}
+					// Plain file write of already-captured bytes; the
+					// expensive transcoding happens after the restart
+					await this.flushChunkBuffer(target);
 				} catch (error) {
-					// Keep recording: segments stay on disk for the next part
-					target.partIndex -= 1;
+					// Chunks stay buffered in capture order and land in
+					// the next part
 					console.error(
-						`${PLUGIN_LOG_PREFIX} Failed to finalize recording part:`,
+						`${PLUGIN_LOG_PREFIX} Failed to flush buffers at part boundary:`,
 						error,
 					);
 					new Notice(
 						'Failed to save recording part. Recording continues; data is kept for the next part.',
 					);
+					continue;
+				}
+				if (target.segmentPaths.length > 0) {
+					snapshots.push({
+						target,
+						segmentPaths: target.segmentPaths,
+					});
+					target.segmentPaths = [];
+					target.segmentIndex = 0;
 				}
 			}
 		} catch (error) {
@@ -825,16 +880,92 @@ export class RecordingManager {
 			// Restart only while still recording or paused; a concurrent
 			// stopRecording awaits this rotation and tears recorders down
 			if (
-				this.status === RecordingStatus.Recording ||
-				this.status === RecordingStatus.Paused
+				!this.isStopping &&
+				(this.status === RecordingStatus.Recording ||
+					this.status === RecordingStatus.Paused)
 			) {
-				this.createAndStartMediaRecorders();
-				if (this.status === RecordingStatus.Paused) {
-					this.recorders.forEach((recorder) => recorder.pause());
-				}
+				this.restartMediaRecorders();
 			}
 			this.partActiveMs = 0;
 			this.activeAnchor = Date.now();
+		}
+
+		// Transcode and write the part files while the next part is
+		// already being captured by the restarted recorders
+		for (const snapshot of snapshots) {
+			await this.finalizeMediaPartSnapshot(
+				snapshot.target,
+				snapshot.segmentPaths,
+			);
+		}
+	}
+
+	/**
+	 * Recreates and starts the MediaRecorders after a part rotation,
+	 * re-applying the paused state. A restart failure (e.g. the input
+	 * device disappeared mid-session) would otherwise leave the session
+	 * silently dead — status Recording with no recorder running — so
+	 * the session is stopped to salvage the parts already written.
+	 */
+	private restartMediaRecorders(): void {
+		try {
+			this.createAndStartMediaRecorders();
+			if (this.status === RecordingStatus.Paused) {
+				this.recorders.forEach((recorder) => recorder.pause());
+			}
+		} catch (error) {
+			console.error(
+				`${PLUGIN_LOG_PREFIX} Failed to restart recorders after part rotation:`,
+				error,
+			);
+			new Notice(
+				'Could not restart recording after saving a part. Stopping and saving the recording.',
+			);
+			void this.stopRecording();
+		}
+	}
+
+	/**
+	 * Transcodes one detached rotation snapshot into a part file and
+	 * records it on the target. On failure the snapshot segments are
+	 * re-attached in front of the data captured since the restart, so
+	 * the audio lands in the next part instead of being lost.
+	 * @param target - Recording target the snapshot belongs to
+	 * @param segmentPaths - Detached segment files in capture order
+	 */
+	private async finalizeMediaPartSnapshot(
+		target: RecordingTarget,
+		segmentPaths: string[],
+	): Promise<void> {
+		target.partIndex += 1;
+		try {
+			const fileName = buildPartFileName(
+				target.fileBaseName,
+				this.sessionPartSuffix,
+				target.partIndex,
+				this.sessionOutputFormat,
+			);
+			const filePath = await this.finalizeSegmentsToFile(
+				segmentPaths,
+				fileName,
+			);
+			if (filePath) {
+				target.partPaths.push(filePath);
+				this.debugLogger.log('Auto-split part saved', { filePath });
+				new Notice(`Recording part ${String(target.partIndex)} saved`);
+			} else {
+				target.partIndex -= 1;
+			}
+		} catch (error) {
+			target.partIndex -= 1;
+			target.segmentPaths = [...segmentPaths, ...target.segmentPaths];
+			console.error(
+				`${PLUGIN_LOG_PREFIX} Failed to finalize recording part:`,
+				error,
+			);
+			new Notice(
+				'Failed to save recording part. Recording continues; data is kept for the next part.',
+			);
 		}
 	}
 
@@ -850,11 +981,7 @@ export class RecordingManager {
 			this.settings,
 		);
 
-		const totalSize = target.pcmBuffers.reduce(
-			(sum, buf) => sum + buf.byteLength,
-			0,
-		);
-		const merged = new Uint8Array(totalSize);
+		const merged = new Uint8Array(totalByteLength(target.pcmBuffers));
 		let offset = 0;
 		for (const buf of target.pcmBuffers) {
 			merged.set(new Uint8Array(buf), offset);
@@ -1065,7 +1192,7 @@ export class RecordingManager {
 		const fileName = this.buildTrackFileName(
 			target,
 			timestamp,
-			this.settings.recordingFormat,
+			this.sessionOutputFormat,
 		);
 		const filePath = await this.finalizeMediaTrackToFile(
 			target,
@@ -1080,15 +1207,12 @@ export class RecordingManager {
 
 	/**
 	 * Finalizes buffered MediaRecorder data of one track into a final
-	 * audio file: flushes buffers, concatenates segments, converts to
-	 * the configured output format, writes the file, and removes the
-	 * temporary segments (rolling the file back when cleanup fails).
-	 * Used both at stop and at auto-split part rotation.
+	 * audio file: flushes the chunk buffer to segment files and hands
+	 * them to finalizeSegmentsToFile. Used at stop; part rotation
+	 * finalizes detached snapshots directly instead.
 	 * @param target - Recording target to finalize
 	 * @param fileName - Final file name
-	 * @param reportProgress - Whether to emit save-progress status
-	 * updates (must stay false during rotation: the Saving status would
-	 * tear down the status bar recording controls)
+	 * @param reportProgress - Whether to emit save-progress status updates
 	 * @returns Final file path, or null when no audio data is buffered
 	 */
 	private async finalizeMediaTrackToFile(
@@ -1097,12 +1221,50 @@ export class RecordingManager {
 		reportProgress: boolean = false,
 	): Promise<string | null> {
 		await this.flushChunkBuffer(target);
-		const blob = await this.buildTrackBlob(target);
-		if (!blob || blob.size === 0) {
+		const filePath = await this.finalizeSegmentsToFile(
+			target.segmentPaths,
+			fileName,
+			reportProgress,
+		);
+		if (filePath) {
+			target.segmentPaths = [];
+			target.segmentIndex = 0;
+		}
+		return filePath;
+	}
+
+	/**
+	 * Transcodes and writes a list of raw segment files into one final
+	 * audio file in the session output format, then removes the
+	 * temporary segments (rolling the final file back when cleanup
+	 * fails). Operates on an explicit segment list so part rotation can
+	 * finalize a detached snapshot while the next part is recording.
+	 * @param segmentPaths - Segment files in capture order
+	 * @param fileName - Final file name
+	 * @param reportProgress - Whether to emit save-progress status
+	 * updates (must stay false during rotation: the Saving status would
+	 * tear down the status bar recording controls)
+	 * @returns Final file path, or null when the segments hold no data
+	 */
+	private async finalizeSegmentsToFile(
+		segmentPaths: string[],
+		fileName: string,
+		reportProgress: boolean = false,
+	): Promise<string | null> {
+		if (segmentPaths.length === 0) {
+			return null;
+		}
+		const segmentBuffers = await Promise.all(
+			segmentPaths.map((path) => this.app.vault.adapter.readBinary(path)),
+		);
+		const blob = new Blob(segmentBuffers, {
+			type: getRecorderMediaType(this.activeRecorderFormat),
+		});
+		if (blob.size === 0) {
 			return null;
 		}
 
-		const outputFormat = this.settings.recordingFormat;
+		const outputFormat = this.sessionOutputFormat;
 		const filePath = await resolveUniquePath(
 			fileName,
 			this.app,
@@ -1131,7 +1293,7 @@ export class RecordingManager {
 			const outputBlob = await convertBlobToFormat(
 				blob,
 				outputFormat,
-				this.settings.bitrate,
+				this.sessionBitrate,
 				(percent) => {
 					if (reportProgress) {
 						this.updateSaveProgress(
@@ -1162,7 +1324,7 @@ export class RecordingManager {
 			this.updateSaveProgress(80, 'Cleaning up...');
 		}
 		const failedCleanupPaths = await removeTemporaryArtifacts(
-			target.segmentPaths,
+			segmentPaths,
 			'Failed to remove segment file after finalization',
 			this.app,
 		);
@@ -1177,8 +1339,6 @@ export class RecordingManager {
 			);
 		}
 
-		target.segmentPaths = [];
-		target.segmentIndex = 0;
 		return filePath;
 	}
 }

--- a/src/recording/RecordingManager.ts
+++ b/src/recording/RecordingManager.ts
@@ -21,6 +21,9 @@ import {
 	MOBILE_BUFFER_LIMIT_BYTES,
 	PCM_FLUSH_THRESHOLD_BYTES,
 	DESKTOP_FLUSH_THRESHOLD_BYTES,
+	DEFAULT_SPLIT_CHUNK_MINUTES,
+	DEFAULT_SPLIT_PART_SUFFIX,
+	MIN_SPLIT_CHUNK_MINUTES,
 } from '../constants';
 import { DebugLogger } from '../utils/DebugLogger';
 import {
@@ -47,7 +50,15 @@ import {
 	buildOutputBlob,
 	mergeAudioTracks,
 } from './AudioFormatConverter';
+import {
+	buildPartFileName,
+	computePcmPartLimitBytes,
+	sanitizePartSuffix,
+} from './AudioSplitter';
 import { captureInsertionContext, insertFileLinks } from './NoteInserter';
+
+/** Milliseconds in one minute. */
+const MS_PER_MINUTE = 60_000;
 
 /**
  * Manages the audio recording lifecycle.
@@ -71,6 +82,18 @@ export class RecordingManager {
 	private isWavPcmRecording: boolean = false;
 	private activeRecorderFormat: string = FORMAT_WEBM;
 	private insertionContext: InsertionContext | null = null;
+	/** Whether auto-split is active for the current session (snapshot). */
+	private sessionSplitEnabled: boolean = false;
+	/** Part duration in minutes for the current session (snapshot). */
+	private sessionPartMinutes: number = DEFAULT_SPLIT_CHUNK_MINUTES;
+	/** Part name suffix for the current session (snapshot). */
+	private sessionPartSuffix: string = DEFAULT_SPLIT_PART_SUFFIX;
+	/** Active (unpaused) milliseconds accumulated in the current part. */
+	private partActiveMs: number = 0;
+	/** Timestamp of the last start/resume/rotation for active-time tracking. */
+	private activeAnchor: number = 0;
+	/** In-flight MediaRecorder part rotation, if any. */
+	private rotationPromise: Promise<void> | null = null;
 
 	/**
 	 * Creates a new RecordingManager.
@@ -158,6 +181,8 @@ export class RecordingManager {
 			this.streams = streams;
 			this.trackOrder = trackOrder;
 
+			this.snapshotSplitSession(streams.length);
+
 			this.recordingStartTime = Date.now();
 			this.recordingTimestamp = new Date()
 				.toISOString()
@@ -175,10 +200,49 @@ export class RecordingManager {
 				this.settings.insertAtOriginalPosition,
 				this.debugLogger,
 			);
+			this.partActiveMs = 0;
+			this.activeAnchor = Date.now();
 			this.setStatus(RecordingStatus.Recording);
 			new Notice('Recording started');
 		} catch (error) {
 			this.handleStartRecordingError(error);
+		}
+	}
+
+	/**
+	 * Snapshots auto-split settings for the current session so that
+	 * settings changes made mid-recording do not alter its behavior.
+	 * Auto-split is skipped for merged multi-track output because the
+	 * tracks are mixed only once at stop.
+	 * @param streamCount - Number of acquired audio streams
+	 */
+	private snapshotSplitSession(streamCount: number): void {
+		this.sessionPartMinutes = Math.max(
+			MIN_SPLIT_CHUNK_MINUTES,
+			Math.floor(this.settings.splitChunkMinutes),
+		);
+		this.sessionPartSuffix = sanitizePartSuffix(
+			this.settings.splitPartSuffix,
+		);
+		this.sessionSplitEnabled =
+			this.settings.autoSplitEnabled && !this.isMobileRecording;
+
+		if (
+			this.sessionSplitEnabled &&
+			this.settings.outputMode === 'single' &&
+			streamCount > 1
+		) {
+			this.sessionSplitEnabled = false;
+			new Notice(
+				'Auto-split is skipped for merged multi-track recordings.',
+			);
+		}
+
+		if (this.sessionSplitEnabled) {
+			this.debugLogger.log('Auto-split enabled for this session', {
+				partMinutes: this.sessionPartMinutes,
+				partSuffix: this.sessionPartSuffix,
+			});
 		}
 	}
 
@@ -212,6 +276,9 @@ export class RecordingManager {
 					pcmBufferedBytes: 0,
 					pcmChannels: 1,
 					pcmSampleRate: this.settings.sampleRate,
+					partIndex: 0,
+					partPaths: [],
+					partPcmBytes: 0,
 				};
 			}),
 		);
@@ -250,6 +317,16 @@ export class RecordingManager {
 	 * and mobile WAV.
 	 */
 	private async initMediaRecording(): Promise<void> {
+		this.chunkTargets = await this.createChunkTargets(this.streams.length);
+		this.createAndStartMediaRecorders();
+	}
+
+	/**
+	 * Creates MediaRecorder instances on the current streams, attaches
+	 * chunk/error handlers, and starts them with the chunk timeslice.
+	 * Used at recording start and after each auto-split part rotation.
+	 */
+	private createAndStartMediaRecorders(): void {
 		const mimeType = buildMimeType(this.activeRecorderFormat);
 		this.recorders = this.streams.map(
 			(stream) =>
@@ -257,9 +334,6 @@ export class RecordingManager {
 					mimeType,
 					audioBitsPerSecond: this.settings.bitrate,
 				}),
-		);
-		this.chunkTargets = await this.createChunkTargets(
-			this.recorders.length,
 		);
 
 		this.recorders.forEach((recorder, index) => {
@@ -309,6 +383,12 @@ export class RecordingManager {
 	 * Stops the current recording and saves the files.
 	 */
 	async stopRecording(): Promise<void> {
+		// Let an in-flight part rotation finish before tearing down,
+		// otherwise the recorders it recreates would leak
+		if (this.rotationPromise) {
+			await this.rotationPromise;
+		}
+
 		const recordersToStop = [...this.recorders];
 		const pcmRecordersToStop = [...this.pcmRecorders];
 		const streamsToStop = [...this.streams];
@@ -365,6 +445,9 @@ export class RecordingManager {
 			this.totalChunks = 0;
 			this.isWavPcmRecording = false;
 			this.insertionContext = null;
+			this.sessionSplitEnabled = false;
+			this.partActiveMs = 0;
+			this.rotationPromise = null;
 			this.setStatus(RecordingStatus.Idle);
 		}
 	}
@@ -379,6 +462,8 @@ export class RecordingManager {
 			} else {
 				this.recorders.forEach((recorder) => recorder.pause());
 			}
+			// Freeze active-time accounting used by auto-split rotation
+			this.partActiveMs += Date.now() - this.activeAnchor;
 			this.setStatus(RecordingStatus.Paused);
 			new Notice('Recording paused');
 		} else if (this.status === RecordingStatus.Paused) {
@@ -387,6 +472,7 @@ export class RecordingManager {
 			} else {
 				this.recorders.forEach((recorder) => recorder.resume());
 			}
+			this.activeAnchor = Date.now();
 			this.setStatus(RecordingStatus.Recording);
 			new Notice('Recording resumed');
 		} else {
@@ -431,11 +517,9 @@ export class RecordingManager {
 
 		if (this.settings.outputMode === 'single') {
 			if (this.chunkTargets.length === 1) {
-				const paths = await this.finalizeTrackFiles(
-					this.chunkTargets[0],
-					timestamp,
-				);
-				fileLinks.push(...paths);
+				const target = this.chunkTargets[0];
+				const paths = await this.finalizeTrackFiles(target, timestamp);
+				fileLinks.push(...target.partPaths, ...paths);
 			} else {
 				if (!this.isWavPcmRecording) {
 					await Promise.all(
@@ -510,11 +594,9 @@ export class RecordingManager {
 			}
 		} else {
 			for (let i = 0; i < this.chunkTargets.length; i++) {
-				const paths = await this.finalizeTrackFiles(
-					this.chunkTargets[i],
-					timestamp,
-				);
-				fileLinks.push(...paths);
+				const target = this.chunkTargets[i];
+				const paths = await this.finalizeTrackFiles(target, timestamp);
+				fileLinks.push(...target.partPaths, ...paths);
 			}
 		}
 
@@ -546,6 +628,16 @@ export class RecordingManager {
 
 		target.pendingWrite = target.pendingWrite.then(enqueue);
 		await target.pendingWrite;
+
+		// Rotation spans all tracks and restarts the recorders, so it runs
+		// outside the per-target pendingWrite chain, guarded against reentry
+		if (this.shouldRotateMediaParts()) {
+			this.rotationPromise = this.rotateMediaRecorderParts().finally(
+				() => {
+					this.rotationPromise = null;
+				},
+			);
+		}
 	}
 
 	private async handlePcmChunk(
@@ -561,6 +653,17 @@ export class RecordingManager {
 		const enqueue = async (): Promise<void> => {
 			target.pcmBuffers.push(data);
 			target.pcmBufferedBytes += data.byteLength;
+			if (this.sessionSplitEnabled) {
+				target.partPcmBytes += data.byteLength;
+				const partLimitBytes = computePcmPartLimitBytes(
+					this.sessionPartMinutes,
+					target.pcmSampleRate,
+					target.pcmChannels,
+				);
+				if (target.partPcmBytes >= partLimitBytes) {
+					await this.finalizePcmPart(target, partLimitBytes);
+				}
+			}
 			if (target.pcmBufferedBytes >= PCM_FLUSH_THRESHOLD_BYTES) {
 				await this.flushPcmBuffer(target);
 			}
@@ -568,6 +671,171 @@ export class RecordingManager {
 
 		target.pendingWrite = target.pendingWrite.then(enqueue);
 		await target.pendingWrite;
+	}
+
+	/**
+	 * Checks whether the MediaRecorder-based recording reached the
+	 * auto-split part boundary. PCM/WAV recordings split by exact byte
+	 * count instead (see handlePcmChunk).
+	 */
+	private shouldRotateMediaParts(): boolean {
+		if (
+			!this.sessionSplitEnabled ||
+			this.isWavPcmRecording ||
+			this.rotationPromise !== null ||
+			this.status !== RecordingStatus.Recording
+		) {
+			return false;
+		}
+		const activeMs = this.partActiveMs + (Date.now() - this.activeAnchor);
+		return activeMs >= this.sessionPartMinutes * MS_PER_MINUTE;
+	}
+
+	/**
+	 * Finalizes the current auto-split part of a PCM/WAV recording.
+	 * Splits the last buffer at the exact part boundary, assembles the
+	 * part WAV file from flushed segments, and carries the overshoot
+	 * into the next part, keeping parts sample-exact. Runs inside the
+	 * target's pendingWrite chain; errors are contained so they cannot
+	 * poison subsequent writes.
+	 * @param target - Recording target to finalize
+	 * @param partLimitBytes - Exact part size in bytes
+	 */
+	private async finalizePcmPart(
+		target: RecordingTarget,
+		partLimitBytes: number,
+	): Promise<void> {
+		const overshoot = target.partPcmBytes - partLimitBytes;
+		let carry: ArrayBuffer | null = null;
+		if (overshoot > 0 && target.pcmBuffers.length > 0) {
+			const last = target.pcmBuffers[target.pcmBuffers.length - 1];
+			const keepBytes = last.byteLength - overshoot;
+			target.pcmBuffers[target.pcmBuffers.length - 1] = last.slice(
+				0,
+				keepBytes,
+			);
+			carry = last.slice(keepBytes);
+		}
+
+		target.partIndex += 1;
+		try {
+			const fileName = buildPartFileName(
+				target.fileBaseName,
+				this.sessionPartSuffix,
+				target.partIndex,
+				FORMAT_WAV,
+			);
+			const filePath = await resolveUniquePath(
+				fileName,
+				this.app,
+				this.settings,
+			);
+			await this.flushPcmBuffer(target);
+			if (target.segmentPaths.length > 0) {
+				await this.assembleWavFile(target, filePath);
+				target.partPaths.push(filePath);
+				this.debugLogger.log('Auto-split part saved', { filePath });
+				new Notice(`Recording part ${String(target.partIndex)} saved`);
+			}
+			target.segmentPaths = [];
+			target.segmentIndex = 0;
+		} catch (error) {
+			// Keep recording: data stays in segments and lands in the next part
+			target.partIndex -= 1;
+			console.error(
+				`${PLUGIN_LOG_PREFIX} Failed to finalize recording part:`,
+				error,
+			);
+			new Notice(
+				'Failed to save recording part. Recording continues; data is kept for the next part.',
+			);
+		} finally {
+			target.pcmBuffers = carry ? [carry] : [];
+			target.pcmBufferedBytes = carry ? carry.byteLength : 0;
+			target.partPcmBytes = carry ? carry.byteLength : 0;
+		}
+	}
+
+	/**
+	 * Rotates MediaRecorder-based recording at an auto-split boundary:
+	 * stops the recorders to obtain a complete container, finalizes the
+	 * buffered data as a part file per track, and restarts the recorders
+	 * on the same streams. The recording status stays Recording the whole
+	 * time. Errors are contained so the session keeps recording.
+	 */
+	private async rotateMediaRecorderParts(): Promise<void> {
+		try {
+			const recordersToStop = [...this.recorders];
+			await Promise.all(
+				recordersToStop.map(
+					(recorder) =>
+						new Promise<void>((resolve) => {
+							recorder.addEventListener('stop', () => resolve(), {
+								once: true,
+							});
+							recorder.stop();
+						}),
+				),
+			);
+			await Promise.all(this.chunkTargets.map((t) => t.pendingWrite));
+
+			for (const target of this.chunkTargets) {
+				target.partIndex += 1;
+				try {
+					const fileName = buildPartFileName(
+						target.fileBaseName,
+						this.sessionPartSuffix,
+						target.partIndex,
+						this.settings.recordingFormat,
+					);
+					const filePath = await this.finalizeMediaTrackToFile(
+						target,
+						fileName,
+					);
+					if (filePath) {
+						target.partPaths.push(filePath);
+						this.debugLogger.log('Auto-split part saved', {
+							filePath,
+						});
+						new Notice(
+							`Recording part ${String(target.partIndex)} saved`,
+						);
+					} else {
+						target.partIndex -= 1;
+					}
+				} catch (error) {
+					// Keep recording: segments stay on disk for the next part
+					target.partIndex -= 1;
+					console.error(
+						`${PLUGIN_LOG_PREFIX} Failed to finalize recording part:`,
+						error,
+					);
+					new Notice(
+						'Failed to save recording part. Recording continues; data is kept for the next part.',
+					);
+				}
+			}
+		} catch (error) {
+			console.error(
+				`${PLUGIN_LOG_PREFIX} Error during part rotation:`,
+				error,
+			);
+			new Notice('Failed to rotate recording part. Recording continues.');
+		} finally {
+			// Restart only while still recording or paused; a concurrent
+			// stopRecording awaits this rotation and tears recorders down
+			if (
+				this.status === RecordingStatus.Recording ||
+				this.status === RecordingStatus.Paused
+			) {
+				this.createAndStartMediaRecorders();
+				if (this.status === RecordingStatus.Paused) {
+					this.recorders.forEach((recorder) => recorder.pause());
+				}
+			}
+			this.partActiveMs = 0;
+			this.activeAnchor = Date.now();
+		}
 	}
 
 	private async flushPcmBuffer(target: RecordingTarget): Promise<void> {
@@ -735,6 +1003,31 @@ export class RecordingManager {
 		});
 	}
 
+	/**
+	 * Builds the final track file name, appending the part suffix when
+	 * the session was auto-split (the residual after the last rotation
+	 * becomes the next part number).
+	 * @param target - Recording target
+	 * @param timestamp - Recording timestamp string
+	 * @param extension - File extension without the dot
+	 */
+	private buildTrackFileName(
+		target: RecordingTarget,
+		timestamp: string,
+		extension: string,
+	): string {
+		const baseName = `${this.settings.filePrefix}-${target.sourceName}-${timestamp}`;
+		if (target.partIndex > 0) {
+			return buildPartFileName(
+				baseName,
+				this.sessionPartSuffix,
+				target.partIndex + 1,
+				extension,
+			);
+		}
+		return `${baseName}.${extension}`;
+	}
+
 	private async finalizeTrackFiles(
 		target: RecordingTarget,
 		timestamp: string,
@@ -753,7 +1046,11 @@ export class RecordingManager {
 				return fileLinks;
 			}
 			this.updateSaveProgress(40, 'Assembling audio...');
-			const fileName = `${this.settings.filePrefix}-${target.sourceName}-${timestamp}.wav`;
+			const fileName = this.buildTrackFileName(
+				target,
+				timestamp,
+				FORMAT_WAV,
+			);
 			const filePath = await resolveUniquePath(
 				fileName,
 				this.app,
@@ -765,24 +1062,61 @@ export class RecordingManager {
 			return fileLinks;
 		}
 
+		const fileName = this.buildTrackFileName(
+			target,
+			timestamp,
+			this.settings.recordingFormat,
+		);
+		const filePath = await this.finalizeMediaTrackToFile(
+			target,
+			fileName,
+			true,
+		);
+		if (filePath) {
+			fileLinks.push(filePath);
+		}
+		return fileLinks;
+	}
+
+	/**
+	 * Finalizes buffered MediaRecorder data of one track into a final
+	 * audio file: flushes buffers, concatenates segments, converts to
+	 * the configured output format, writes the file, and removes the
+	 * temporary segments (rolling the file back when cleanup fails).
+	 * Used both at stop and at auto-split part rotation.
+	 * @param target - Recording target to finalize
+	 * @param fileName - Final file name
+	 * @param reportProgress - Whether to emit save-progress status
+	 * updates (must stay false during rotation: the Saving status would
+	 * tear down the status bar recording controls)
+	 * @returns Final file path, or null when no audio data is buffered
+	 */
+	private async finalizeMediaTrackToFile(
+		target: RecordingTarget,
+		fileName: string,
+		reportProgress: boolean = false,
+	): Promise<string | null> {
 		await this.flushChunkBuffer(target);
 		const blob = await this.buildTrackBlob(target);
 		if (!blob || blob.size === 0) {
-			return fileLinks;
+			return null;
 		}
 
 		const outputFormat = this.settings.recordingFormat;
-		const fileName = `${this.settings.filePrefix}-${target.sourceName}-${timestamp}.${outputFormat}`;
 		const filePath = await resolveUniquePath(
 			fileName,
 			this.app,
 			this.settings,
 		);
 
-		if (this.settings.recordingFormat === FORMAT_WAV) {
-			this.updateSaveProgress(40, 'Assembling audio...');
+		if (outputFormat === FORMAT_WAV) {
+			if (reportProgress) {
+				this.updateSaveProgress(40, 'Assembling audio...');
+			}
 			const wavBlob = await convertBlobToWav(blob);
-			this.updateSaveProgress(60, 'Writing file...');
+			if (reportProgress) {
+				this.updateSaveProgress(60, 'Writing file...');
+			}
 			await this.app.vault.createBinary(
 				filePath,
 				await wavBlob.arrayBuffer(),
@@ -791,32 +1125,42 @@ export class RecordingManager {
 			isOfflineOnlyFormat(outputFormat, this.activeRecorderFormat)
 		) {
 			// Offline-only format: decode intermediate blob, re-encode to target
-			this.updateSaveProgress(40, 'Encoding audio...');
+			if (reportProgress) {
+				this.updateSaveProgress(40, 'Encoding audio...');
+			}
 			const outputBlob = await convertBlobToFormat(
 				blob,
 				outputFormat,
 				this.settings.bitrate,
 				(percent) => {
-					this.updateSaveProgress(
-						40 + Math.round(percent * 0.2),
-						'Encoding audio...',
-					);
+					if (reportProgress) {
+						this.updateSaveProgress(
+							40 + Math.round(percent * 0.2),
+							'Encoding audio...',
+						);
+					}
 				},
 			);
-			this.updateSaveProgress(60, 'Writing file...');
+			if (reportProgress) {
+				this.updateSaveProgress(60, 'Writing file...');
+			}
 			await this.app.vault.createBinary(
 				filePath,
 				await outputBlob.arrayBuffer(),
 			);
 		} else {
-			this.updateSaveProgress(60, 'Writing file...');
+			if (reportProgress) {
+				this.updateSaveProgress(60, 'Writing file...');
+			}
 			await this.app.vault.createBinary(
 				filePath,
 				await blob.arrayBuffer(),
 			);
 		}
 
-		this.updateSaveProgress(80, 'Cleaning up...');
+		if (reportProgress) {
+			this.updateSaveProgress(80, 'Cleaning up...');
+		}
 		const failedCleanupPaths = await removeTemporaryArtifacts(
 			target.segmentPaths,
 			'Failed to remove segment file after finalization',
@@ -833,7 +1177,8 @@ export class RecordingManager {
 			);
 		}
 
-		fileLinks.push(filePath);
-		return fileLinks;
+		target.segmentPaths = [];
+		target.segmentIndex = 0;
+		return filePath;
 	}
 }

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -15,6 +15,7 @@ import {
 	MIN_SPLIT_CHUNK_MINUTES,
 	MAX_SPLIT_CHUNK_MINUTES,
 	SPLIT_PART_SUFFIX_PATTERN,
+	SPLIT_PART_SUFFIX_RULE_TEXT,
 } from '../constants';
 import { getDefaultDeviceId } from '../utils/DeviceUtils';
 
@@ -277,7 +278,7 @@ export function validateSettings(settings: AudioRecorderSettings): void {
 	if (!SPLIT_PART_SUFFIX_PATTERN.test(settings.splitPartSuffix)) {
 		throw new SettingsValidationError(
 			'splitPartSuffix',
-			'Part suffix may contain only letters, digits, hyphens, and underscores.',
+			SPLIT_PART_SUFFIX_RULE_TEXT,
 		);
 	}
 

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -9,6 +9,13 @@ import {
 	DEFAULT_SAMPLE_RATE,
 	DEFAULT_BITRATE,
 } from '../recording/AudioCapabilityDetector';
+import {
+	DEFAULT_SPLIT_CHUNK_MINUTES,
+	DEFAULT_SPLIT_PART_SUFFIX,
+	MIN_SPLIT_CHUNK_MINUTES,
+	MAX_SPLIT_CHUNK_MINUTES,
+	SPLIT_PART_SUFFIX_PATTERN,
+} from '../constants';
 import { getDefaultDeviceId } from '../utils/DeviceUtils';
 
 /**
@@ -86,6 +93,14 @@ export interface AudioRecorderSettings {
 	deleteSourceAfterConversion: boolean;
 	/** What to do with converted file links in notes */
 	conversionLinkAction: ConversionLinkAction;
+	/** Automatically split recordings into parts of fixed duration */
+	autoSplitEnabled: boolean;
+	/** Duration of one split part in minutes */
+	splitChunkMinutes: number;
+	/** Filename suffix for split parts (e.g. 'part' -> '-part1', '-part2') */
+	splitPartSuffix: string;
+	/** Delete the source file after a successful manual split */
+	deleteSourceAfterSplit: boolean;
 }
 
 /**
@@ -112,6 +127,10 @@ export const DEFAULT_SETTINGS: AudioRecorderSettings = {
 	insertAtOriginalPosition: false,
 	deleteSourceAfterConversion: false,
 	conversionLinkAction: 'replace',
+	autoSplitEnabled: false,
+	splitChunkMinutes: DEFAULT_SPLIT_CHUNK_MINUTES,
+	splitPartSuffix: DEFAULT_SPLIT_PART_SUFFIX,
+	deleteSourceAfterSplit: false,
 };
 
 export interface AudioRecorderSettingsInput extends Partial<
@@ -253,6 +272,26 @@ export function validateSettings(settings: AudioRecorderSettings): void {
 			'recordingFormat',
 			'Recording format is not selected.',
 		);
+	}
+
+	if (!SPLIT_PART_SUFFIX_PATTERN.test(settings.splitPartSuffix)) {
+		throw new SettingsValidationError(
+			'splitPartSuffix',
+			'Part suffix may contain only letters, digits, hyphens, and underscores.',
+		);
+	}
+
+	if (settings.autoSplitEnabled) {
+		if (
+			!Number.isInteger(settings.splitChunkMinutes) ||
+			settings.splitChunkMinutes < MIN_SPLIT_CHUNK_MINUTES ||
+			settings.splitChunkMinutes > MAX_SPLIT_CHUNK_MINUTES
+		) {
+			throw new SettingsValidationError(
+				'splitChunkMinutes',
+				`Part duration must be an integer between ${String(MIN_SPLIT_CHUNK_MINUTES)} and ${String(MAX_SPLIT_CHUNK_MINUTES)} minutes.`,
+			);
+		}
 	}
 
 	if (settings.enableMultiTrack) {

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -282,17 +282,19 @@ export function validateSettings(settings: AudioRecorderSettings): void {
 		);
 	}
 
-	if (settings.autoSplitEnabled) {
-		if (
-			!Number.isInteger(settings.splitChunkMinutes) ||
-			settings.splitChunkMinutes < MIN_SPLIT_CHUNK_MINUTES ||
-			settings.splitChunkMinutes > MAX_SPLIT_CHUNK_MINUTES
-		) {
-			throw new SettingsValidationError(
-				'splitChunkMinutes',
-				`Part duration must be an integer between ${String(MIN_SPLIT_CHUNK_MINUTES)} and ${String(MAX_SPLIT_CHUNK_MINUTES)} minutes.`,
-			);
-		}
+	// Validated regardless of autoSplitEnabled: the value is also the
+	// default part duration for manual splitting. Runtime paths still
+	// clamp/sanitize defensively (clampSplitMinutes, sanitizePartSuffix)
+	// because validateSettings is not on the production load path.
+	if (
+		!Number.isInteger(settings.splitChunkMinutes) ||
+		settings.splitChunkMinutes < MIN_SPLIT_CHUNK_MINUTES ||
+		settings.splitChunkMinutes > MAX_SPLIT_CHUNK_MINUTES
+	) {
+		throw new SettingsValidationError(
+			'splitChunkMinutes',
+			`Part duration must be an integer between ${String(MIN_SPLIT_CHUNK_MINUTES)} and ${String(MAX_SPLIT_CHUNK_MINUTES)} minutes.`,
+		);
 	}
 
 	if (settings.enableMultiTrack) {

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -345,7 +345,7 @@ export class AudioRecorderSettingTab extends PluginSettingTab {
 		new Setting(containerEl)
 			.setName('Split recordings automatically')
 			.setDesc(
-				'Save the recording as separate part files of fixed duration instead of one long file. Not applied to merged multi-track recordings.',
+				'Save the recording as separate part files of fixed duration instead of one long file. Desktop only; not applied to merged multi-track recordings.',
 			)
 			.addToggle((toggle) =>
 				toggle
@@ -386,14 +386,23 @@ export class AudioRecorderSettingTab extends PluginSettingTab {
 					.setPlaceholder(DEFAULT_SPLIT_PART_SUFFIX)
 					.setValue(this.plugin.settings.splitPartSuffix)
 					.onChange(async (value) => {
-						// Persist only valid suffixes; the red border tells
-						// the user the last valid value is still in effect
-						const valid = SPLIT_PART_SUFFIX_PATTERN.test(value);
+						// Mirror the manual split dialog: surrounding
+						// whitespace is ignored and an empty field means
+						// the default suffix. Only valid suffixes are
+						// persisted; the red border tells the user the
+						// last valid value is still in effect
+						const trimmed = value.trim();
+						const valid =
+							trimmed === '' ||
+							SPLIT_PART_SUFFIX_PATTERN.test(trimmed);
 						text.inputEl.toggleClass('aar-input-invalid', !valid);
 						if (!valid) {
 							return;
 						}
-						this.plugin.settings.splitPartSuffix = value;
+						this.plugin.settings.splitPartSuffix =
+							trimmed === ''
+								? DEFAULT_SPLIT_PART_SUFFIX
+								: trimmed;
 						await this.plugin.saveSettings();
 					}),
 			);

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -30,6 +30,7 @@ import {
 	DEFAULT_SPLIT_PART_SUFFIX,
 	MIN_SPLIT_CHUNK_MINUTES,
 	MAX_SPLIT_CHUNK_MINUTES,
+	SPLIT_PART_SUFFIX_PATTERN,
 } from '../constants';
 import { SystemDiagnostics } from '../diagnostics/SystemDiagnostics';
 import { SystemInfoModal } from '../diagnostics/SystemInfoModal';
@@ -385,6 +386,13 @@ export class AudioRecorderSettingTab extends PluginSettingTab {
 					.setPlaceholder(DEFAULT_SPLIT_PART_SUFFIX)
 					.setValue(this.plugin.settings.splitPartSuffix)
 					.onChange(async (value) => {
+						// Persist only valid suffixes; the red border tells
+						// the user the last valid value is still in effect
+						const valid = SPLIT_PART_SUFFIX_PATTERN.test(value);
+						text.inputEl.toggleClass('aar-input-invalid', !valid);
+						if (!valid) {
+							return;
+						}
 						this.plugin.settings.splitPartSuffix = value;
 						await this.plugin.saveSettings();
 					}),

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -26,6 +26,11 @@ import {
 	getEncoderDescription,
 	isOfflineEncodingSupported,
 } from '../recording/AudioEncoder';
+import {
+	DEFAULT_SPLIT_PART_SUFFIX,
+	MIN_SPLIT_CHUNK_MINUTES,
+	MAX_SPLIT_CHUNK_MINUTES,
+} from '../constants';
 import { SystemDiagnostics } from '../diagnostics/SystemDiagnostics';
 import { SystemInfoModal } from '../diagnostics/SystemInfoModal';
 
@@ -329,6 +334,72 @@ export class AudioRecorderSettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.insertAtOriginalPosition)
 					.onChange(async (value) => {
 						this.plugin.settings.insertAtOriginalPosition = value;
+						await this.plugin.saveSettings();
+					}),
+			);
+
+		// ── Audio splitting ───────────────────────────────────────
+		new Setting(containerEl).setName('Audio splitting').setHeading();
+
+		new Setting(containerEl)
+			.setName('Split recordings automatically')
+			.setDesc(
+				'Save the recording as separate part files of fixed duration instead of one long file. Not applied to merged multi-track recordings.',
+			)
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.autoSplitEnabled)
+					.onChange(async (value) => {
+						this.plugin.settings.autoSplitEnabled = value;
+						await this.plugin.saveSettings();
+					}),
+			);
+
+		new Setting(containerEl)
+			.setName('Part duration')
+			.setDesc(
+				'Length of each part in minutes. Also used as the default for manual splitting from the context menu.',
+			)
+			.addSlider((slider) =>
+				slider
+					.setLimits(
+						MIN_SPLIT_CHUNK_MINUTES,
+						MAX_SPLIT_CHUNK_MINUTES,
+						1,
+					)
+					.setValue(this.plugin.settings.splitChunkMinutes)
+					.setDynamicTooltip()
+					.onChange(async (value) => {
+						this.plugin.settings.splitChunkMinutes = value;
+						await this.plugin.saveSettings();
+					}),
+			);
+
+		new Setting(containerEl)
+			.setName('Part name suffix')
+			.setDesc(
+				'Appended with the part number to part file names, e.g. "recording-part1.webm". Letters, digits, hyphens, and underscores only.',
+			)
+			.addText((text) =>
+				text
+					.setPlaceholder(DEFAULT_SPLIT_PART_SUFFIX)
+					.setValue(this.plugin.settings.splitPartSuffix)
+					.onChange(async (value) => {
+						this.plugin.settings.splitPartSuffix = value;
+						await this.plugin.saveSettings();
+					}),
+			);
+
+		new Setting(containerEl)
+			.setName('Delete source after split')
+			.setDesc(
+				'Default state of the delete source file option in the manual split dialog.',
+			)
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.deleteSourceAfterSplit)
+					.onChange(async (value) => {
+						this.plugin.settings.deleteSourceAfterSplit = value;
 						await this.plugin.saveSettings();
 					}),
 			);

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,4 +57,10 @@ export type RecordingTarget = {
 	pcmBufferedBytes: number;
 	pcmChannels: number;
 	pcmSampleRate: number;
+	/** Number of auto-split parts already finalized for this track. */
+	partIndex: number;
+	/** Saved auto-split part file paths in order of creation. */
+	partPaths: string[];
+	/** Bytes of PCM data accumulated toward the current auto-split part. */
+	partPcmBytes: number;
 };

--- a/src/ui/ContextMenu.ts
+++ b/src/ui/ContextMenu.ts
@@ -19,6 +19,7 @@ import { AUDIO_EXTENSIONS } from '../constants';
 import { getAudioFileInfo } from '../utils/AudioFileAnalyzer';
 import { AudioFileInfoModal } from './AudioFileInfoModal';
 import { ConversionModal } from './ConversionModal';
+import { SplitModal } from './SplitModal';
 import type { AudioRecorderSettings } from '../settings/Settings';
 
 /** CodeMirror view attached to Editor (internal Obsidian API). */
@@ -41,6 +42,8 @@ export class ContextMenu {
 	private readonly menusWithInfoItem = new WeakSet<Menu>();
 	/** Tracks menus that already have the "Convert audio format" item to prevent duplicates. */
 	private readonly menusWithConvertItem = new WeakSet<Menu>();
+	/** Tracks menus that already have the "Split audio into parts" item to prevent duplicates. */
+	private readonly menusWithSplitItem = new WeakSet<Menu>();
 
 	/**
 	 * Creates a new ContextMenu instance.
@@ -169,6 +172,7 @@ export class ContextMenu {
 					if (file instanceof TFile && this.isAudioFile(file)) {
 						this.addAudioFileInfoMenuItem(menu, file);
 						this.addConvertMenuItem(menu, file);
+						this.addSplitMenuItem(menu, file);
 						this.addDeleteRecordingMenuItem(menu, file);
 					}
 				},
@@ -225,6 +229,7 @@ export class ContextMenu {
 
 		this.addAudioFileInfoMenuItem(menu, file);
 		this.addConvertMenuItem(menu, file);
+		this.addSplitMenuItem(menu, file);
 		this.addDeleteRecordingAndLinkMenuItem(
 			menu,
 			file,
@@ -379,6 +384,27 @@ export class ContextMenu {
 						file,
 						this.getSettings(),
 					).open();
+				});
+		});
+	}
+
+	/**
+	 * Adds a "Split audio into parts" item to the menu.
+	 * @param menu - The menu to add the item to.
+	 * @param file - The audio file.
+	 */
+	private addSplitMenuItem(menu: Menu, file: TFile): void {
+		if (this.menusWithSplitItem.has(menu)) {
+			return;
+		}
+		this.menusWithSplitItem.add(menu);
+
+		menu.addItem((item: MenuItem) => {
+			item.setTitle('Split audio into parts')
+				.setIcon('scissors')
+				.setSection(AAR_MENU_SECTION)
+				.onClick(() => {
+					new SplitModal(this.app, file, this.getSettings()).open();
 				});
 		});
 	}

--- a/src/ui/ConversionModal.ts
+++ b/src/ui/ConversionModal.ts
@@ -3,15 +3,7 @@
  * @module ui/ConversionModal
  */
 
-import {
-	App,
-	MarkdownView,
-	Modal,
-	Notice,
-	Setting,
-	TFile,
-	normalizePath,
-} from 'obsidian';
+import { App, Modal, Notice, Setting, TFile, normalizePath } from 'obsidian';
 import {
 	encodeAudioBuffer,
 	isOfflineEncodingSupported,
@@ -19,6 +11,8 @@ import {
 } from '../recording/AudioEncoder';
 import { AUDIO_EXTENSIONS, FORMAT_WAV } from '../constants';
 import { getSupportedBitrates } from '../recording/AudioCapabilityDetector';
+import { decodeAudioDataAtNativeRate } from '../recording/AudioFormatConverter';
+import { updateLinksInOpenEditors } from '../utils/LinkUpdater';
 import type {
 	AudioRecorderSettings,
 	ConversionLinkAction,
@@ -158,7 +152,7 @@ export class ConversionModal extends Modal {
 			);
 
 			progressEl.setText('Decoding audio...');
-			const audioBuffer = await this.decodeAudioFile(arrayBuffer);
+			const audioBuffer = await decodeAudioDataAtNativeRate(arrayBuffer);
 
 			progressEl.setText('Encoding...');
 			const blob = await encodeAudioBuffer(
@@ -181,7 +175,12 @@ export class ConversionModal extends Modal {
 			// Update links in notes
 			if (this.linkAction !== 'none') {
 				progressEl.setText('Updating links...');
-				this.updateLinksInNotes(this.sourceFile.name, newFileName);
+				updateLinksInOpenEditors(
+					this.app,
+					this.sourceFile.name,
+					[newFileName],
+					this.linkAction,
+				);
 			}
 
 			// Delete source file
@@ -199,96 +198,6 @@ export class ConversionModal extends Modal {
 				error instanceof Error ? error.message : String(error);
 			progressEl.setText(`Error: ${message}`);
 			new Notice(`Conversion failed: ${message}`);
-		}
-	}
-
-	/**
-	 * Decodes an audio file preserving its native sample rate.
-	 * Uses OfflineAudioContext to avoid sample rate conversion
-	 * artifacts from the default AudioContext.
-	 */
-	private async decodeAudioFile(
-		arrayBuffer: ArrayBuffer,
-	): Promise<AudioBuffer> {
-		// First decode with a temporary context to discover the native sample rate
-		const probeCtx = new AudioContext();
-		const probeBuffer = await probeCtx.decodeAudioData(
-			arrayBuffer.slice(0),
-		);
-		const nativeSampleRate = probeBuffer.sampleRate;
-		await probeCtx.close();
-
-		// Re-decode with an OfflineAudioContext at the native sample rate
-		// to avoid resampling artifacts
-		const offlineCtx = new OfflineAudioContext(
-			probeBuffer.numberOfChannels,
-			probeBuffer.length,
-			nativeSampleRate,
-		);
-		const decoded = await offlineCtx.decodeAudioData(arrayBuffer);
-		return decoded;
-	}
-
-	/**
-	 * Builds a regex matching all common link formats for a filename:
-	 * ![[file]], [[file]], ![[file|alias]], [[file|alias]]
-	 */
-	private buildLinkPattern(fileName: string): RegExp {
-		const escaped = fileName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-		return new RegExp(`(!?\\[\\[${escaped}(?:\\|[^\\]]*)?\\]\\])`, 'g');
-	}
-
-	/**
-	 * Finds and updates links to the source file in all open editors.
-	 * Uses replaceRange to preserve undo history.
-	 */
-	private updateLinksInNotes(
-		sourceFileName: string,
-		newFileName: string,
-	): void {
-		const leaves = this.app.workspace.getLeavesOfType('markdown');
-		const pattern = this.buildLinkPattern(sourceFileName);
-
-		for (const leaf of leaves) {
-			if (!(leaf.view instanceof MarkdownView)) {
-				continue;
-			}
-			const editor = leaf.view.editor;
-			const content = editor.getValue();
-			if (!content.includes(sourceFileName)) {
-				continue;
-			}
-
-			// Collect matches in reverse order to avoid offset shifts
-			const matches: { index: number; length: number; text: string }[] =
-				[];
-			let match: RegExpExecArray | null;
-			while ((match = pattern.exec(content)) !== null) {
-				matches.push({
-					index: match.index,
-					length: match[0].length,
-					text: match[0],
-				});
-			}
-
-			// Apply replacements from end to start so positions stay valid
-			for (let i = matches.length - 1; i >= 0; i--) {
-				const m = matches[i];
-				const from = editor.offsetToPos(m.index);
-				const to = editor.offsetToPos(m.index + m.length);
-
-				// Build the replacement link preserving embed prefix
-				const isEmbed = m.text.startsWith('!');
-				const newLink = isEmbed
-					? `![[${newFileName}]]`
-					: `[[${newFileName}]]`;
-
-				if (this.linkAction === 'replace') {
-					editor.replaceRange(newLink, from, to);
-				} else if (this.linkAction === 'after') {
-					editor.replaceRange(`${m.text}\n${newLink}`, from, to);
-				}
-			}
 		}
 	}
 }

--- a/src/ui/SplitModal.ts
+++ b/src/ui/SplitModal.ts
@@ -16,6 +16,7 @@ import {
 	MAX_SPLIT_CHUNK_MINUTES,
 	DEFAULT_SPLIT_PART_SUFFIX,
 	PLUGIN_LOG_PREFIX,
+	SECONDS_PER_MINUTE,
 	SPLIT_PART_SUFFIX_PATTERN,
 	SPLIT_PART_SUFFIX_RULE_TEXT,
 } from '../constants';
@@ -32,13 +33,11 @@ import {
 	sanitizePartSuffix,
 } from '../recording/AudioSplitter';
 import { updateLinksInVault } from '../utils/LinkUpdater';
+import type { VaultLinkUpdateResult } from '../utils/LinkUpdater';
 import type {
 	AudioRecorderSettings,
 	ConversionLinkAction,
 } from '../settings/Settings';
-
-/** Seconds in one minute. */
-const SECONDS_PER_MINUTE = 60;
 
 /**
  * Modal for splitting an audio file into parts of a fixed duration.
@@ -49,7 +48,11 @@ export class SplitModal extends Modal {
 	private partSuffix: string;
 	private bitrate: number;
 	private deleteSource: boolean;
-	private linkAction: ConversionLinkAction = 'replace';
+	private linkAction: ConversionLinkAction;
+	/** Whether the split pipeline is currently running. */
+	private isSplitting = false;
+	/** Progress notice shown when the modal is closed mid-split. */
+	private progressNotice: Notice | null = null;
 
 	constructor(app: App, sourceFile: TFile, settings: AudioRecorderSettings) {
 		super(app);
@@ -58,6 +61,7 @@ export class SplitModal extends Modal {
 		this.partSuffix = sanitizePartSuffix(settings.splitPartSuffix);
 		this.bitrate = settings.bitrate;
 		this.deleteSource = settings.deleteSourceAfterSplit;
+		this.linkAction = settings.conversionLinkAction;
 	}
 
 	onOpen(): void {
@@ -87,27 +91,40 @@ export class SplitModal extends Modal {
 					}),
 			);
 
-		new Setting(contentEl)
-			.setName('Part name suffix')
-			.setDesc(
-				`Appended with the part number, e.g. "${this.sourceFile.basename}-${this.partSuffix}1.${this.sourceFile.extension}".`,
-			)
-			.addText((text) =>
-				text
-					.setPlaceholder(DEFAULT_SPLIT_PART_SUFFIX)
-					.setValue(this.partSuffix)
-					.onChange((value) => {
-						this.partSuffix = value;
-						// Mirror resolvePartSuffix: surrounding whitespace
-						// is ignored and empty means the default suffix
-						const trimmed = value.trim();
-						text.inputEl.toggleClass(
-							'aar-input-invalid',
-							trimmed !== '' &&
-								!SPLIT_PART_SUFFIX_PATTERN.test(trimmed),
-						);
-					}),
+		const suffixSetting = new Setting(contentEl).setName(
+			'Part name suffix',
+		);
+		const updateSuffixExample = (): void => {
+			const trimmed = this.partSuffix.trim();
+			if (trimmed !== '' && !SPLIT_PART_SUFFIX_PATTERN.test(trimmed)) {
+				// Keep the last valid example; the red border already
+				// marks the input as invalid
+				return;
+			}
+			const example =
+				trimmed === '' ? DEFAULT_SPLIT_PART_SUFFIX : trimmed;
+			suffixSetting.setDesc(
+				`Appended with the part number, e.g. "${this.sourceFile.basename}-${example}1.${this.getTargetExtension()}".`,
 			);
+		};
+		updateSuffixExample();
+		suffixSetting.addText((text) =>
+			text
+				.setPlaceholder(DEFAULT_SPLIT_PART_SUFFIX)
+				.setValue(this.partSuffix)
+				.onChange((value) => {
+					this.partSuffix = value;
+					// Mirror resolvePartSuffix: surrounding whitespace
+					// is ignored and empty means the default suffix
+					const trimmed = value.trim();
+					text.inputEl.toggleClass(
+						'aar-input-invalid',
+						trimmed !== '' &&
+							!SPLIT_PART_SUFFIX_PATTERN.test(trimmed),
+					);
+					updateSuffixExample();
+				}),
+		);
 
 		if (this.sourceFile.extension.toLowerCase() !== FORMAT_WAV) {
 			new Setting(contentEl)
@@ -121,6 +138,19 @@ export class SplitModal extends Modal {
 						const kbps = Math.round(bps / 1000);
 						dropdown.addOption(String(bps), `${String(kbps)} kbps`);
 					});
+					if (
+						bitrates.length > 0 &&
+						!bitrates.includes(this.bitrate)
+					) {
+						// Snap to the closest supported value so the dropdown
+						// always shows the bitrate actually used for encoding
+						this.bitrate = bitrates.reduce((closest, bps) =>
+							Math.abs(bps - this.bitrate) <
+							Math.abs(closest - this.bitrate)
+								? bps
+								: closest,
+						);
+					}
 					dropdown.setValue(String(this.bitrate));
 					dropdown.onChange((value) => {
 						this.bitrate = parseInt(value, 10);
@@ -140,7 +170,7 @@ export class SplitModal extends Modal {
 		new Setting(contentEl)
 			.setName('Update links in notes')
 			.setDesc(
-				'How to handle links to the source file in your notes. Links in all notes of the vault are updated.',
+				'How to handle links to the source file. Links in note bodies across the whole vault are updated; links in frontmatter properties are not.',
 			)
 			.addDropdown((dropdown) => {
 				dropdown.addOption('none', 'Do nothing');
@@ -170,7 +200,47 @@ export class SplitModal extends Modal {
 	}
 
 	onClose(): void {
+		if (this.isSplitting && !this.progressNotice) {
+			// Timeout 0 keeps the notice visible until hidden explicitly;
+			// setProgress mirrors further pipeline progress into it
+			this.progressNotice = new Notice(
+				`Splitting "${this.sourceFile.name}" continues in the background...`,
+				0,
+			);
+		}
 		this.contentEl.empty();
+	}
+
+	/**
+	 * Shows pipeline progress in the modal and mirrors it to the
+	 * background notice when the modal was closed mid-split.
+	 * @param progressEl - Progress element inside the modal
+	 * @param text - Progress text; an empty string clears the element
+	 */
+	private setProgress(progressEl: HTMLElement, text: string): void {
+		progressEl.setText(text);
+		if (this.progressNotice && text !== '') {
+			this.progressNotice.setMessage(
+				`Splitting "${this.sourceFile.name}": ${text}`,
+			);
+		}
+	}
+
+	/**
+	 * Resolves the extension the part files will get: WAV sources stay
+	 * WAV; compressed sources keep their format when an offline encoder
+	 * exists and fall back to WAV otherwise.
+	 * @returns Part file extension without the dot
+	 */
+	private getTargetExtension(): string {
+		const sourceExtension = this.sourceFile.extension.toLowerCase();
+		if (
+			sourceExtension === FORMAT_WAV ||
+			!isOfflineEncodingSupported(sourceExtension)
+		) {
+			return FORMAT_WAV;
+		}
+		return sourceExtension;
 	}
 
 	/**
@@ -195,69 +265,145 @@ export class SplitModal extends Modal {
 	/**
 	 * Executes the split pipeline: prepare parts, pre-check collisions,
 	 * write part files, update links, optionally delete the source.
+	 * Failures before any part is written abort the whole split;
+	 * failures after that are reported as partial success, because the
+	 * part files already exist on disk and a repeated run would abort
+	 * on the collision pre-check.
 	 */
 	private async runSplit(progressEl: HTMLElement): Promise<void> {
+		this.isSplitting = true;
 		try {
 			const suffix = this.resolvePartSuffix();
 			if (suffix === null) {
+				this.setProgress(progressEl, '');
 				return;
 			}
 			const partSeconds =
 				clampSplitMinutes(this.partMinutes) * SECONDS_PER_MINUTE;
 
-			progressEl.setText('Reading source file...');
-			const sourceBytes = await this.app.vault.adapter.readBinary(
-				this.sourceFile.path,
-			);
+			let partFiles: TFile[];
+			let partCount: number;
+			let firstPartName: string;
+			try {
+				this.setProgress(progressEl, 'Reading source file...');
+				const sourceBytes = await this.app.vault.adapter.readBinary(
+					this.sourceFile.path,
+				);
 
-			const parts = await this.preparePartBlobs(
-				sourceBytes,
-				partSeconds,
-				suffix,
-				progressEl,
-			);
-			if (!parts) {
+				const parts = await this.preparePartBlobs(
+					sourceBytes,
+					partSeconds,
+					suffix,
+					progressEl,
+				);
+				if (!parts) {
+					this.setProgress(progressEl, '');
+					return;
+				}
+
+				const partNames = parts.map((part) => part.fileName);
+				const partPaths = await this.resolvePartPaths(partNames);
+				if (!partPaths) {
+					this.setProgress(progressEl, '');
+					return;
+				}
+
+				partFiles = await this.writePartFiles(
+					parts,
+					partPaths,
+					progressEl,
+				);
+				partCount = parts.length;
+				firstPartName = partNames[0];
+			} catch (error) {
+				const message =
+					error instanceof Error ? error.message : String(error);
+				this.setProgress(progressEl, `Error: ${message}`);
+				new Notice(`Split failed: ${message}`);
 				return;
 			}
 
-			const partNames = parts.map((part) => part.fileName);
-			const partPaths = await this.resolvePartPaths(partNames);
-			if (!partPaths) {
+			// The parts exist on disk from here on
+			if (!(await this.finishSplit(progressEl, partFiles))) {
 				return;
 			}
 
-			const partFiles = await this.writePartFiles(
-				parts,
-				partPaths,
-				progressEl,
+			this.setProgress(progressEl, '');
+			new Notice(
+				`Split into ${String(partCount)} parts: ${firstPartName} ...`,
 			);
+			// Cleared before close() so onClose does not start a
+			// background notice for an already finished split
+			this.isSplitting = false;
+			this.close();
+		} finally {
+			this.isSplitting = false;
+			this.progressNotice?.hide();
+			this.progressNotice = null;
+		}
+	}
 
-			if (this.linkAction !== 'none') {
-				progressEl.setText('Updating links...');
-				await updateLinksInVault(
+	/**
+	 * Post-write pipeline steps: updates links and optionally deletes
+	 * the source file. The part files already exist, so errors here are
+	 * reported as partial success and never as a failed split. The
+	 * source file is kept when some links could not be updated, because
+	 * deleting it would leave those links broken.
+	 * @param progressEl - Progress element inside the modal
+	 * @param partFiles - Created part files in write order
+	 * @returns True when every requested step succeeded
+	 */
+	private async finishSplit(
+		progressEl: HTMLElement,
+		partFiles: TFile[],
+	): Promise<boolean> {
+		let linkResult: VaultLinkUpdateResult | null = null;
+		if (this.linkAction !== 'none') {
+			this.setProgress(progressEl, 'Updating links...');
+			try {
+				linkResult = await updateLinksInVault(
 					this.app,
 					this.sourceFile,
 					partFiles,
 					this.linkAction,
 				);
+			} catch (error) {
+				const message =
+					error instanceof Error ? error.message : String(error);
+				this.setProgress(progressEl, `Error: ${message}`);
+				new Notice(
+					`Parts were created, but updating links failed: ${message}. The source file was kept.`,
+				);
+				return false;
 			}
-
-			if (this.deleteSource) {
-				progressEl.setText('Removing source file...');
-				await this.app.fileManager.trashFile(this.sourceFile);
+			if (linkResult.frontmatterReferences > 0) {
+				new Notice(
+					`${String(linkResult.frontmatterReferences)} frontmatter link(s) still point to the source file: properties cannot hold several links.`,
+				);
 			}
-
-			progressEl.setText('');
-			new Notice(
-				`Split into ${String(parts.length)} parts: ${partNames[0]} ...`,
-			);
-			this.close();
-		} catch (error) {
-			const message =
-				error instanceof Error ? error.message : String(error);
-			progressEl.setText(`Error: ${message}`);
-			new Notice(`Split failed: ${message}`);
 		}
+
+		if (this.deleteSource) {
+			if (linkResult !== null && linkResult.skippedReferences > 0) {
+				new Notice(
+					`Source file kept: ${String(linkResult.skippedReferences)} link(s) could not be updated.`,
+				);
+			} else {
+				this.setProgress(progressEl, 'Removing source file...');
+				try {
+					await this.app.fileManager.trashFile(this.sourceFile);
+				} catch (error) {
+					const message =
+						error instanceof Error ? error.message : String(error);
+					this.setProgress(progressEl, `Error: ${message}`);
+					new Notice(
+						`Parts were created, but the source file could not be deleted: ${message}`,
+					);
+					return false;
+				}
+			}
+		}
+		return true;
 	}
 
 	/**
@@ -309,7 +455,7 @@ export class SplitModal extends Modal {
 			// Non-raw WAV (compressed codec inside): fall through to decode
 		}
 
-		progressEl.setText('Decoding audio...');
+		this.setProgress(progressEl, 'Decoding audio...');
 		const audioBuffer = await decodeAudioDataAtNativeRate(sourceBytes);
 		const partSamples = partSeconds * audioBuffer.sampleRate;
 		if (audioBuffer.length <= partSamples) {
@@ -317,9 +463,7 @@ export class SplitModal extends Modal {
 			return null;
 		}
 
-		const targetFormat = isOfflineEncodingSupported(sourceExtension)
-			? sourceExtension
-			: FORMAT_WAV;
+		const targetFormat = this.getTargetExtension();
 		if (targetFormat !== sourceExtension) {
 			new Notice(
 				`Encoding to "${sourceExtension}" is unavailable; parts are saved as WAV.`,
@@ -383,11 +527,11 @@ export class SplitModal extends Modal {
 		partPaths: string[],
 		progressEl: HTMLElement,
 	): Promise<TFile[]> {
-		const writtenFiles: TFile[] = [];
-		const writtenPaths: string[] = [];
+		const written: { path: string; file: TFile | null }[] = [];
 		try {
 			for (let i = 0; i < parts.length; i++) {
-				progressEl.setText(
+				this.setProgress(
+					progressEl,
 					`Writing part ${String(i + 1)} of ${String(parts.length)}...`,
 				);
 				const bytes = await parts[i].data();
@@ -395,28 +539,34 @@ export class SplitModal extends Modal {
 					partPaths[i],
 					bytes,
 				);
-				writtenPaths.push(partPaths[i]);
-				if (created instanceof TFile) {
-					writtenFiles.push(created);
-				}
+				written.push({
+					path: partPaths[i],
+					file: created instanceof TFile ? created : null,
+				});
 				// Yield to the UI between parts: MP3 encoding is synchronous
 				await new Promise<void>((resolve) =>
 					activeWindow.setTimeout(resolve, 0),
 				);
 			}
 		} catch (error) {
-			for (const path of writtenPaths) {
+			for (const part of written) {
 				try {
-					await this.app.vault.adapter.remove(path);
+					if (part.file) {
+						// trashFile respects the user's file deletion
+						// preference and keeps the rollback recoverable
+						await this.app.fileManager.trashFile(part.file);
+					} else {
+						await this.app.vault.adapter.remove(part.path);
+					}
 				} catch (cleanupError) {
 					console.error(
 						`${PLUGIN_LOG_PREFIX} Failed to remove part after split error:`,
-						{ path, cleanupError },
+						{ path: part.path, cleanupError },
 					);
 				}
 			}
 			throw error;
 		}
-		return writtenFiles;
+		return written.flatMap((part) => (part.file ? [part.file] : []));
 	}
 }

--- a/src/ui/SplitModal.ts
+++ b/src/ui/SplitModal.ts
@@ -1,0 +1,375 @@
+/**
+ * Modal dialog for splitting an audio file into time-based parts.
+ * WAV files are split losslessly at the byte level; compressed formats
+ * are decoded once and re-encoded per part.
+ * @module ui/SplitModal
+ */
+
+import { App, Modal, Notice, Setting, TFile, normalizePath } from 'obsidian';
+import {
+	encodeAudioBuffer,
+	isOfflineEncodingSupported,
+} from '../recording/AudioEncoder';
+import {
+	FORMAT_WAV,
+	MIN_SPLIT_CHUNK_MINUTES,
+	MAX_SPLIT_CHUNK_MINUTES,
+	DEFAULT_SPLIT_PART_SUFFIX,
+	PLUGIN_LOG_PREFIX,
+} from '../constants';
+import { getSupportedBitrates } from '../recording/AudioCapabilityDetector';
+import { decodeAudioDataAtNativeRate } from '../recording/AudioFormatConverter';
+import {
+	parseWavLayout,
+	splitWavBuffer,
+	sliceAudioBuffer,
+	computePartCount,
+	buildPartFileName,
+	sanitizePartSuffix,
+} from '../recording/AudioSplitter';
+import { updateLinksInVault } from '../utils/LinkUpdater';
+import type {
+	AudioRecorderSettings,
+	ConversionLinkAction,
+} from '../settings/Settings';
+
+/** Seconds in one minute. */
+const SECONDS_PER_MINUTE = 60;
+
+/**
+ * Modal for splitting an audio file into parts of a fixed duration.
+ */
+export class SplitModal extends Modal {
+	private readonly sourceFile: TFile;
+	private partMinutes: number;
+	private partSuffix: string;
+	private bitrate: number;
+	private deleteSource: boolean;
+	private linkAction: ConversionLinkAction = 'replace';
+
+	constructor(app: App, sourceFile: TFile, settings: AudioRecorderSettings) {
+		super(app);
+		this.sourceFile = sourceFile;
+		this.partMinutes = settings.splitChunkMinutes;
+		this.partSuffix = sanitizePartSuffix(settings.splitPartSuffix);
+		this.bitrate = settings.bitrate;
+		this.deleteSource = settings.deleteSourceAfterSplit;
+	}
+
+	onOpen(): void {
+		const { contentEl } = this;
+		contentEl.empty();
+
+		new Setting(contentEl).setName('Split audio into parts').setHeading();
+		contentEl.createEl('p', {
+			text: `Source: ${this.sourceFile.name}`,
+			cls: 'aar-split-source',
+		});
+
+		new Setting(contentEl)
+			.setName('Part duration')
+			.setDesc('Length of each part in minutes.')
+			.addSlider((slider) =>
+				slider
+					.setLimits(
+						MIN_SPLIT_CHUNK_MINUTES,
+						MAX_SPLIT_CHUNK_MINUTES,
+						1,
+					)
+					.setValue(this.partMinutes)
+					.setDynamicTooltip()
+					.onChange((value) => {
+						this.partMinutes = value;
+					}),
+			);
+
+		new Setting(contentEl)
+			.setName('Part name suffix')
+			.setDesc(
+				`Appended with the part number, e.g. "${this.sourceFile.basename}-${this.partSuffix}1.${this.sourceFile.extension}".`,
+			)
+			.addText((text) =>
+				text
+					.setPlaceholder(DEFAULT_SPLIT_PART_SUFFIX)
+					.setValue(this.partSuffix)
+					.onChange((value) => {
+						this.partSuffix = value;
+					}),
+			);
+
+		if (this.sourceFile.extension.toLowerCase() !== FORMAT_WAV) {
+			new Setting(contentEl)
+				.setName('Bitrate')
+				.setDesc(
+					'Bitrate used when re-encoding parts of compressed formats.',
+				)
+				.addDropdown((dropdown) => {
+					const bitrates = getSupportedBitrates();
+					bitrates.forEach((bps) => {
+						const kbps = Math.round(bps / 1000);
+						dropdown.addOption(String(bps), `${String(kbps)} kbps`);
+					});
+					dropdown.setValue(String(this.bitrate));
+					dropdown.onChange((value) => {
+						this.bitrate = parseInt(value, 10);
+					});
+				});
+		}
+
+		new Setting(contentEl)
+			.setName('Delete source file')
+			.setDesc('Remove the original file after a successful split.')
+			.addToggle((toggle) =>
+				toggle.setValue(this.deleteSource).onChange((value) => {
+					this.deleteSource = value;
+				}),
+			);
+
+		new Setting(contentEl)
+			.setName('Update links in notes')
+			.setDesc(
+				'How to handle links to the source file in your notes. Links in all notes of the vault are updated.',
+			)
+			.addDropdown((dropdown) => {
+				dropdown.addOption('none', 'Do nothing');
+				dropdown.addOption('replace', 'Replace source link');
+				dropdown.addOption('after', 'Insert after source link');
+				dropdown.setValue(this.linkAction);
+				dropdown.onChange((value) => {
+					this.linkAction = value as ConversionLinkAction;
+				});
+			});
+
+		const progressEl = contentEl.createDiv({
+			cls: 'aar-split-progress',
+		});
+
+		new Setting(contentEl).addButton((button) => {
+			button
+				.setButtonText('Split')
+				.setCta()
+				.onClick(() => {
+					button.setDisabled(true);
+					void this.runSplit(progressEl).finally(() => {
+						button.setDisabled(false);
+					});
+				});
+		});
+	}
+
+	onClose(): void {
+		this.contentEl.empty();
+	}
+
+	/**
+	 * Executes the split pipeline: prepare parts, pre-check collisions,
+	 * write part files, update links, optionally delete the source.
+	 */
+	private async runSplit(progressEl: HTMLElement): Promise<void> {
+		try {
+			const partSeconds =
+				Math.max(
+					MIN_SPLIT_CHUNK_MINUTES,
+					Math.floor(this.partMinutes),
+				) * SECONDS_PER_MINUTE;
+
+			progressEl.setText('Reading source file...');
+			const sourceBytes = await this.app.vault.adapter.readBinary(
+				this.sourceFile.path,
+			);
+
+			const parts = await this.preparePartBlobs(
+				sourceBytes,
+				partSeconds,
+				progressEl,
+			);
+			if (!parts) {
+				return;
+			}
+
+			const partNames = parts.map((part) => part.fileName);
+			const partPaths = await this.resolvePartPaths(partNames);
+			if (!partPaths) {
+				return;
+			}
+
+			await this.writePartFiles(parts, partPaths, progressEl);
+
+			if (this.linkAction !== 'none') {
+				progressEl.setText('Updating links...');
+				await updateLinksInVault(
+					this.app,
+					this.sourceFile,
+					partNames,
+					this.linkAction,
+				);
+			}
+
+			if (this.deleteSource) {
+				progressEl.setText('Removing source file...');
+				await this.app.fileManager.trashFile(this.sourceFile);
+			}
+
+			progressEl.setText('');
+			new Notice(
+				`Split into ${String(parts.length)} parts: ${partNames[0]} ...`,
+			);
+			this.close();
+		} catch (error) {
+			const message =
+				error instanceof Error ? error.message : String(error);
+			progressEl.setText(`Error: ${message}`);
+			new Notice(`Split failed: ${message}`);
+		}
+	}
+
+	/**
+	 * Builds part blobs from the source bytes. WAV sources with a raw
+	 * sample data chunk are split byte-exactly without decoding; other
+	 * formats are decoded once and re-encoded per part.
+	 * @returns Parts with target file names, or null when splitting
+	 * is not possible (a Notice explains why)
+	 */
+	private async preparePartBlobs(
+		sourceBytes: ArrayBuffer,
+		partSeconds: number,
+		progressEl: HTMLElement,
+	): Promise<
+		{ fileName: string; data: () => Promise<ArrayBuffer> }[] | null
+	> {
+		const suffix = sanitizePartSuffix(this.partSuffix);
+		const baseName = this.sourceFile.basename;
+		const sourceExtension = this.sourceFile.extension.toLowerCase();
+
+		if (sourceExtension === FORMAT_WAV) {
+			const layout = parseWavLayout(sourceBytes);
+			if (layout) {
+				const partBytes =
+					Math.floor(
+						(layout.byteRate * partSeconds) / layout.blockAlign,
+					) * layout.blockAlign;
+				if (layout.dataLength <= partBytes) {
+					new Notice('File is shorter than one part.');
+					return null;
+				}
+				progressEl.setText('Splitting audio data...');
+				const buffers = splitWavBuffer(
+					sourceBytes,
+					layout,
+					partSeconds,
+				);
+				return buffers.map((buffer, index) => ({
+					fileName: buildPartFileName(
+						baseName,
+						suffix,
+						index + 1,
+						FORMAT_WAV,
+					),
+					data: () => Promise.resolve(buffer),
+				}));
+			}
+			// Non-raw WAV (compressed codec inside): fall through to decode
+		}
+
+		progressEl.setText('Decoding audio...');
+		const audioBuffer = await decodeAudioDataAtNativeRate(sourceBytes);
+		const partSamples = partSeconds * audioBuffer.sampleRate;
+		if (audioBuffer.length <= partSamples) {
+			new Notice('File is shorter than one part.');
+			return null;
+		}
+
+		const targetFormat = isOfflineEncodingSupported(sourceExtension)
+			? sourceExtension
+			: FORMAT_WAV;
+		if (targetFormat !== sourceExtension) {
+			new Notice(
+				`Encoding to "${sourceExtension}" is unavailable; parts are saved as WAV.`,
+			);
+		}
+
+		const partCount = computePartCount(audioBuffer.length, partSamples);
+		return Array.from({ length: partCount }, (_, index) => ({
+			fileName: buildPartFileName(
+				baseName,
+				suffix,
+				index + 1,
+				targetFormat,
+			),
+			data: async () => {
+				const slice = sliceAudioBuffer(
+					audioBuffer,
+					index * partSamples,
+					(index + 1) * partSamples,
+				);
+				const blob = await encodeAudioBuffer(slice, {
+					format: targetFormat,
+					bitrate: this.bitrate,
+				});
+				return blob.arrayBuffer();
+			},
+		}));
+	}
+
+	/**
+	 * Resolves full vault paths for all parts and aborts when any
+	 * target file already exists.
+	 * @returns Normalized part paths, or null on collision
+	 */
+	private async resolvePartPaths(
+		partNames: string[],
+	): Promise<string[] | null> {
+		const directory = this.sourceFile.parent?.path ?? '';
+		const paths = partNames.map((name) =>
+			normalizePath(directory ? `${directory}/${name}` : name),
+		);
+		for (const path of paths) {
+			if (await this.app.vault.adapter.exists(path)) {
+				new Notice(
+					`File "${path}" already exists. Rename it or choose a different suffix.`,
+				);
+				return null;
+			}
+		}
+		return paths;
+	}
+
+	/**
+	 * Writes all part files, yielding to the UI between parts.
+	 * On failure removes already-written parts and rethrows, keeping
+	 * the source file intact.
+	 */
+	private async writePartFiles(
+		parts: { fileName: string; data: () => Promise<ArrayBuffer> }[],
+		partPaths: string[],
+		progressEl: HTMLElement,
+	): Promise<void> {
+		const writtenPaths: string[] = [];
+		try {
+			for (let i = 0; i < parts.length; i++) {
+				progressEl.setText(
+					`Writing part ${String(i + 1)} of ${String(parts.length)}...`,
+				);
+				const bytes = await parts[i].data();
+				await this.app.vault.createBinary(partPaths[i], bytes);
+				writtenPaths.push(partPaths[i]);
+				// Yield to the UI between parts: MP3 encoding is synchronous
+				await new Promise<void>((resolve) =>
+					activeWindow.setTimeout(resolve, 0),
+				);
+			}
+		} catch (error) {
+			for (const path of writtenPaths) {
+				try {
+					await this.app.vault.adapter.remove(path);
+				} catch (cleanupError) {
+					console.error(
+						`${PLUGIN_LOG_PREFIX} Failed to remove part after split error:`,
+						{ path, cleanupError },
+					);
+				}
+			}
+			throw error;
+		}
+	}
+}

--- a/src/ui/SplitModal.ts
+++ b/src/ui/SplitModal.ts
@@ -16,12 +16,16 @@ import {
 	MAX_SPLIT_CHUNK_MINUTES,
 	DEFAULT_SPLIT_PART_SUFFIX,
 	PLUGIN_LOG_PREFIX,
+	SPLIT_PART_SUFFIX_PATTERN,
+	SPLIT_PART_SUFFIX_RULE_TEXT,
 } from '../constants';
 import { getSupportedBitrates } from '../recording/AudioCapabilityDetector';
 import { decodeAudioDataAtNativeRate } from '../recording/AudioFormatConverter';
 import {
 	parseWavLayout,
-	splitWavBuffer,
+	buildWavPart,
+	clampSplitMinutes,
+	computeWavPartBytes,
 	sliceAudioBuffer,
 	computePartCount,
 	buildPartFileName,
@@ -50,7 +54,7 @@ export class SplitModal extends Modal {
 	constructor(app: App, sourceFile: TFile, settings: AudioRecorderSettings) {
 		super(app);
 		this.sourceFile = sourceFile;
-		this.partMinutes = settings.splitChunkMinutes;
+		this.partMinutes = clampSplitMinutes(settings.splitChunkMinutes);
 		this.partSuffix = sanitizePartSuffix(settings.splitPartSuffix);
 		this.bitrate = settings.bitrate;
 		this.deleteSource = settings.deleteSourceAfterSplit;
@@ -94,6 +98,14 @@ export class SplitModal extends Modal {
 					.setValue(this.partSuffix)
 					.onChange((value) => {
 						this.partSuffix = value;
+						// Mirror resolvePartSuffix: surrounding whitespace
+						// is ignored and empty means the default suffix
+						const trimmed = value.trim();
+						text.inputEl.toggleClass(
+							'aar-input-invalid',
+							trimmed !== '' &&
+								!SPLIT_PART_SUFFIX_PATTERN.test(trimmed),
+						);
 					}),
 			);
 
@@ -162,16 +174,36 @@ export class SplitModal extends Modal {
 	}
 
 	/**
+	 * Resolves the effective part suffix from the text field. An empty
+	 * field means the default suffix (shown as the placeholder); an
+	 * invalid value aborts the split with an explanation instead of
+	 * being silently replaced.
+	 * @returns The suffix to use, or null when the input is invalid
+	 */
+	private resolvePartSuffix(): string | null {
+		const suffix = this.partSuffix.trim();
+		if (suffix === '') {
+			return DEFAULT_SPLIT_PART_SUFFIX;
+		}
+		if (!SPLIT_PART_SUFFIX_PATTERN.test(suffix)) {
+			new Notice(SPLIT_PART_SUFFIX_RULE_TEXT);
+			return null;
+		}
+		return suffix;
+	}
+
+	/**
 	 * Executes the split pipeline: prepare parts, pre-check collisions,
 	 * write part files, update links, optionally delete the source.
 	 */
 	private async runSplit(progressEl: HTMLElement): Promise<void> {
 		try {
+			const suffix = this.resolvePartSuffix();
+			if (suffix === null) {
+				return;
+			}
 			const partSeconds =
-				Math.max(
-					MIN_SPLIT_CHUNK_MINUTES,
-					Math.floor(this.partMinutes),
-				) * SECONDS_PER_MINUTE;
+				clampSplitMinutes(this.partMinutes) * SECONDS_PER_MINUTE;
 
 			progressEl.setText('Reading source file...');
 			const sourceBytes = await this.app.vault.adapter.readBinary(
@@ -181,6 +213,7 @@ export class SplitModal extends Modal {
 			const parts = await this.preparePartBlobs(
 				sourceBytes,
 				partSeconds,
+				suffix,
 				progressEl,
 			);
 			if (!parts) {
@@ -193,14 +226,18 @@ export class SplitModal extends Modal {
 				return;
 			}
 
-			await this.writePartFiles(parts, partPaths, progressEl);
+			const partFiles = await this.writePartFiles(
+				parts,
+				partPaths,
+				progressEl,
+			);
 
 			if (this.linkAction !== 'none') {
 				progressEl.setText('Updating links...');
 				await updateLinksInVault(
 					this.app,
 					this.sourceFile,
-					partNames,
+					partFiles,
 					this.linkAction,
 				);
 			}
@@ -233,39 +270,40 @@ export class SplitModal extends Modal {
 	private async preparePartBlobs(
 		sourceBytes: ArrayBuffer,
 		partSeconds: number,
+		suffix: string,
 		progressEl: HTMLElement,
 	): Promise<
 		{ fileName: string; data: () => Promise<ArrayBuffer> }[] | null
 	> {
-		const suffix = sanitizePartSuffix(this.partSuffix);
 		const baseName = this.sourceFile.basename;
 		const sourceExtension = this.sourceFile.extension.toLowerCase();
 
 		if (sourceExtension === FORMAT_WAV) {
 			const layout = parseWavLayout(sourceBytes);
 			if (layout) {
-				const partBytes =
-					Math.floor(
-						(layout.byteRate * partSeconds) / layout.blockAlign,
-					) * layout.blockAlign;
-				if (layout.dataLength <= partBytes) {
+				const partBytes = computeWavPartBytes(layout, partSeconds);
+				if (partBytes <= 0 || layout.dataLength <= partBytes) {
 					new Notice('File is shorter than one part.');
 					return null;
 				}
-				progressEl.setText('Splitting audio data...');
-				const buffers = splitWavBuffer(
-					sourceBytes,
-					layout,
-					partSeconds,
+				const partCount = computePartCount(
+					layout.dataLength,
+					partBytes,
 				);
-				return buffers.map((buffer, index) => ({
+				return Array.from({ length: partCount }, (_, index) => ({
 					fileName: buildPartFileName(
 						baseName,
 						suffix,
 						index + 1,
 						FORMAT_WAV,
 					),
-					data: () => Promise.resolve(buffer),
+					// Built lazily inside data() so at most one part
+					// buffer is alive at a time while writing files that
+					// can be gigabytes in size
+					data: () =>
+						Promise.resolve(
+							buildWavPart(sourceBytes, layout, partBytes, index),
+						),
 				}));
 			}
 			// Non-raw WAV (compressed codec inside): fall through to decode
@@ -338,12 +376,14 @@ export class SplitModal extends Modal {
 	 * Writes all part files, yielding to the UI between parts.
 	 * On failure removes already-written parts and rethrows, keeping
 	 * the source file intact.
+	 * @returns The created part files in write order
 	 */
 	private async writePartFiles(
 		parts: { fileName: string; data: () => Promise<ArrayBuffer> }[],
 		partPaths: string[],
 		progressEl: HTMLElement,
-	): Promise<void> {
+	): Promise<TFile[]> {
+		const writtenFiles: TFile[] = [];
 		const writtenPaths: string[] = [];
 		try {
 			for (let i = 0; i < parts.length; i++) {
@@ -351,8 +391,14 @@ export class SplitModal extends Modal {
 					`Writing part ${String(i + 1)} of ${String(parts.length)}...`,
 				);
 				const bytes = await parts[i].data();
-				await this.app.vault.createBinary(partPaths[i], bytes);
+				const created = await this.app.vault.createBinary(
+					partPaths[i],
+					bytes,
+				);
 				writtenPaths.push(partPaths[i]);
+				if (created instanceof TFile) {
+					writtenFiles.push(created);
+				}
 				// Yield to the UI between parts: MP3 encoding is synchronous
 				await new Promise<void>((resolve) =>
 					activeWindow.setTimeout(resolve, 0),
@@ -371,5 +417,6 @@ export class SplitModal extends Modal {
 			}
 			throw error;
 		}
+		return writtenFiles;
 	}
 }

--- a/src/utils/LinkUpdater.ts
+++ b/src/utils/LinkUpdater.ts
@@ -2,12 +2,15 @@
  * Shared utilities for rewriting links to audio files in notes.
  * Used by the conversion flow (editor-based, preserves undo history)
  * and by the split flow (vault-wide, covers closed notes because the
- * source file may be deleted afterwards).
+ * source file may be deleted afterwards). The vault-wide variant works
+ * on parsed metadata references, so every link syntax Obsidian indexes
+ * (wikilinks, Markdown links, relative paths) is rewritten.
  * @module utils/LinkUpdater
  */
 
-import { MarkdownView, TFile } from 'obsidian';
-import type { App } from 'obsidian';
+import { MarkdownView, TFile, getLinkpath } from 'obsidian';
+import type { App, ReferenceCache } from 'obsidian';
+import { PLUGIN_LOG_PREFIX } from '../constants';
 import type { ConversionLinkAction } from '../settings/Settings';
 
 /**
@@ -111,48 +114,127 @@ export function updateLinksInOpenEditors(
 }
 
 /**
+ * Builds the replacement text for one parsed reference: one link per
+ * new file, generated with the user's link-format preferences, joined
+ * by newlines. The embed prefix of the original reference is preserved
+ * regardless of how generateMarkdownLink treats the file type.
+ * @param app - Obsidian App instance
+ * @param reference - The reference being replaced
+ * @param newFiles - Files the replacement links point to
+ * @param notePath - Path of the note containing the reference
+ * @param action - How to rewrite the link
+ * @returns Replacement text for the reference
+ */
+function buildReferenceReplacement(
+	app: App,
+	reference: ReferenceCache,
+	newFiles: TFile[],
+	notePath: string,
+	action: ConversionLinkAction,
+): string {
+	const isEmbed = reference.original.startsWith('!');
+	const links = newFiles
+		.map((file) => {
+			const link = app.fileManager.generateMarkdownLink(file, notePath);
+			const bareLink = link.startsWith('!') ? link.slice(1) : link;
+			return isEmbed ? `!${bareLink}` : bareLink;
+		})
+		.join('\n');
+	return action === 'after' ? `${reference.original}\n${links}` : links;
+}
+
+/**
+ * Collects the parsed references (links and embeds) of a note that
+ * resolve to the source file, sorted by descending position so they
+ * can be replaced from the end of the note to the start. Frontmatter
+ * links are deliberately excluded: multi-line replacement text would
+ * corrupt YAML properties.
+ * @param app - Obsidian App instance
+ * @param note - Note to scan
+ * @param sourceFile - File the references must resolve to
+ * @returns Matching references in descending position order
+ */
+function collectSourceReferences(
+	app: App,
+	note: TFile,
+	sourceFile: TFile,
+): ReferenceCache[] {
+	const cache = app.metadataCache.getFileCache(note);
+	const references = [...(cache?.links ?? []), ...(cache?.embeds ?? [])];
+	return references
+		.filter((reference) => {
+			const target = app.metadataCache.getFirstLinkpathDest(
+				getLinkpath(reference.link),
+				note.path,
+			);
+			return target?.path === sourceFile.path;
+		})
+		.sort((a, b) => b.position.start.offset - a.position.start.offset);
+}
+
+/**
  * Updates links to the source file in every note of the vault that
  * references it, including notes that are not currently open. Uses
- * metadataCache.resolvedLinks to find referencing notes and
- * vault.process for atomic modification.
+ * metadataCache.resolvedLinks to find referencing notes, the parsed
+ * link/embed references for exact positions (covering wikilinks,
+ * Markdown links, and relative paths alike), and vault.process for
+ * atomic modification.
  * @param app - Obsidian App instance
  * @param sourceFile - File whose links are being rewritten
- * @param newFileNames - File names of the replacement links
+ * @param newFiles - Files the replacement links point to
  * @param action - How to rewrite the links ('none' is a no-op)
  * @returns Number of notes that were updated
  */
 export async function updateLinksInVault(
 	app: App,
 	sourceFile: TFile,
-	newFileNames: string[],
+	newFiles: TFile[],
 	action: ConversionLinkAction,
 ): Promise<number> {
-	if (action === 'none' || newFileNames.length === 0) {
+	if (action === 'none' || newFiles.length === 0) {
 		return 0;
 	}
 
-	// Notes may link by file name or by full vault path; cover both forms
-	const patterns = [buildLinkPattern(sourceFile.name)];
-	if (sourceFile.path !== sourceFile.name) {
-		patterns.push(buildLinkPattern(sourceFile.path));
-	}
-	const referencingPaths = Object.entries(
-		app.metadataCache.resolvedLinks,
-	).filter(([, links]) => sourceFile.path in links);
+	const referencingPaths = Object.entries(app.metadataCache.resolvedLinks)
+		.filter(([, links]) => sourceFile.path in links)
+		.map(([notePath]) => notePath);
 
 	let updatedCount = 0;
-	for (const [notePath] of referencingPaths) {
+	for (const notePath of referencingPaths) {
 		const note = app.vault.getAbstractFileByPath(notePath);
 		if (!(note instanceof TFile)) {
+			continue;
+		}
+		const references = collectSourceReferences(app, note, sourceFile);
+		if (references.length === 0) {
 			continue;
 		}
 		let changed = false;
 		await app.vault.process(note, (content) => {
 			let rewritten = content;
-			for (const pattern of patterns) {
-				rewritten = rewritten.replace(pattern, (matchedLink) =>
-					rewriteMatchedLink(matchedLink, newFileNames, action),
-				);
+			// Replace from the end to the start so earlier offsets stay valid
+			for (const reference of references) {
+				const { start, end } = reference.position;
+				const original = rewritten.slice(start.offset, end.offset);
+				if (original !== reference.original) {
+					// The metadata cache lags behind the file content;
+					// skip the reference instead of corrupting the note
+					console.warn(
+						`${PLUGIN_LOG_PREFIX} Skipped a stale link reference in:`,
+						notePath,
+					);
+					continue;
+				}
+				rewritten =
+					rewritten.slice(0, start.offset) +
+					buildReferenceReplacement(
+						app,
+						reference,
+						newFiles,
+						notePath,
+						action,
+					) +
+					rewritten.slice(end.offset);
 			}
 			changed = rewritten !== content;
 			return rewritten;

--- a/src/utils/LinkUpdater.ts
+++ b/src/utils/LinkUpdater.ts
@@ -1,0 +1,165 @@
+/**
+ * Shared utilities for rewriting links to audio files in notes.
+ * Used by the conversion flow (editor-based, preserves undo history)
+ * and by the split flow (vault-wide, covers closed notes because the
+ * source file may be deleted afterwards).
+ * @module utils/LinkUpdater
+ */
+
+import { MarkdownView, TFile } from 'obsidian';
+import type { App } from 'obsidian';
+import type { ConversionLinkAction } from '../settings/Settings';
+
+/**
+ * Builds a regex matching all common internal link formats for a filename:
+ * ![[file]], [[file]], ![[file|alias]], [[file|alias]]
+ * @param fileName - File name (with extension) to match
+ * @returns Global regex matching links to the file
+ */
+export function buildLinkPattern(fileName: string): RegExp {
+	const escaped = fileName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	return new RegExp(`(!?\\[\\[${escaped}(?:\\|[^\\]]*)?\\]\\])`, 'g');
+}
+
+/**
+ * Builds the replacement text for a matched link: one link per new file,
+ * joined by newlines, preserving the embed prefix of the original link.
+ * @param newFileNames - File names of the replacement links
+ * @param isEmbed - Whether the original link was an embed (starts with '!')
+ * @returns Newline-joined replacement links
+ */
+export function buildReplacementLinks(
+	newFileNames: string[],
+	isEmbed: boolean,
+): string {
+	return newFileNames
+		.map((name) => (isEmbed ? `![[${name}]]` : `[[${name}]]`))
+		.join('\n');
+}
+
+/**
+ * Applies the link action to a single matched link text.
+ * @param matchedLink - The full matched link (e.g. "![[file.webm]]")
+ * @param newFileNames - File names of the replacement links
+ * @param action - How to rewrite the link
+ * @returns Replacement text for the match
+ */
+function rewriteMatchedLink(
+	matchedLink: string,
+	newFileNames: string[],
+	action: ConversionLinkAction,
+): string {
+	const isEmbed = matchedLink.startsWith('!');
+	const links = buildReplacementLinks(newFileNames, isEmbed);
+	return action === 'after' ? `${matchedLink}\n${links}` : links;
+}
+
+/**
+ * Finds and updates links to the source file in all open Markdown editors.
+ * Uses replaceRange to preserve undo history.
+ * @param app - Obsidian App instance
+ * @param sourceFileName - File name (with extension) being replaced
+ * @param newFileNames - File names of the replacement links
+ * @param action - How to rewrite the links ('none' is a no-op)
+ */
+export function updateLinksInOpenEditors(
+	app: App,
+	sourceFileName: string,
+	newFileNames: string[],
+	action: ConversionLinkAction,
+): void {
+	if (action === 'none' || newFileNames.length === 0) {
+		return;
+	}
+
+	const leaves = app.workspace.getLeavesOfType('markdown');
+	const pattern = buildLinkPattern(sourceFileName);
+
+	for (const leaf of leaves) {
+		if (!(leaf.view instanceof MarkdownView)) {
+			continue;
+		}
+		const editor = leaf.view.editor;
+		const content = editor.getValue();
+		if (!content.includes(sourceFileName)) {
+			continue;
+		}
+
+		// Collect matches first, then apply replacements from end to start
+		// so earlier offsets stay valid
+		const matches: { index: number; length: number; text: string }[] = [];
+		let match: RegExpExecArray | null;
+		while ((match = pattern.exec(content)) !== null) {
+			matches.push({
+				index: match.index,
+				length: match[0].length,
+				text: match[0],
+			});
+		}
+
+		for (let i = matches.length - 1; i >= 0; i--) {
+			const m = matches[i];
+			const from = editor.offsetToPos(m.index);
+			const to = editor.offsetToPos(m.index + m.length);
+			editor.replaceRange(
+				rewriteMatchedLink(m.text, newFileNames, action),
+				from,
+				to,
+			);
+		}
+	}
+}
+
+/**
+ * Updates links to the source file in every note of the vault that
+ * references it, including notes that are not currently open. Uses
+ * metadataCache.resolvedLinks to find referencing notes and
+ * vault.process for atomic modification.
+ * @param app - Obsidian App instance
+ * @param sourceFile - File whose links are being rewritten
+ * @param newFileNames - File names of the replacement links
+ * @param action - How to rewrite the links ('none' is a no-op)
+ * @returns Number of notes that were updated
+ */
+export async function updateLinksInVault(
+	app: App,
+	sourceFile: TFile,
+	newFileNames: string[],
+	action: ConversionLinkAction,
+): Promise<number> {
+	if (action === 'none' || newFileNames.length === 0) {
+		return 0;
+	}
+
+	// Notes may link by file name or by full vault path; cover both forms
+	const patterns = [buildLinkPattern(sourceFile.name)];
+	if (sourceFile.path !== sourceFile.name) {
+		patterns.push(buildLinkPattern(sourceFile.path));
+	}
+	const referencingPaths = Object.entries(
+		app.metadataCache.resolvedLinks,
+	).filter(([, links]) => sourceFile.path in links);
+
+	let updatedCount = 0;
+	for (const [notePath] of referencingPaths) {
+		const note = app.vault.getAbstractFileByPath(notePath);
+		if (!(note instanceof TFile)) {
+			continue;
+		}
+		let changed = false;
+		await app.vault.process(note, (content) => {
+			let rewritten = content;
+			for (const pattern of patterns) {
+				rewritten = rewritten.replace(pattern, (matchedLink) =>
+					rewriteMatchedLink(matchedLink, newFileNames, action),
+				);
+			}
+			changed = rewritten !== content;
+			return rewritten;
+		});
+		if (changed) {
+			updatedCount++;
+		}
+	}
+	return updatedCount;
+}

--- a/src/utils/LinkUpdater.ts
+++ b/src/utils/LinkUpdater.ts
@@ -4,7 +4,8 @@
  * and by the split flow (vault-wide, covers closed notes because the
  * source file may be deleted afterwards). The vault-wide variant works
  * on parsed metadata references, so every link syntax Obsidian indexes
- * (wikilinks, Markdown links, relative paths) is rewritten.
+ * (wikilinks, Markdown links, relative paths) is rewritten; frontmatter
+ * links cannot hold several replacement links and are only counted.
  * @module utils/LinkUpdater
  */
 
@@ -26,18 +27,46 @@ export function buildLinkPattern(fileName: string): RegExp {
 
 /**
  * Builds the replacement text for a matched link: one link per new file,
- * joined by newlines, preserving the embed prefix of the original link.
+ * joined by the given separator, preserving the embed prefix of the
+ * original link.
  * @param newFileNames - File names of the replacement links
  * @param isEmbed - Whether the original link was an embed (starts with '!')
- * @returns Newline-joined replacement links
+ * @param separator - Text inserted between the replacement links
+ * @returns Joined replacement links
  */
 export function buildReplacementLinks(
 	newFileNames: string[],
 	isEmbed: boolean,
+	separator: string = '\n',
 ): string {
 	return newFileNames
 		.map((name) => (isEmbed ? `![[${name}]]` : `[[${name}]]`))
-		.join('\n');
+		.join(separator);
+}
+
+/**
+ * Checks whether a reference occupies its line alone (ignoring
+ * surrounding whitespace). Only then is it safe to expand one link into
+ * several newline-separated links; inside single-line constructs such
+ * as table rows, headings, or callout titles a newline would sever the
+ * construct, so the replacement must stay on one line.
+ * @param content - Full note content the offsets refer to
+ * @param startOffset - Start offset of the reference
+ * @param endOffset - End offset of the reference
+ * @returns True when nothing but whitespace shares the line
+ */
+function isReferenceAloneOnLine(
+	content: string,
+	startOffset: number,
+	endOffset: number,
+): boolean {
+	const lineStart = content.lastIndexOf('\n', startOffset - 1) + 1;
+	const newlineAfter = content.indexOf('\n', endOffset);
+	const lineEnd = newlineAfter === -1 ? content.length : newlineAfter;
+	return (
+		content.slice(lineStart, startOffset).trim() === '' &&
+		content.slice(endOffset, lineEnd).trim() === ''
+	);
 }
 
 /**
@@ -45,16 +74,18 @@ export function buildReplacementLinks(
  * @param matchedLink - The full matched link (e.g. "![[file.webm]]")
  * @param newFileNames - File names of the replacement links
  * @param action - How to rewrite the link
+ * @param separator - Text inserted between the resulting links
  * @returns Replacement text for the match
  */
 function rewriteMatchedLink(
 	matchedLink: string,
 	newFileNames: string[],
 	action: ConversionLinkAction,
+	separator: string,
 ): string {
 	const isEmbed = matchedLink.startsWith('!');
-	const links = buildReplacementLinks(newFileNames, isEmbed);
-	return action === 'after' ? `${matchedLink}\n${links}` : links;
+	const links = buildReplacementLinks(newFileNames, isEmbed, separator);
+	return action === 'after' ? `${matchedLink}${separator}${links}` : links;
 }
 
 /**
@@ -104,8 +135,15 @@ export function updateLinksInOpenEditors(
 			const m = matches[i];
 			const from = editor.offsetToPos(m.index);
 			const to = editor.offsetToPos(m.index + m.length);
+			const separator = isReferenceAloneOnLine(
+				content,
+				m.index,
+				m.index + m.length,
+			)
+				? '\n'
+				: ' ';
 			editor.replaceRange(
-				rewriteMatchedLink(m.text, newFileNames, action),
+				rewriteMatchedLink(m.text, newFileNames, action, separator),
 				from,
 				to,
 			);
@@ -116,13 +154,14 @@ export function updateLinksInOpenEditors(
 /**
  * Builds the replacement text for one parsed reference: one link per
  * new file, generated with the user's link-format preferences, joined
- * by newlines. The embed prefix of the original reference is preserved
- * regardless of how generateMarkdownLink treats the file type.
+ * by the given separator. The embed prefix of the original reference is
+ * preserved regardless of how generateMarkdownLink treats the file type.
  * @param app - Obsidian App instance
  * @param reference - The reference being replaced
  * @param newFiles - Files the replacement links point to
  * @param notePath - Path of the note containing the reference
  * @param action - How to rewrite the link
+ * @param separator - Text inserted between the resulting links
  * @returns Replacement text for the reference
  */
 function buildReferenceReplacement(
@@ -131,6 +170,7 @@ function buildReferenceReplacement(
 	newFiles: TFile[],
 	notePath: string,
 	action: ConversionLinkAction,
+	separator: string,
 ): string {
 	const isEmbed = reference.original.startsWith('!');
 	const links = newFiles
@@ -139,16 +179,40 @@ function buildReferenceReplacement(
 			const bareLink = link.startsWith('!') ? link.slice(1) : link;
 			return isEmbed ? `!${bareLink}` : bareLink;
 		})
-		.join('\n');
-	return action === 'after' ? `${reference.original}\n${links}` : links;
+		.join(separator);
+	return action === 'after'
+		? `${reference.original}${separator}${links}`
+		: links;
+}
+
+/**
+ * Checks whether a parsed reference resolves to the given file.
+ * @param app - Obsidian App instance
+ * @param link - Link text of the reference (may carry a subpath)
+ * @param notePath - Path of the note containing the reference
+ * @param sourceFile - File the reference must resolve to
+ * @returns True when the reference points at the source file
+ */
+function resolvesToFile(
+	app: App,
+	link: string,
+	notePath: string,
+	sourceFile: TFile,
+): boolean {
+	const target = app.metadataCache.getFirstLinkpathDest(
+		getLinkpath(link),
+		notePath,
+	);
+	return target?.path === sourceFile.path;
 }
 
 /**
  * Collects the parsed references (links and embeds) of a note that
  * resolve to the source file, sorted by descending position so they
  * can be replaced from the end of the note to the start. Frontmatter
- * links are deliberately excluded: multi-line replacement text would
- * corrupt YAML properties.
+ * links are deliberately excluded: a YAML property cannot hold several
+ * links, so they are only counted (see countFrontmatterReferences) and
+ * reported to the caller.
  * @param app - Obsidian App instance
  * @param note - Note to scan
  * @param sourceFile - File the references must resolve to
@@ -162,14 +226,44 @@ function collectSourceReferences(
 	const cache = app.metadataCache.getFileCache(note);
 	const references = [...(cache?.links ?? []), ...(cache?.embeds ?? [])];
 	return references
-		.filter((reference) => {
-			const target = app.metadataCache.getFirstLinkpathDest(
-				getLinkpath(reference.link),
-				note.path,
-			);
-			return target?.path === sourceFile.path;
-		})
+		.filter((reference) =>
+			resolvesToFile(app, reference.link, note.path, sourceFile),
+		)
 		.sort((a, b) => b.position.start.offset - a.position.start.offset);
+}
+
+/**
+ * Counts the frontmatter links of a note that resolve to the source
+ * file. These cannot be rewritten to several part links, so callers
+ * surface the count to the user instead.
+ * @param app - Obsidian App instance
+ * @param note - Note to scan
+ * @param sourceFile - File the references must resolve to
+ * @returns Number of frontmatter references to the source file
+ */
+function countFrontmatterReferences(
+	app: App,
+	note: TFile,
+	sourceFile: TFile,
+): number {
+	const cache = app.metadataCache.getFileCache(note);
+	return (cache?.frontmatterLinks ?? []).filter((reference) =>
+		resolvesToFile(app, reference.link, note.path, sourceFile),
+	).length;
+}
+
+/**
+ * Outcome of a vault-wide link update, surfaced to the user by callers:
+ * skipped references mean some links still point at the source file,
+ * and frontmatter references cannot be rewritten at all.
+ */
+export interface VaultLinkUpdateResult {
+	/** Number of notes whose body content was updated. */
+	updatedNotes: number;
+	/** References skipped because the metadata cache was stale. */
+	skippedReferences: number;
+	/** Frontmatter references to the source that cannot be rewritten. */
+	frontmatterReferences: number;
 }
 
 /**
@@ -178,33 +272,46 @@ function collectSourceReferences(
  * metadataCache.resolvedLinks to find referencing notes, the parsed
  * link/embed references for exact positions (covering wikilinks,
  * Markdown links, and relative paths alike), and vault.process for
- * atomic modification.
+ * atomic modification. References that share a line with other content
+ * are replaced with space-separated links so single-line constructs
+ * (table rows, headings) stay intact; references alone on their line
+ * get one link per line.
  * @param app - Obsidian App instance
  * @param sourceFile - File whose links are being rewritten
  * @param newFiles - Files the replacement links point to
  * @param action - How to rewrite the links ('none' is a no-op)
- * @returns Number of notes that were updated
+ * @returns Counts of updated notes, skipped references, and
+ * frontmatter references left untouched
  */
 export async function updateLinksInVault(
 	app: App,
 	sourceFile: TFile,
 	newFiles: TFile[],
 	action: ConversionLinkAction,
-): Promise<number> {
+): Promise<VaultLinkUpdateResult> {
+	const result: VaultLinkUpdateResult = {
+		updatedNotes: 0,
+		skippedReferences: 0,
+		frontmatterReferences: 0,
+	};
 	if (action === 'none' || newFiles.length === 0) {
-		return 0;
+		return result;
 	}
 
 	const referencingPaths = Object.entries(app.metadataCache.resolvedLinks)
 		.filter(([, links]) => sourceFile.path in links)
 		.map(([notePath]) => notePath);
 
-	let updatedCount = 0;
 	for (const notePath of referencingPaths) {
 		const note = app.vault.getAbstractFileByPath(notePath);
 		if (!(note instanceof TFile)) {
 			continue;
 		}
+		result.frontmatterReferences += countFrontmatterReferences(
+			app,
+			note,
+			sourceFile,
+		);
 		const references = collectSourceReferences(app, note, sourceFile);
 		if (references.length === 0) {
 			continue;
@@ -219,12 +326,20 @@ export async function updateLinksInVault(
 				if (original !== reference.original) {
 					// The metadata cache lags behind the file content;
 					// skip the reference instead of corrupting the note
+					result.skippedReferences++;
 					console.warn(
 						`${PLUGIN_LOG_PREFIX} Skipped a stale link reference in:`,
 						notePath,
 					);
 					continue;
 				}
+				const separator = isReferenceAloneOnLine(
+					rewritten,
+					start.offset,
+					end.offset,
+				)
+					? '\n'
+					: ' ';
 				rewritten =
 					rewritten.slice(0, start.offset) +
 					buildReferenceReplacement(
@@ -233,6 +348,7 @@ export async function updateLinksInVault(
 						newFiles,
 						notePath,
 						action,
+						separator,
 					) +
 					rewritten.slice(end.offset);
 			}
@@ -240,8 +356,8 @@ export async function updateLinksInVault(
 			return rewritten;
 		});
 		if (changed) {
-			updatedCount++;
+			result.updatedNotes++;
 		}
 	}
-	return updatedCount;
+	return result;
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -160,3 +160,8 @@ If your plugin does not need CSS, delete this file.
     color: var(--color-green);
     font-weight: bold;
 }
+
+/* Split modal and settings */
+input.aar-input-invalid {
+    border-color: var(--text-error);
+}

--- a/tests/mocks/obsidian.ts
+++ b/tests/mocks/obsidian.ts
@@ -416,6 +416,15 @@ export function setIcon(_el: HTMLElement, _iconId: string): void {
 	// Mock implementation
 }
 
+/**
+ * Mock getLinkpath function: strips the subpath (heading/block
+ * reference) from a link text, mirroring the Obsidian behavior.
+ */
+export function getLinkpath(linktext: string): string {
+	const hashIndex = linktext.indexOf('#');
+	return hashIndex >= 0 ? linktext.slice(0, hashIndex) : linktext;
+}
+
 export const Platform = {
 	isMobile: false,
 	isMobileApp: false,

--- a/tests/unit/AudioFormatConverter.test.ts
+++ b/tests/unit/AudioFormatConverter.test.ts
@@ -98,6 +98,7 @@ import {
 	getRecorderMediaType,
 	convertBlobToWav,
 	convertBlobToFormat,
+	decodeAudioDataAtNativeRate,
 	buildOutputBlob,
 	mergeAudioTracks,
 } from '../../src/recording/AudioFormatConverter';
@@ -327,6 +328,42 @@ describe('AudioFormatConverter', () => {
 			const ctxInstance = (AudioContext as unknown as jest.Mock).mock
 				.results[0].value;
 			expect(ctxInstance.close).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	// ---------------------------------------------------------------
+	// decodeAudioDataAtNativeRate
+	// ---------------------------------------------------------------
+	describe('decodeAudioDataAtNativeRate', () => {
+		it('should probe, close the probe context, and re-decode offline', async () => {
+			const buffer = new ArrayBuffer(8);
+			await decodeAudioDataAtNativeRate(buffer);
+
+			expect(AudioContext).toHaveBeenCalledTimes(1);
+			const probeCtx = (AudioContext as unknown as jest.Mock).mock
+				.results[0].value;
+			expect(probeCtx.decodeAudioData).toHaveBeenCalledTimes(1);
+			expect(probeCtx.close).toHaveBeenCalledTimes(1);
+			expect(OfflineAudioContext).toHaveBeenCalledWith(1, 44100, 44100);
+		});
+
+		it('should close the probe context when decoding fails', async () => {
+			const decodeError = new Error('decode failed');
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- required for mock override
+			(AudioContext as any).mockImplementationOnce(() => ({
+				decodeAudioData: jest.fn().mockRejectedValue(decodeError),
+				close: jest.fn().mockResolvedValue(undefined),
+			}));
+
+			await expect(
+				decodeAudioDataAtNativeRate(new ArrayBuffer(8)),
+			).rejects.toThrow('decode failed');
+
+			// The probe AudioContext must not leak on corrupted input
+			const probeCtx = (AudioContext as unknown as jest.Mock).mock
+				.results[0].value;
+			expect(probeCtx.close).toHaveBeenCalledTimes(1);
+			expect(OfflineAudioContext).not.toHaveBeenCalled();
 		});
 	});
 

--- a/tests/unit/AudioSplitter.test.ts
+++ b/tests/unit/AudioSplitter.test.ts
@@ -1,0 +1,359 @@
+/**
+ * Unit tests for AudioSplitter module.
+ * @module tests/unit/AudioSplitter.test
+ */
+
+import {
+	parseWavLayout,
+	splitWavBuffer,
+	sliceAudioBuffer,
+	computePartCount,
+	computePcmPartLimitBytes,
+	buildPartFileName,
+	sanitizePartSuffix,
+	PCM_BYTES_PER_SAMPLE,
+} from '../../src/recording/AudioSplitter';
+import { createWavHeader } from '../../src/recording/WavEncoder';
+
+/** WAV header size produced by createWavHeader. */
+const WAV_HEADER_SIZE = 44;
+
+/**
+ * Builds a complete WAV file with a recognizable byte pattern.
+ */
+function buildTestWav(
+	numChannels: number,
+	sampleRate: number,
+	dataBytes: number,
+): ArrayBuffer {
+	const header = createWavHeader(numChannels, sampleRate, dataBytes);
+	const wav = new Uint8Array(WAV_HEADER_SIZE + dataBytes);
+	wav.set(new Uint8Array(header), 0);
+	for (let i = 0; i < dataBytes; i++) {
+		wav[WAV_HEADER_SIZE + i] = i % 251;
+	}
+	return wav.buffer;
+}
+
+/**
+ * Functional AudioBuffer stand-in for jsdom, where the real
+ * constructor is unavailable.
+ */
+class FakeAudioBuffer {
+	numberOfChannels: number;
+	length: number;
+	sampleRate: number;
+	private channels: Float32Array[];
+
+	constructor(options: {
+		numberOfChannels: number;
+		length: number;
+		sampleRate: number;
+	}) {
+		this.numberOfChannels = options.numberOfChannels;
+		this.length = options.length;
+		this.sampleRate = options.sampleRate;
+		this.channels = Array.from(
+			{ length: options.numberOfChannels },
+			() => new Float32Array(options.length),
+		);
+	}
+
+	get duration(): number {
+		return this.length / this.sampleRate;
+	}
+
+	getChannelData(channel: number): Float32Array {
+		return this.channels[channel];
+	}
+
+	copyToChannel(source: Float32Array, channel: number): void {
+		this.channels[channel].set(source.subarray(0, this.length));
+	}
+}
+
+beforeAll(() => {
+	(global as Record<string, unknown>).AudioBuffer = FakeAudioBuffer;
+});
+
+describe('parseWavLayout', () => {
+	it('should parse a standard 44-byte-header WAV file', () => {
+		const wav = buildTestWav(2, 44100, 1000);
+
+		const layout = parseWavLayout(wav);
+
+		expect(layout).not.toBeNull();
+		expect(layout?.dataOffset).toBe(WAV_HEADER_SIZE);
+		expect(layout?.dataLength).toBe(1000);
+		expect(layout?.byteRate).toBe(44100 * 2 * 2);
+		expect(layout?.blockAlign).toBe(4);
+	});
+
+	it('should parse a WAV with an extra chunk before the data chunk', () => {
+		const base = new Uint8Array(buildTestWav(1, 8000, 100));
+		// Insert a 10-byte LIST chunk between fmt and data
+		const extraChunk = new Uint8Array(18);
+		const extraView = new DataView(extraChunk.buffer);
+		extraChunk.set([0x4c, 0x49, 0x53, 0x54], 0); // 'LIST'
+		extraView.setUint32(4, 10, true);
+		const wav = new Uint8Array(base.length + extraChunk.length);
+		wav.set(base.subarray(0, 36), 0);
+		wav.set(extraChunk, 36);
+		wav.set(base.subarray(36), 36 + extraChunk.length);
+		// Patch RIFF size for the inserted bytes
+		new DataView(wav.buffer).setUint32(4, wav.length - 8, true);
+
+		const layout = parseWavLayout(wav.buffer);
+
+		expect(layout).not.toBeNull();
+		expect(layout?.dataOffset).toBe(WAV_HEADER_SIZE + extraChunk.length);
+		expect(layout?.dataLength).toBe(100);
+	});
+
+	it('should return null for non-RIFF data', () => {
+		const bytes = new Uint8Array(100).fill(0x42);
+
+		expect(parseWavLayout(bytes.buffer)).toBeNull();
+	});
+
+	it('should return null for a buffer shorter than the RIFF header', () => {
+		expect(parseWavLayout(new ArrayBuffer(8))).toBeNull();
+	});
+
+	it('should return null for compressed WAV format codes', () => {
+		const wav = buildTestWav(1, 8000, 100);
+		// Overwrite the fmt audioFormat field with 0x0055 (MP3)
+		new DataView(wav).setUint16(20, 0x0055, true);
+
+		expect(parseWavLayout(wav)).toBeNull();
+	});
+
+	it('should accept IEEE float format code', () => {
+		const wav = buildTestWav(1, 8000, 100);
+		new DataView(wav).setUint16(20, 0x0003, true);
+
+		expect(parseWavLayout(wav)).not.toBeNull();
+	});
+
+	it('should clamp dataLength to the actual buffer size', () => {
+		const wav = buildTestWav(1, 8000, 100);
+		// Claim more data than the file contains
+		new DataView(wav).setUint32(40, 5000, true);
+
+		const layout = parseWavLayout(wav);
+
+		expect(layout?.dataLength).toBe(100);
+	});
+
+	it('should return null for a truncated fmt chunk', () => {
+		// "RIFF<size>WAVE" + "fmt <size=16>" but only 4 bytes of fmt data
+		const bytes = new Uint8Array(24);
+		const view = new DataView(bytes.buffer);
+		bytes.set([0x52, 0x49, 0x46, 0x46], 0); // 'RIFF'
+		view.setUint32(4, 16, true);
+		bytes.set([0x57, 0x41, 0x56, 0x45], 8); // 'WAVE'
+		bytes.set([0x66, 0x6d, 0x74, 0x20], 12); // 'fmt '
+		view.setUint32(16, 16, true);
+
+		expect(parseWavLayout(bytes.buffer)).toBeNull();
+	});
+
+	it('should return null when no data chunk exists', () => {
+		// A valid header with the data chunk id overwritten
+		const wav = buildTestWav(1, 8000, 0);
+		new Uint8Array(wav).set([0x4c, 0x49, 0x53, 0x54], 36); // 'LIST'
+
+		expect(parseWavLayout(wav)).toBeNull();
+	});
+});
+
+describe('splitWavBuffer', () => {
+	it('should split into equal parts when data is an exact multiple', () => {
+		// 1000 Hz mono 16-bit: byteRate = 2000 B/s; 2 s parts = 4000 B
+		const wav = buildTestWav(1, 1000, 12000);
+		const layout = parseWavLayout(wav);
+
+		const parts = splitWavBuffer(wav, layout!, 2);
+
+		expect(parts).toHaveLength(3);
+		for (const part of parts) {
+			const partLayout = parseWavLayout(part);
+			expect(partLayout?.dataLength).toBe(4000);
+		}
+	});
+
+	it('should put the remainder into a shorter last part', () => {
+		const wav = buildTestWav(1, 1000, 10000);
+		const layout = parseWavLayout(wav);
+
+		const parts = splitWavBuffer(wav, layout!, 2);
+
+		expect(parts).toHaveLength(3);
+		expect(parseWavLayout(parts[0])?.dataLength).toBe(4000);
+		expect(parseWavLayout(parts[1])?.dataLength).toBe(4000);
+		expect(parseWavLayout(parts[2])?.dataLength).toBe(2000);
+	});
+
+	it('should cut on blockAlign boundaries for stereo data', () => {
+		// 1000 Hz stereo 16-bit: blockAlign = 4, byteRate = 4000 B/s
+		const wav = buildTestWav(2, 1000, 16000);
+		const layout = parseWavLayout(wav);
+
+		// 1.5 s -> raw 6000 B, already aligned to 4
+		const parts = splitWavBuffer(wav, layout!, 1.5);
+
+		expect(parts).toHaveLength(3);
+		for (const part of parts) {
+			const partLayout = parseWavLayout(part);
+			expect((partLayout?.dataLength ?? 0) % 4).toBe(0);
+		}
+	});
+
+	it('should preserve the sample bytes across parts', () => {
+		const wav = buildTestWav(1, 1000, 6000);
+		const layout = parseWavLayout(wav);
+
+		const parts = splitWavBuffer(wav, layout!, 1.5);
+
+		const reassembled: number[] = [];
+		for (const part of parts) {
+			const partLayout = parseWavLayout(part);
+			const bytes = new Uint8Array(
+				part,
+				partLayout!.dataOffset,
+				partLayout!.dataLength,
+			);
+			reassembled.push(...bytes);
+		}
+		const original = new Uint8Array(wav, layout!.dataOffset, 6000);
+		expect(reassembled).toEqual([...original]);
+	});
+
+	it('should patch the RIFF size of each part', () => {
+		const wav = buildTestWav(1, 1000, 6000);
+		const layout = parseWavLayout(wav);
+
+		const parts = splitWavBuffer(wav, layout!, 2);
+
+		for (const part of parts) {
+			const view = new DataView(part);
+			expect(view.getUint32(4, true)).toBe(part.byteLength - 8);
+		}
+	});
+
+	it('should return an empty array for a non-positive part size', () => {
+		const wav = buildTestWav(1, 1000, 6000);
+		const layout = parseWavLayout(wav);
+
+		expect(splitWavBuffer(wav, layout!, 0)).toEqual([]);
+	});
+});
+
+describe('sliceAudioBuffer', () => {
+	function buildRampBuffer(
+		channels: number,
+		length: number,
+		sampleRate: number,
+	): AudioBuffer {
+		const buffer = new FakeAudioBuffer({
+			numberOfChannels: channels,
+			length,
+			sampleRate,
+		}) as unknown as AudioBuffer;
+		for (let ch = 0; ch < channels; ch++) {
+			const data = buffer.getChannelData(ch);
+			for (let i = 0; i < length; i++) {
+				data[i] = (ch + 1) * i;
+			}
+		}
+		return buffer;
+	}
+
+	it('should copy the requested sample range for all channels', () => {
+		const source = buildRampBuffer(2, 100, 8000);
+
+		const slice = sliceAudioBuffer(source, 10, 20);
+
+		expect(slice.length).toBe(10);
+		expect(slice.numberOfChannels).toBe(2);
+		expect(slice.sampleRate).toBe(8000);
+		expect(slice.getChannelData(0)[0]).toBe(10);
+		expect(slice.getChannelData(0)[9]).toBe(19);
+		expect(slice.getChannelData(1)[0]).toBe(20);
+		expect(slice.getChannelData(1)[9]).toBe(38);
+	});
+
+	it('should clamp the end sample to the buffer length', () => {
+		const source = buildRampBuffer(1, 50, 8000);
+
+		const slice = sliceAudioBuffer(source, 40, 100);
+
+		expect(slice.length).toBe(10);
+		expect(slice.getChannelData(0)[9]).toBe(49);
+	});
+
+	it('should clamp a negative start sample to zero', () => {
+		const source = buildRampBuffer(1, 50, 8000);
+
+		const slice = sliceAudioBuffer(source, -10, 5);
+
+		expect(slice.length).toBe(5);
+		expect(slice.getChannelData(0)[0]).toBe(0);
+	});
+});
+
+describe('computePartCount', () => {
+	it('should round up to include the remainder part', () => {
+		expect(computePartCount(10, 4)).toBe(3);
+	});
+
+	it('should return the exact count for multiples', () => {
+		expect(computePartCount(12, 4)).toBe(3);
+	});
+
+	it('should return zero for empty input', () => {
+		expect(computePartCount(0, 4)).toBe(0);
+	});
+
+	it('should return zero for a non-positive part size', () => {
+		expect(computePartCount(10, 0)).toBe(0);
+	});
+});
+
+describe('computePcmPartLimitBytes', () => {
+	it('should compute the limit from minutes, rate, and channels', () => {
+		expect(computePcmPartLimitBytes(1, 44100, 1)).toBe(
+			60 * 44100 * PCM_BYTES_PER_SAMPLE,
+		);
+	});
+
+	it('should scale with channel count', () => {
+		expect(computePcmPartLimitBytes(2, 48000, 2)).toBe(
+			2 * 60 * 48000 * 2 * PCM_BYTES_PER_SAMPLE,
+		);
+	});
+});
+
+describe('buildPartFileName', () => {
+	it('should compose base, suffix, number, and extension', () => {
+		expect(buildPartFileName('recording-2026', 'part', 3, 'webm')).toBe(
+			'recording-2026-part3.webm',
+		);
+	});
+});
+
+describe('sanitizePartSuffix', () => {
+	it('should keep a valid suffix', () => {
+		expect(sanitizePartSuffix('chunk_1-a')).toBe('chunk_1-a');
+	});
+
+	it('should fall back to the default for an empty suffix', () => {
+		expect(sanitizePartSuffix('')).toBe('part');
+	});
+
+	it('should fall back to the default for illegal characters', () => {
+		expect(sanitizePartSuffix('pa/rt')).toBe('part');
+		expect(sanitizePartSuffix('pa.rt')).toBe('part');
+		expect(sanitizePartSuffix('pa rt')).toBe('part');
+	});
+});

--- a/tests/unit/AudioSplitter.test.ts
+++ b/tests/unit/AudioSplitter.test.ts
@@ -5,13 +5,18 @@
 
 import {
 	parseWavLayout,
-	splitWavBuffer,
+	computeWavPartBytes,
+	buildWavPart,
 	sliceAudioBuffer,
 	computePartCount,
 	computePcmPartLimitBytes,
 	buildPartFileName,
 	sanitizePartSuffix,
+	clampSplitMinutes,
+	totalByteLength,
+	detachTrailingBytes,
 	PCM_BYTES_PER_SAMPLE,
+	type WavLayout,
 } from '../../src/recording/AudioSplitter';
 import { createWavHeader } from '../../src/recording/WavEncoder';
 
@@ -33,6 +38,67 @@ function buildTestWav(
 		wav[WAV_HEADER_SIZE + i] = i % 251;
 	}
 	return wav.buffer;
+}
+
+/**
+ * Builds a WAV with a LIST chunk between fmt and data, producing a
+ * header larger than the canonical 44 bytes.
+ */
+function buildTestWavWithListChunk(
+	numChannels: number,
+	sampleRate: number,
+	dataBytes: number,
+): ArrayBuffer {
+	const base = new Uint8Array(
+		buildTestWav(numChannels, sampleRate, dataBytes),
+	);
+	const extraChunk = new Uint8Array(18);
+	const extraView = new DataView(extraChunk.buffer);
+	extraChunk.set([0x4c, 0x49, 0x53, 0x54], 0); // 'LIST'
+	extraView.setUint32(4, 10, true);
+	const wav = new Uint8Array(base.length + extraChunk.length);
+	wav.set(base.subarray(0, 36), 0);
+	wav.set(extraChunk, 36);
+	wav.set(base.subarray(36), 36 + extraChunk.length);
+	// Patch RIFF size for the inserted bytes
+	new DataView(wav.buffer).setUint32(4, wav.length - 8, true);
+	return wav.buffer;
+}
+
+/**
+ * Reconstructs a full byte-level split through the lazy per-part API,
+ * mirroring how production code iterates over parts one at a time.
+ */
+function splitWav(
+	buffer: ArrayBuffer,
+	layout: WavLayout,
+	partDurationSec: number,
+): ArrayBuffer[] {
+	const partBytes = computeWavPartBytes(layout, partDurationSec);
+	const partCount = computePartCount(layout.dataLength, partBytes);
+	const parts: ArrayBuffer[] = [];
+	for (let i = 0; i < partCount; i++) {
+		parts.push(buildWavPart(buffer, layout, partBytes, i));
+	}
+	return parts;
+}
+
+/**
+ * Creates an ArrayBuffer filled with sequential byte values from `start`.
+ */
+function buildBytes(length: number, start: number): ArrayBuffer {
+	const bytes = new Uint8Array(length);
+	for (let i = 0; i < length; i++) {
+		bytes[i] = (start + i) % 256;
+	}
+	return bytes.buffer;
+}
+
+/**
+ * Flattens a buffer list into a single array of byte values.
+ */
+function concatBytes(buffers: ArrayBuffer[]): number[] {
+	return buffers.flatMap((buffer) => [...new Uint8Array(buffer)]);
 }
 
 /**
@@ -116,6 +182,13 @@ describe('parseWavLayout', () => {
 		expect(parseWavLayout(bytes.buffer)).toBeNull();
 	});
 
+	it('should return null for RIFF data that is not WAVE', () => {
+		const wav = buildTestWav(1, 8000, 100);
+		new Uint8Array(wav).set([0x41, 0x56, 0x49, 0x20], 8); // 'AVI '
+
+		expect(parseWavLayout(wav)).toBeNull();
+	});
+
 	it('should return null for a buffer shorter than the RIFF header', () => {
 		expect(parseWavLayout(new ArrayBuffer(8))).toBeNull();
 	});
@@ -133,6 +206,20 @@ describe('parseWavLayout', () => {
 		new DataView(wav).setUint16(20, 0x0003, true);
 
 		expect(parseWavLayout(wav)).not.toBeNull();
+	});
+
+	it('should return null for a zero byte rate', () => {
+		const wav = buildTestWav(1, 8000, 100);
+		new DataView(wav).setUint32(28, 0, true);
+
+		expect(parseWavLayout(wav)).toBeNull();
+	});
+
+	it('should return null for a zero block align', () => {
+		const wav = buildTestWav(1, 8000, 100);
+		new DataView(wav).setUint16(32, 0, true);
+
+		expect(parseWavLayout(wav)).toBeNull();
 	});
 
 	it('should clamp dataLength to the actual buffer size', () => {
@@ -167,13 +254,46 @@ describe('parseWavLayout', () => {
 	});
 });
 
-describe('splitWavBuffer', () => {
+describe('computeWavPartBytes', () => {
+	it('should compute the part size from byteRate and duration', () => {
+		// 1000 Hz mono 16-bit: byteRate = 2000 B/s; 2 s parts = 4000 B
+		const wav = buildTestWav(1, 1000, 12000);
+		const layout = parseWavLayout(wav);
+
+		expect(computeWavPartBytes(layout!, 2)).toBe(4000);
+	});
+
+	it('should align the part size down to blockAlign', () => {
+		const layout: WavLayout = {
+			dataOffset: WAV_HEADER_SIZE,
+			dataLength: 16000,
+			byteRate: 4000,
+			blockAlign: 4,
+		};
+
+		// 1.5005 s -> raw 6002 B, aligned down to 6000
+		expect(computeWavPartBytes(layout, 1.5005)).toBe(6000);
+	});
+
+	it('should return zero for a zero duration', () => {
+		const layout: WavLayout = {
+			dataOffset: WAV_HEADER_SIZE,
+			dataLength: 1000,
+			byteRate: 2000,
+			blockAlign: 2,
+		};
+
+		expect(computeWavPartBytes(layout, 0)).toBe(0);
+	});
+});
+
+describe('buildWavPart', () => {
 	it('should split into equal parts when data is an exact multiple', () => {
 		// 1000 Hz mono 16-bit: byteRate = 2000 B/s; 2 s parts = 4000 B
 		const wav = buildTestWav(1, 1000, 12000);
 		const layout = parseWavLayout(wav);
 
-		const parts = splitWavBuffer(wav, layout!, 2);
+		const parts = splitWav(wav, layout!, 2);
 
 		expect(parts).toHaveLength(3);
 		for (const part of parts) {
@@ -186,7 +306,7 @@ describe('splitWavBuffer', () => {
 		const wav = buildTestWav(1, 1000, 10000);
 		const layout = parseWavLayout(wav);
 
-		const parts = splitWavBuffer(wav, layout!, 2);
+		const parts = splitWav(wav, layout!, 2);
 
 		expect(parts).toHaveLength(3);
 		expect(parseWavLayout(parts[0])?.dataLength).toBe(4000);
@@ -200,7 +320,7 @@ describe('splitWavBuffer', () => {
 		const layout = parseWavLayout(wav);
 
 		// 1.5 s -> raw 6000 B, already aligned to 4
-		const parts = splitWavBuffer(wav, layout!, 1.5);
+		const parts = splitWav(wav, layout!, 1.5);
 
 		expect(parts).toHaveLength(3);
 		for (const part of parts) {
@@ -213,7 +333,7 @@ describe('splitWavBuffer', () => {
 		const wav = buildTestWav(1, 1000, 6000);
 		const layout = parseWavLayout(wav);
 
-		const parts = splitWavBuffer(wav, layout!, 1.5);
+		const parts = splitWav(wav, layout!, 1.5);
 
 		const reassembled: number[] = [];
 		for (const part of parts) {
@@ -233,7 +353,7 @@ describe('splitWavBuffer', () => {
 		const wav = buildTestWav(1, 1000, 6000);
 		const layout = parseWavLayout(wav);
 
-		const parts = splitWavBuffer(wav, layout!, 2);
+		const parts = splitWav(wav, layout!, 2);
 
 		for (const part of parts) {
 			const view = new DataView(part);
@@ -241,11 +361,65 @@ describe('splitWavBuffer', () => {
 		}
 	});
 
-	it('should return an empty array for a non-positive part size', () => {
+	it('should patch the data chunk size of each part', () => {
+		const wav = buildTestWav(1, 1000, 10000);
+		const layout = parseWavLayout(wav);
+
+		const parts = splitWav(wav, layout!, 2);
+
+		const expectedSizes = [4000, 4000, 2000];
+		parts.forEach((part, index) => {
+			const view = new DataView(part);
+			// data chunk size field immediately precedes the sample data
+			expect(view.getUint32(WAV_HEADER_SIZE - 4, true)).toBe(
+				expectedSizes[index],
+			);
+		});
+	});
+
+	it('should copy a non-44-byte header into every part', () => {
+		// Mono 8000 Hz 16-bit: byteRate = 16000 B/s; 0.0025 s parts = 40 B
+		const wav = buildTestWavWithListChunk(1, 8000, 100);
+		const layout = parseWavLayout(wav);
+		expect(layout?.dataOffset).toBe(WAV_HEADER_SIZE + 18);
+
+		const parts = splitWav(wav, layout!, 0.0025);
+
+		expect(parts).toHaveLength(3);
+		const reassembled: number[] = [];
+		for (const part of parts) {
+			const partLayout = parseWavLayout(part);
+			expect(partLayout?.dataOffset).toBe(layout!.dataOffset);
+			reassembled.push(
+				...new Uint8Array(
+					part,
+					partLayout!.dataOffset,
+					partLayout!.dataLength,
+				),
+			);
+		}
+		const original = new Uint8Array(wav, layout!.dataOffset, 100);
+		expect(reassembled).toEqual([...original]);
+	});
+
+	it('should produce no parts for a non-positive part size', () => {
 		const wav = buildTestWav(1, 1000, 6000);
 		const layout = parseWavLayout(wav);
 
-		expect(splitWavBuffer(wav, layout!, 0)).toEqual([]);
+		expect(splitWav(wav, layout!, 0)).toEqual([]);
+	});
+
+	it('should build a header-only part when the index starts at the data end', () => {
+		const wav = buildTestWav(1, 1000, 6000);
+		const layout = parseWavLayout(wav);
+
+		// start = 2 * 3000 = dataLength, so the part holds zero sample bytes
+		const part = buildWavPart(wav, layout!, 3000, 2);
+
+		expect(part.byteLength).toBe(WAV_HEADER_SIZE);
+		const view = new DataView(part);
+		expect(view.getUint32(4, true)).toBe(WAV_HEADER_SIZE - 8);
+		expect(view.getUint32(WAV_HEADER_SIZE - 4, true)).toBe(0);
 	});
 });
 
@@ -355,5 +529,119 @@ describe('sanitizePartSuffix', () => {
 		expect(sanitizePartSuffix('pa/rt')).toBe('part');
 		expect(sanitizePartSuffix('pa.rt')).toBe('part');
 		expect(sanitizePartSuffix('pa rt')).toBe('part');
+	});
+});
+
+describe('clampSplitMinutes', () => {
+	it('should clamp values below the minimum', () => {
+		expect(clampSplitMinutes(0)).toBe(1);
+		expect(clampSplitMinutes(-10)).toBe(1);
+	});
+
+	it('should clamp values above the maximum', () => {
+		expect(clampSplitMinutes(181)).toBe(180);
+		expect(clampSplitMinutes(10000)).toBe(180);
+	});
+
+	it('should floor fractional values', () => {
+		expect(clampSplitMinutes(2.9)).toBe(2);
+		expect(clampSplitMinutes(15.5)).toBe(15);
+	});
+
+	it('should return the default for NaN', () => {
+		expect(clampSplitMinutes(Number.NaN)).toBe(15);
+	});
+
+	it('should return the default for Infinity', () => {
+		expect(clampSplitMinutes(Number.POSITIVE_INFINITY)).toBe(15);
+		expect(clampSplitMinutes(Number.NEGATIVE_INFINITY)).toBe(15);
+	});
+
+	it('should pass through valid whole minutes', () => {
+		expect(clampSplitMinutes(1)).toBe(1);
+		expect(clampSplitMinutes(15)).toBe(15);
+		expect(clampSplitMinutes(180)).toBe(180);
+	});
+});
+
+describe('totalByteLength', () => {
+	it('should return zero for an empty list', () => {
+		expect(totalByteLength([])).toBe(0);
+	});
+
+	it('should sum the byte lengths of all buffers', () => {
+		const buffers = [
+			new ArrayBuffer(3),
+			new ArrayBuffer(5),
+			new ArrayBuffer(0),
+		];
+
+		expect(totalByteLength(buffers)).toBe(8);
+	});
+});
+
+describe('detachTrailingBytes', () => {
+	it('should be a no-op for zero trailing bytes', () => {
+		const buffers = [buildBytes(4, 0)];
+
+		const carry = detachTrailingBytes(buffers, 0);
+
+		expect(carry).toEqual([]);
+		expect(buffers).toHaveLength(1);
+		expect(buffers[0].byteLength).toBe(4);
+	});
+
+	it('should return an empty carry for an empty list', () => {
+		const buffers: ArrayBuffer[] = [];
+
+		expect(detachTrailingBytes(buffers, 5)).toEqual([]);
+		expect(buffers).toEqual([]);
+	});
+
+	it('should split inside the last buffer', () => {
+		const buffers = [buildBytes(10, 0)];
+
+		const carry = detachTrailingBytes(buffers, 4);
+
+		expect(buffers).toHaveLength(1);
+		expect([...new Uint8Array(buffers[0])]).toEqual([0, 1, 2, 3, 4, 5]);
+		expect(carry).toHaveLength(1);
+		expect([...new Uint8Array(carry[0])]).toEqual([6, 7, 8, 9]);
+	});
+
+	it('should detach whole buffers plus a partial one across a boundary', () => {
+		const buffers = [buildBytes(4, 0), buildBytes(4, 4), buildBytes(4, 8)];
+
+		const carry = detachTrailingBytes(buffers, 6);
+
+		expect(buffers).toHaveLength(2);
+		expect([...new Uint8Array(buffers[0])]).toEqual([0, 1, 2, 3]);
+		expect([...new Uint8Array(buffers[1])]).toEqual([4, 5]);
+		// Carry preserves the original byte order: partial tail, then whole buffer
+		expect(carry).toHaveLength(2);
+		expect([...new Uint8Array(carry[0])]).toEqual([6, 7]);
+		expect([...new Uint8Array(carry[1])]).toEqual([8, 9, 10, 11]);
+	});
+
+	it('should detach everything when trailing bytes equal the total', () => {
+		const first = buildBytes(3, 0);
+		const second = buildBytes(5, 3);
+		const buffers = [first, second];
+
+		const carry = detachTrailingBytes(buffers, 8);
+
+		expect(buffers).toEqual([]);
+		// Whole buffers are moved by reference in their original order
+		expect(carry).toEqual([first, second]);
+	});
+
+	it('should reproduce the original sequence from remainder plus carry', () => {
+		const buffers = [buildBytes(7, 0), buildBytes(5, 7), buildBytes(9, 12)];
+		const original = concatBytes(buffers);
+
+		const carry = detachTrailingBytes(buffers, 11);
+
+		expect(concatBytes(carry)).toHaveLength(11);
+		expect(concatBytes([...buffers, ...carry])).toEqual(original);
 	});
 });

--- a/tests/unit/ContextMenu.test.ts
+++ b/tests/unit/ContextMenu.test.ts
@@ -50,6 +50,12 @@ jest.mock('../../src/ui/ConversionModal', () => ({
 	})),
 }));
 
+jest.mock('../../src/ui/SplitModal', () => ({
+	SplitModal: jest.fn().mockImplementation(() => ({
+		open: jest.fn(),
+	})),
+}));
+
 // Mock AudioEncoder to avoid mediabunny TextDecoder requirement
 jest.mock('../../src/recording/AudioEncoder', () => ({
 	encodeAudioBuffer: jest.fn(),
@@ -180,11 +186,11 @@ describe('ContextMenu', () => {
 
 			fileMenuCallback(mockMenu, mockFile);
 
-			expect(mockMenu.addItem).toHaveBeenCalledTimes(3);
+			expect(mockMenu.addItem).toHaveBeenCalledTimes(4);
 
-			// Verify the delete item configuration (3rd item: Audio info, Convert, Delete)
+			// Verify the delete item configuration (4th item: Audio info, Convert, Split, Delete)
 			const addItemCallback = (mockMenu.addItem as jest.Mock).mock
-				.calls[2][0];
+				.calls[3][0];
 			const mockItem = {
 				setTitle: jest.fn().mockReturnThis(),
 				setIcon: jest.fn().mockReturnThis(),
@@ -205,7 +211,7 @@ describe('ContextMenu', () => {
 
 			fileMenuCallback(mockMenu, mockFile);
 
-			expect(mockMenu.addItem).toHaveBeenCalledTimes(3);
+			expect(mockMenu.addItem).toHaveBeenCalledTimes(4);
 
 			// Verify the audio info item configuration (1st item)
 			const addItemCallback = (mockMenu.addItem as jest.Mock).mock
@@ -313,6 +319,90 @@ describe('ContextMenu', () => {
 			expect(infoCount).toBe(1);
 		});
 
+		it('should add "Split audio into parts" item for audio files', () => {
+			const mockMenu = new Menu();
+			const mockFile = new TFile();
+			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
+
+			fileMenuCallback(mockMenu, mockFile);
+
+			expect(mockMenu.addItem).toHaveBeenCalledTimes(4);
+
+			// Verify the split item configuration (3rd item: info, convert, split, delete)
+			const addItemCallback = (mockMenu.addItem as jest.Mock).mock
+				.calls[2][0];
+			const mockItem = {
+				setTitle: jest.fn().mockReturnThis(),
+				setIcon: jest.fn().mockReturnThis(),
+				setSection: jest.fn().mockReturnThis(),
+				onClick: jest.fn(),
+			};
+			addItemCallback(mockItem);
+
+			expect(mockItem.setTitle).toHaveBeenCalledWith(
+				'Split audio into parts',
+			);
+			expect(mockItem.setIcon).toHaveBeenCalledWith('scissors');
+			expect(mockItem.setSection).toHaveBeenCalledWith('aar');
+		});
+
+		it('should open SplitModal on "Split audio into parts" click', () => {
+			const { SplitModal } = jest.requireMock('../../src/ui/SplitModal');
+			const mockMenu = new Menu();
+			const mockFile = new TFile();
+			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
+
+			fileMenuCallback(mockMenu, mockFile);
+
+			const addItemCallback = (mockMenu.addItem as jest.Mock).mock
+				.calls[2][0];
+			const mockItem = {
+				setTitle: jest.fn().mockReturnThis(),
+				setIcon: jest.fn().mockReturnThis(),
+				setSection: jest.fn().mockReturnThis(),
+				onClick: jest.fn(),
+			};
+			addItemCallback(mockItem);
+
+			const clickHandler = mockItem.onClick.mock.calls[0][0];
+			clickHandler();
+
+			expect(SplitModal).toHaveBeenCalledWith(
+				mockApp,
+				mockFile,
+				expect.objectContaining({
+					deleteSourceAfterConversion: true,
+				}),
+			);
+		});
+
+		it('should not duplicate "Split audio into parts" when called twice on the same menu', () => {
+			const mockMenu = new Menu();
+			const mockFile = new TFile();
+			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
+
+			fileMenuCallback(mockMenu, mockFile);
+			fileMenuCallback(mockMenu, mockFile);
+
+			const calls = (mockMenu.addItem as jest.Mock).mock.calls;
+			const titles: string[] = [];
+			for (const call of calls) {
+				const mockItem = {
+					setTitle: jest.fn().mockReturnThis(),
+					setIcon: jest.fn().mockReturnThis(),
+					setSection: jest.fn().mockReturnThis(),
+					onClick: jest.fn(),
+				};
+				call[0](mockItem);
+				titles.push(mockItem.setTitle.mock.calls[0][0] as string);
+			}
+
+			const splitCount = titles.filter(
+				(t) => t === 'Split audio into parts',
+			).length;
+			expect(splitCount).toBe(1);
+		});
+
 		it('should NOT add item for non-audio files', () => {
 			const mockMenu = new Menu();
 			const mockFile = new TFile();
@@ -331,7 +421,7 @@ describe('ContextMenu', () => {
 			fileMenuCallback(mockMenu, mockFile);
 
 			const addItemCallback = (mockMenu.addItem as jest.Mock).mock
-				.calls[2][0];
+				.calls[3][0];
 			const mockItem = {
 				setTitle: jest.fn().mockReturnThis(),
 				setIcon: jest.fn().mockReturnThis(),
@@ -362,7 +452,7 @@ describe('ContextMenu', () => {
 			fileMenuCallback(mockMenu, mockFile);
 
 			const addItemCallback = (mockMenu.addItem as jest.Mock).mock
-				.calls[2][0];
+				.calls[3][0];
 			const mockItem = {
 				setTitle: jest.fn().mockReturnThis(),
 				setIcon: jest.fn().mockReturnThis(),
@@ -476,9 +566,9 @@ describe('ContextMenu', () => {
 
 			editorMenuCallback(mockMenu, mockEditor, {});
 
-			expect(mockMenu.addItem).toHaveBeenCalledTimes(3);
+			expect(mockMenu.addItem).toHaveBeenCalledTimes(4);
 			const addItemCallback = (mockMenu.addItem as jest.Mock).mock
-				.calls[2][0]; // Delete recording & link is the third item (info, convert, delete&link)
+				.calls[3][0]; // Delete recording & link is the fourth item (info, convert, split, delete&link)
 			const mockItem = {
 				setTitle: jest.fn().mockReturnThis(),
 				setIcon: jest.fn().mockReturnThis(),
@@ -512,7 +602,7 @@ describe('ContextMenu', () => {
 			editorMenuCallback(mockMenu, mockEditor, {});
 
 			const addItemCallback = (mockMenu.addItem as jest.Mock).mock
-				.calls[2][0];
+				.calls[3][0];
 			const mockItem = {
 				setTitle: jest.fn().mockReturnThis(),
 				setIcon: jest.fn().mockReturnThis(),
@@ -564,7 +654,7 @@ describe('ContextMenu', () => {
 			editorMenuCallback(mockMenu, mockEditor, {});
 
 			const addItemCallback = (mockMenu.addItem as jest.Mock).mock
-				.calls[2][0];
+				.calls[3][0];
 			const mockItem = {
 				setTitle: jest.fn().mockReturnThis(),
 				setIcon: jest.fn().mockReturnThis(),

--- a/tests/unit/LinkUpdater.test.ts
+++ b/tests/unit/LinkUpdater.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Unit tests for LinkUpdater module.
+ * @module tests/unit/LinkUpdater.test
+ */
+
+import {
+	buildLinkPattern,
+	buildReplacementLinks,
+	updateLinksInOpenEditors,
+	updateLinksInVault,
+} from '../../src/utils/LinkUpdater';
+import { App, MarkdownView, TFile } from 'obsidian';
+
+jest.mock('obsidian', () => ({
+	MarkdownView: class {
+		editor: unknown = null;
+	},
+	TFile: class {
+		path = '';
+		name = '';
+	},
+}));
+
+/**
+ * Minimal editor double exposing the methods LinkUpdater relies on.
+ */
+interface EditorDouble {
+	getValue: jest.Mock;
+	offsetToPos: jest.Mock;
+	replaceRange: jest.Mock;
+}
+
+function createEditor(content: string): EditorDouble {
+	return {
+		getValue: jest.fn().mockReturnValue(content),
+		offsetToPos: jest.fn((offset: number) => ({ line: 0, ch: offset })),
+		replaceRange: jest.fn(),
+	};
+}
+
+function createLeafWithEditor(editor: EditorDouble): { view: MarkdownView } {
+	const view = new MarkdownView();
+	(view as unknown as { editor: EditorDouble }).editor = editor;
+	return { view };
+}
+
+describe('buildLinkPattern', () => {
+	// A fresh pattern per assertion: the /g flag makes test() stateful
+	it('should match embed and plain wiki links', () => {
+		expect(buildLinkPattern('rec.webm').test('![[rec.webm]]')).toBe(true);
+		expect(buildLinkPattern('rec.webm').test('[[rec.webm]]')).toBe(true);
+	});
+
+	it('should match links with aliases', () => {
+		expect(
+			buildLinkPattern('rec.webm').test('![[rec.webm|My recording]]'),
+		).toBe(true);
+	});
+
+	it('should escape regex metacharacters in the file name', () => {
+		expect(buildLinkPattern('rec (1).webm').test('![[rec (1).webm]]')).toBe(
+			true,
+		);
+		expect(buildLinkPattern('rec (1).webm').test('![[rec 1.webm]]')).toBe(
+			false,
+		);
+	});
+
+	it('should not match a different file', () => {
+		expect(buildLinkPattern('rec.webm').test('![[other.webm]]')).toBe(
+			false,
+		);
+	});
+});
+
+describe('buildReplacementLinks', () => {
+	it('should join embed links with newlines', () => {
+		expect(buildReplacementLinks(['a.wav', 'b.wav'], true)).toBe(
+			'![[a.wav]]\n![[b.wav]]',
+		);
+	});
+
+	it('should preserve plain link form', () => {
+		expect(buildReplacementLinks(['a.wav'], false)).toBe('[[a.wav]]');
+	});
+});
+
+describe('updateLinksInOpenEditors', () => {
+	function createApp(editors: EditorDouble[]): App {
+		return {
+			workspace: {
+				getLeavesOfType: jest
+					.fn()
+					.mockReturnValue(editors.map(createLeafWithEditor)),
+			},
+		} as unknown as App;
+	}
+
+	it('should replace a single embed link with multiple part links', () => {
+		const editor = createEditor('before ![[rec.webm]] after');
+		const app = createApp([editor]);
+
+		updateLinksInOpenEditors(
+			app,
+			'rec.webm',
+			['rec-part1.webm', 'rec-part2.webm'],
+			'replace',
+		);
+
+		expect(editor.replaceRange).toHaveBeenCalledTimes(1);
+		expect(editor.replaceRange).toHaveBeenCalledWith(
+			'![[rec-part1.webm]]\n![[rec-part2.webm]]',
+			{ line: 0, ch: 7 },
+			{ line: 0, ch: 20 },
+		);
+	});
+
+	it('should insert links after the source link for the after action', () => {
+		const editor = createEditor('![[rec.webm]]');
+		const app = createApp([editor]);
+
+		updateLinksInOpenEditors(app, 'rec.webm', ['new.webm'], 'after');
+
+		expect(editor.replaceRange).toHaveBeenCalledWith(
+			'![[rec.webm]]\n![[new.webm]]',
+			{ line: 0, ch: 0 },
+			{ line: 0, ch: 13 },
+		);
+	});
+
+	it('should replace multiple matches from end to start', () => {
+		const editor = createEditor('![[rec.webm]] middle [[rec.webm]]');
+		const app = createApp([editor]);
+
+		updateLinksInOpenEditors(app, 'rec.webm', ['new.webm'], 'replace');
+
+		expect(editor.replaceRange).toHaveBeenCalledTimes(2);
+		// Last match is replaced first so earlier offsets stay valid
+		const firstCall = editor.replaceRange.mock.calls[0];
+		expect(firstCall[0]).toBe('[[new.webm]]');
+		expect(firstCall[1]).toEqual({ line: 0, ch: 21 });
+		const secondCall = editor.replaceRange.mock.calls[1];
+		expect(secondCall[0]).toBe('![[new.webm]]');
+		expect(secondCall[1]).toEqual({ line: 0, ch: 0 });
+	});
+
+	it('should skip editors whose content does not mention the file', () => {
+		const editor = createEditor('nothing here');
+		const app = createApp([editor]);
+
+		updateLinksInOpenEditors(app, 'rec.webm', ['new.webm'], 'replace');
+
+		expect(editor.replaceRange).not.toHaveBeenCalled();
+	});
+
+	it('should do nothing for the none action', () => {
+		const editor = createEditor('![[rec.webm]]');
+		const app = createApp([editor]);
+
+		updateLinksInOpenEditors(app, 'rec.webm', ['new.webm'], 'none');
+
+		expect(editor.replaceRange).not.toHaveBeenCalled();
+	});
+
+	it('should do nothing for an empty replacement list', () => {
+		const editor = createEditor('![[rec.webm]]');
+		const app = createApp([editor]);
+
+		updateLinksInOpenEditors(app, 'rec.webm', [], 'replace');
+
+		expect(editor.replaceRange).not.toHaveBeenCalled();
+	});
+
+	it('should skip leaves whose view is not a MarkdownView', () => {
+		const app = {
+			workspace: {
+				getLeavesOfType: jest
+					.fn()
+					.mockReturnValue([{ view: { not: 'markdown' } }]),
+			},
+		} as unknown as App;
+
+		expect(() =>
+			updateLinksInOpenEditors(app, 'rec.webm', ['new.webm'], 'replace'),
+		).not.toThrow();
+	});
+});
+
+describe('updateLinksInVault', () => {
+	function createSourceFile(path: string, name: string): TFile {
+		const file = new TFile();
+		(file as unknown as { path: string; name: string }).path = path;
+		(file as unknown as { path: string; name: string }).name = name;
+		return file;
+	}
+
+	function createVaultApp(
+		resolvedLinks: Record<string, Record<string, number>>,
+		noteContents: Record<string, string>,
+	): { app: App; processedContents: Record<string, string> } {
+		const processedContents: Record<string, string> = {
+			...noteContents,
+		};
+		const app = {
+			metadataCache: { resolvedLinks },
+			vault: {
+				getAbstractFileByPath: jest.fn((path: string) => {
+					if (path in noteContents) {
+						return createSourceFile(path, path);
+					}
+					return null;
+				}),
+				process: jest.fn(
+					async (
+						note: TFile,
+						transform: (content: string) => string,
+					) => {
+						const path = note.path;
+						processedContents[path] = transform(
+							processedContents[path],
+						);
+						return processedContents[path];
+					},
+				),
+			},
+		} as unknown as App;
+		return { app, processedContents };
+	}
+
+	it('should rewrite links in every referencing note', async () => {
+		const source = createSourceFile('audio/rec.webm', 'rec.webm');
+		const { app, processedContents } = createVaultApp(
+			{
+				'note1.md': { 'audio/rec.webm': 1 },
+				'note2.md': { 'other.webm': 1 },
+				'note3.md': { 'audio/rec.webm': 2 },
+			},
+			{
+				'note1.md': 'intro ![[rec.webm]] outro',
+				'note2.md': '![[other.webm]]',
+				'note3.md': '[[rec.webm|alias]] and ![[audio/rec.webm]]',
+			},
+		);
+
+		const updated = await updateLinksInVault(
+			app,
+			source,
+			['rec-part1.webm', 'rec-part2.webm'],
+			'replace',
+		);
+
+		expect(updated).toBe(2);
+		expect(processedContents['note1.md']).toBe(
+			'intro ![[rec-part1.webm]]\n![[rec-part2.webm]] outro',
+		);
+		expect(processedContents['note2.md']).toBe('![[other.webm]]');
+		expect(processedContents['note3.md']).toBe(
+			'[[rec-part1.webm]]\n[[rec-part2.webm]] and ![[rec-part1.webm]]\n![[rec-part2.webm]]',
+		);
+	});
+
+	it('should append links for the after action', async () => {
+		const source = createSourceFile('rec.webm', 'rec.webm');
+		const { app, processedContents } = createVaultApp(
+			{ 'note.md': { 'rec.webm': 1 } },
+			{ 'note.md': '![[rec.webm]]' },
+		);
+
+		await updateLinksInVault(app, source, ['new.webm'], 'after');
+
+		expect(processedContents['note.md']).toBe(
+			'![[rec.webm]]\n![[new.webm]]',
+		);
+	});
+
+	it('should return zero and skip processing for the none action', async () => {
+		const source = createSourceFile('rec.webm', 'rec.webm');
+		const { app } = createVaultApp(
+			{ 'note.md': { 'rec.webm': 1 } },
+			{ 'note.md': '![[rec.webm]]' },
+		);
+
+		const updated = await updateLinksInVault(
+			app,
+			source,
+			['new.webm'],
+			'none',
+		);
+
+		expect(updated).toBe(0);
+		expect(app.vault.process).not.toHaveBeenCalled();
+	});
+
+	it('should skip notes that cannot be resolved to a file', async () => {
+		const source = createSourceFile('rec.webm', 'rec.webm');
+		const { app } = createVaultApp({ 'missing.md': { 'rec.webm': 1 } }, {});
+
+		const updated = await updateLinksInVault(
+			app,
+			source,
+			['new.webm'],
+			'replace',
+		);
+
+		expect(updated).toBe(0);
+	});
+
+	it('should not count notes whose content did not change', async () => {
+		const source = createSourceFile('rec.webm', 'rec.webm');
+		const { app } = createVaultApp(
+			{ 'note.md': { 'rec.webm': 1 } },
+			{ 'note.md': 'mentions rec.webm without a link' },
+		);
+
+		const updated = await updateLinksInVault(
+			app,
+			source,
+			['new.webm'],
+			'replace',
+		);
+
+		expect(updated).toBe(0);
+	});
+});

--- a/tests/unit/LinkUpdater.test.ts
+++ b/tests/unit/LinkUpdater.test.ts
@@ -78,9 +78,15 @@ describe('buildLinkPattern', () => {
 });
 
 describe('buildReplacementLinks', () => {
-	it('should join embed links with newlines', () => {
+	it('should join embed links with newlines by default', () => {
 		expect(buildReplacementLinks(['a.wav', 'b.wav'], true)).toBe(
 			'![[a.wav]]\n![[b.wav]]',
+		);
+	});
+
+	it('should join links with a custom separator', () => {
+		expect(buildReplacementLinks(['a.wav', 'b.wav'], true, ' ')).toBe(
+			'![[a.wav]] ![[b.wav]]',
 		);
 	});
 
@@ -100,7 +106,9 @@ describe('updateLinksInOpenEditors', () => {
 		} as unknown as App;
 	}
 
-	it('should replace a single embed link with multiple part links', () => {
+	it('should replace an inline embed with space-separated part links', () => {
+		// The link shares its line with other content, so newlines would
+		// reflow the surrounding text
 		const editor = createEditor('before ![[rec.webm]] after');
 		const app = createApp([editor]);
 
@@ -113,9 +121,27 @@ describe('updateLinksInOpenEditors', () => {
 
 		expect(editor.replaceRange).toHaveBeenCalledTimes(1);
 		expect(editor.replaceRange).toHaveBeenCalledWith(
-			'![[rec-part1.webm]]\n![[rec-part2.webm]]',
+			'![[rec-part1.webm]] ![[rec-part2.webm]]',
 			{ line: 0, ch: 7 },
 			{ line: 0, ch: 20 },
+		);
+	});
+
+	it('should replace a link alone on its line with one link per line', () => {
+		const editor = createEditor('![[rec.webm]]');
+		const app = createApp([editor]);
+
+		updateLinksInOpenEditors(
+			app,
+			'rec.webm',
+			['rec-part1.webm', 'rec-part2.webm'],
+			'replace',
+		);
+
+		expect(editor.replaceRange).toHaveBeenCalledWith(
+			'![[rec-part1.webm]]\n![[rec-part2.webm]]',
+			{ line: 0, ch: 0 },
+			{ line: 0, ch: 13 },
 		);
 	});
 
@@ -209,6 +235,7 @@ describe('updateLinksInVault', () => {
 		content: string;
 		links?: ReferenceDouble[];
 		embeds?: ReferenceDouble[];
+		frontmatterLinks?: { link: string }[];
 	}
 
 	/**
@@ -284,10 +311,18 @@ describe('updateLinksInVault', () => {
 				resolvedLinks,
 				getFileCache: jest.fn((note: TFile) => {
 					const entry = notes[note.path];
-					if (!entry.links && !entry.embeds) {
+					if (
+						!entry.links &&
+						!entry.embeds &&
+						!entry.frontmatterLinks
+					) {
 						return null;
 					}
-					return { links: entry.links, embeds: entry.embeds };
+					return {
+						links: entry.links,
+						embeds: entry.embeds,
+						frontmatterLinks: entry.frontmatterLinks,
+					};
 				}),
 				getFirstLinkpathDest: jest.fn(
 					(linkpath: string) => linkTargets[linkpath] ?? null,
@@ -336,9 +371,11 @@ describe('updateLinksInVault', () => {
 			'replace',
 		);
 
-		expect(updated).toBe(1);
+		expect(updated.updatedNotes).toBe(1);
+		// The embed shares its line with other text, so the part links
+		// are space-separated to keep the line intact
 		expect(contents['note.md']).toBe(
-			'intro ![[rec-part1.webm]]\n![[rec-part2.webm]] outro',
+			'intro ![[rec-part1.webm]] ![[rec-part2.webm]] outro',
 		);
 		expect(generateMarkdownLink).toHaveBeenCalledWith(
 			expect.objectContaining({ path: 'audio/rec-part1.webm' }),
@@ -372,7 +409,7 @@ describe('updateLinksInVault', () => {
 			'replace',
 		);
 
-		expect(updated).toBe(1);
+		expect(updated.updatedNotes).toBe(1);
 		expect(contents['note.md']).toBe('see [[new.webm]] here');
 	});
 
@@ -400,7 +437,7 @@ describe('updateLinksInVault', () => {
 			'replace',
 		);
 
-		expect(updated).toBe(1);
+		expect(updated.updatedNotes).toBe(1);
 		expect(contents['note.md']).toBe('audio: ![](new.webm)');
 	});
 
@@ -438,7 +475,7 @@ describe('updateLinksInVault', () => {
 			'replace',
 		);
 
-		expect(updated).toBe(0);
+		expect(updated.updatedNotes).toBe(0);
 		expect(processMock).not.toHaveBeenCalled();
 		expect(contents['note.md']).toBe(content);
 	});
@@ -467,7 +504,7 @@ describe('updateLinksInVault', () => {
 			'after',
 		);
 
-		expect(updated).toBe(1);
+		expect(updated.updatedNotes).toBe(1);
 		expect(contents['note.md']).toBe('![[rec.webm]]\n![[new.webm]]');
 	});
 
@@ -488,14 +525,18 @@ describe('updateLinksInVault', () => {
 		);
 
 		expect(
-			await updateLinksInVault(
-				app,
-				source,
-				[createFile('new.webm')],
-				'none',
-			),
+			(
+				await updateLinksInVault(
+					app,
+					source,
+					[createFile('new.webm')],
+					'none',
+				)
+			).updatedNotes,
 		).toBe(0);
-		expect(await updateLinksInVault(app, source, [], 'replace')).toBe(0);
+		expect(
+			(await updateLinksInVault(app, source, [], 'replace')).updatedNotes,
+		).toBe(0);
 		expect(processMock).not.toHaveBeenCalled();
 	});
 
@@ -525,7 +566,8 @@ describe('updateLinksInVault', () => {
 			'replace',
 		);
 
-		expect(updated).toBe(0);
+		expect(updated.updatedNotes).toBe(0);
+		expect(updated.skippedReferences).toBe(1);
 		expect(contents['note.md']).toBe(content);
 		expect(warnSpy).toHaveBeenCalledTimes(1);
 		warnSpy.mockRestore();
@@ -565,9 +607,11 @@ describe('updateLinksInVault', () => {
 			'replace',
 		);
 
-		expect(updated).toBe(1);
+		expect(updated.updatedNotes).toBe(1);
+		// Both references share their line with other text, so the part
+		// links are space-separated to keep the line intact
 		expect(contents['note.md']).toBe(
-			'![[part1.webm]]\n![[part2.webm]] middle [[part1.webm]]\n[[part2.webm]] end',
+			'![[part1.webm]] ![[part2.webm]] middle [[part1.webm]] [[part2.webm]] end',
 		);
 	});
 
@@ -586,7 +630,7 @@ describe('updateLinksInVault', () => {
 			'replace',
 		);
 
-		expect(updated).toBe(0);
+		expect(updated.updatedNotes).toBe(0);
 		expect(processMock).not.toHaveBeenCalled();
 	});
 
@@ -605,7 +649,7 @@ describe('updateLinksInVault', () => {
 			'replace',
 		);
 
-		expect(updated).toBe(0);
+		expect(updated.updatedNotes).toBe(0);
 		expect(processMock).not.toHaveBeenCalled();
 	});
 
@@ -658,9 +702,149 @@ describe('updateLinksInVault', () => {
 			'replace',
 		);
 
-		expect(updated).toBe(1);
+		expect(updated.updatedNotes).toBe(1);
+		expect(updated.skippedReferences).toBe(1);
 		expect(contents['good.md']).toBe('![[new.webm]]');
 		expect(contents['stale.md']).toBe(staleContent);
 		warnSpy.mockRestore();
+	});
+
+	it('should keep a table row on one line when replacing an embed inside it', async () => {
+		const source = createFile('rec.webm');
+		const content = '| ![[rec.webm]] | comment |';
+		const { app, contents, generateMarkdownLink } = createVaultApp(
+			{ 'note.md': { 'rec.webm': 1 } },
+			{
+				'note.md': {
+					content,
+					embeds: [
+						createReference(content, '![[rec.webm]]', 'rec.webm'),
+					],
+				},
+			},
+			{ 'rec.webm': source },
+		);
+		generateMarkdownLink.mockImplementation(
+			(file: TFile) => `[[${file.name}]]`,
+		);
+
+		const updated = await updateLinksInVault(
+			app,
+			source,
+			[createFile('p1.webm'), createFile('p2.webm')],
+			'replace',
+		);
+
+		expect(updated.updatedNotes).toBe(1);
+		expect(contents['note.md']).toBe(
+			'| ![[p1.webm]] ![[p2.webm]] | comment |',
+		);
+	});
+
+	it('should keep a table row on one line for the after action', async () => {
+		const source = createFile('rec.webm');
+		const content = '| ![[rec.webm]] |';
+		const { app, contents, generateMarkdownLink } = createVaultApp(
+			{ 'note.md': { 'rec.webm': 1 } },
+			{
+				'note.md': {
+					content,
+					embeds: [
+						createReference(content, '![[rec.webm]]', 'rec.webm'),
+					],
+				},
+			},
+			{ 'rec.webm': source },
+		);
+		generateMarkdownLink.mockReturnValue('![[new.webm]]');
+
+		const updated = await updateLinksInVault(
+			app,
+			source,
+			[createFile('new.webm')],
+			'after',
+		);
+
+		expect(updated.updatedNotes).toBe(1);
+		expect(contents['note.md']).toBe('| ![[rec.webm]] ![[new.webm]] |');
+	});
+
+	it('should use one link per line when the embed is alone on its line', async () => {
+		const source = createFile('rec.webm');
+		const content = 'intro\n![[rec.webm]]\noutro';
+		const { app, contents, generateMarkdownLink } = createVaultApp(
+			{ 'note.md': { 'rec.webm': 1 } },
+			{
+				'note.md': {
+					content,
+					embeds: [
+						createReference(content, '![[rec.webm]]', 'rec.webm'),
+					],
+				},
+			},
+			{ 'rec.webm': source },
+		);
+		generateMarkdownLink.mockImplementation(
+			(file: TFile) => `[[${file.name}]]`,
+		);
+
+		const updated = await updateLinksInVault(
+			app,
+			source,
+			[createFile('p1.webm'), createFile('p2.webm')],
+			'replace',
+		);
+
+		expect(updated.updatedNotes).toBe(1);
+		expect(contents['note.md']).toBe(
+			'intro\n![[p1.webm]]\n![[p2.webm]]\noutro',
+		);
+	});
+
+	it('should count frontmatter references without touching them', async () => {
+		const source = createFile('rec.webm');
+		const bodyContent = '---\naudio: "[[rec.webm]]"\n---\n![[rec.webm]]';
+		const { app, contents, generateMarkdownLink } = createVaultApp(
+			{
+				'note.md': { 'rec.webm': 2 },
+				'fm-only.md': { 'rec.webm': 1 },
+			},
+			{
+				'note.md': {
+					content: bodyContent,
+					embeds: [
+						createReference(
+							bodyContent,
+							'![[rec.webm]]',
+							'rec.webm',
+						),
+					],
+					frontmatterLinks: [{ link: 'rec.webm' }],
+				},
+				'fm-only.md': {
+					content: '---\naudio: "[[rec.webm]]"\n---\n',
+					frontmatterLinks: [{ link: 'rec.webm' }],
+				},
+			},
+			{ 'rec.webm': source },
+		);
+		generateMarkdownLink.mockReturnValue('![[new.webm]]');
+
+		const updated = await updateLinksInVault(
+			app,
+			source,
+			[createFile('new.webm')],
+			'replace',
+		);
+
+		expect(updated.updatedNotes).toBe(1);
+		expect(updated.frontmatterReferences).toBe(2);
+		// The body embed is rewritten, the frontmatter stays untouched
+		expect(contents['note.md']).toBe(
+			'---\naudio: "[[rec.webm]]"\n---\n![[new.webm]]',
+		);
+		expect(contents['fm-only.md']).toBe(
+			'---\naudio: "[[rec.webm]]"\n---\n',
+		);
 	});
 });

--- a/tests/unit/LinkUpdater.test.ts
+++ b/tests/unit/LinkUpdater.test.ts
@@ -19,6 +19,10 @@ jest.mock('obsidian', () => ({
 		path = '';
 		name = '';
 	},
+	getLinkpath: (linktext: string): string => {
+		const hashIndex = linktext.indexOf('#');
+		return hashIndex === -1 ? linktext : linktext.slice(0, hashIndex);
+	},
 }));
 
 /**
@@ -187,138 +191,476 @@ describe('updateLinksInOpenEditors', () => {
 });
 
 describe('updateLinksInVault', () => {
-	function createSourceFile(path: string, name: string): TFile {
+	/**
+	 * Minimal reference cache double carrying only the fields
+	 * updateLinksInVault reads (link text, original text, offsets).
+	 */
+	interface ReferenceDouble {
+		link: string;
+		original: string;
+		position: { start: { offset: number }; end: { offset: number } };
+	}
+
+	/**
+	 * Note entry for the vault double: raw content plus the parsed
+	 * references the metadata cache would report for it.
+	 */
+	interface VaultNoteEntry {
+		content: string;
+		links?: ReferenceDouble[];
+		embeds?: ReferenceDouble[];
+	}
+
+	/**
+	 * Handles the tests assert against after building the app double.
+	 */
+	interface VaultAppDouble {
+		app: App;
+		contents: Record<string, string>;
+		processMock: jest.Mock;
+		generateMarkdownLink: jest.Mock;
+	}
+
+	/**
+	 * Creates a TFile instance (of the mocked class) with path and name set.
+	 */
+	function createFile(path: string): TFile {
 		const file = new TFile();
-		(file as unknown as { path: string; name: string }).path = path;
-		(file as unknown as { path: string; name: string }).name = name;
+		const writable = file as unknown as { path: string; name: string };
+		writable.path = path;
+		writable.name = path.split('/').pop() ?? path;
 		return file;
 	}
 
-	function createVaultApp(
-		resolvedLinks: Record<string, Record<string, number>>,
-		noteContents: Record<string, string>,
-	): { app: App; processedContents: Record<string, string> } {
-		const processedContents: Record<string, string> = {
-			...noteContents,
-		};
-		const app = {
-			metadataCache: { resolvedLinks },
-			vault: {
-				getAbstractFileByPath: jest.fn((path: string) => {
-					if (path in noteContents) {
-						return createSourceFile(path, path);
-					}
-					return null;
-				}),
-				process: jest.fn(
-					async (
-						note: TFile,
-						transform: (content: string) => string,
-					) => {
-						const path = note.path;
-						processedContents[path] = transform(
-							processedContents[path],
-						);
-						return processedContents[path];
-					},
-				),
+	/**
+	 * Builds a reference whose offsets point at the given occurrence of
+	 * the original text inside the note content, so the defensive
+	 * stale-cache check in updateLinksInVault passes.
+	 */
+	function createReference(
+		content: string,
+		original: string,
+		link: string,
+		occurrence = 0,
+	): ReferenceDouble {
+		let start = -1;
+		for (let i = 0; i <= occurrence; i++) {
+			start = content.indexOf(original, start + 1);
+		}
+		return {
+			link,
+			original,
+			position: {
+				start: { offset: start },
+				end: { offset: start + original.length },
 			},
-		} as unknown as App;
-		return { app, processedContents };
+		};
 	}
 
-	it('should rewrite links in every referencing note', async () => {
-		const source = createSourceFile('audio/rec.webm', 'rec.webm');
-		const { app, processedContents } = createVaultApp(
+	/**
+	 * Builds an App double wired the way updateLinksInVault expects:
+	 * resolvedLinks drives note discovery, getFileCache serves the
+	 * parsed references, getFirstLinkpathDest resolves link paths via
+	 * the provided map, and vault.process applies the transform to the
+	 * in-memory contents.
+	 */
+	function createVaultApp(
+		resolvedLinks: Record<string, Record<string, number>>,
+		notes: Record<string, VaultNoteEntry>,
+		linkTargets: Record<string, TFile>,
+	): VaultAppDouble {
+		const contents: Record<string, string> = {};
+		for (const [path, entry] of Object.entries(notes)) {
+			contents[path] = entry.content;
+		}
+		const generateMarkdownLink = jest.fn();
+		const processMock = jest.fn(
+			async (note: TFile, transform: (content: string) => string) => {
+				contents[note.path] = transform(contents[note.path]);
+			},
+		);
+		const app = {
+			metadataCache: {
+				resolvedLinks,
+				getFileCache: jest.fn((note: TFile) => {
+					const entry = notes[note.path];
+					if (!entry.links && !entry.embeds) {
+						return null;
+					}
+					return { links: entry.links, embeds: entry.embeds };
+				}),
+				getFirstLinkpathDest: jest.fn(
+					(linkpath: string) => linkTargets[linkpath] ?? null,
+				),
+			},
+			vault: {
+				getAbstractFileByPath: jest.fn((path: string) =>
+					path in notes ? createFile(path) : null,
+				),
+				process: processMock,
+			},
+			fileManager: { generateMarkdownLink },
+		} as unknown as App;
+		return { app, contents, processMock, generateMarkdownLink };
+	}
+
+	it('should replace a wikilink embed and preserve the embed prefix', async () => {
+		const source = createFile('audio/rec.webm');
+		const content = 'intro ![[rec.webm]] outro';
+		const { app, contents, generateMarkdownLink } = createVaultApp(
 			{
-				'note1.md': { 'audio/rec.webm': 1 },
-				'note2.md': { 'other.webm': 1 },
-				'note3.md': { 'audio/rec.webm': 2 },
+				'note.md': { 'audio/rec.webm': 1 },
+				'unrelated.md': { 'other.webm': 1 },
 			},
 			{
-				'note1.md': 'intro ![[rec.webm]] outro',
-				'note2.md': '![[other.webm]]',
-				'note3.md': '[[rec.webm|alias]] and ![[audio/rec.webm]]',
+				'note.md': {
+					content,
+					embeds: [
+						createReference(content, '![[rec.webm]]', 'rec.webm'),
+					],
+				},
 			},
+			{ 'rec.webm': source },
+		);
+		generateMarkdownLink.mockImplementation(
+			(file: TFile) => `[[${file.name}]]`,
 		);
 
 		const updated = await updateLinksInVault(
 			app,
 			source,
-			['rec-part1.webm', 'rec-part2.webm'],
+			[
+				createFile('audio/rec-part1.webm'),
+				createFile('audio/rec-part2.webm'),
+			],
 			'replace',
 		);
 
-		expect(updated).toBe(2);
-		expect(processedContents['note1.md']).toBe(
+		expect(updated).toBe(1);
+		expect(contents['note.md']).toBe(
 			'intro ![[rec-part1.webm]]\n![[rec-part2.webm]] outro',
 		);
-		expect(processedContents['note2.md']).toBe('![[other.webm]]');
-		expect(processedContents['note3.md']).toBe(
-			'[[rec-part1.webm]]\n[[rec-part2.webm]] and ![[rec-part1.webm]]\n![[rec-part2.webm]]',
+		expect(generateMarkdownLink).toHaveBeenCalledWith(
+			expect.objectContaining({ path: 'audio/rec-part1.webm' }),
+			'note.md',
 		);
 	});
 
-	it('should append links for the after action', async () => {
-		const source = createSourceFile('rec.webm', 'rec.webm');
-		const { app, processedContents } = createVaultApp(
+	it('should strip the embed prefix for non-embed wikilinks', async () => {
+		const source = createFile('rec.webm');
+		const content = 'see [[rec.webm]] here';
+		const { app, contents, generateMarkdownLink } = createVaultApp(
 			{ 'note.md': { 'rec.webm': 1 } },
-			{ 'note.md': '![[rec.webm]]' },
+			{
+				'note.md': {
+					content,
+					links: [
+						createReference(content, '[[rec.webm]]', 'rec.webm'),
+					],
+				},
+			},
+			{ 'rec.webm': source },
+		);
+		// generateMarkdownLink embeds media files by default; the plain
+		// link in the note must stay a plain link
+		generateMarkdownLink.mockReturnValue('![[new.webm]]');
+
+		const updated = await updateLinksInVault(
+			app,
+			source,
+			[createFile('new.webm')],
+			'replace',
 		);
 
-		await updateLinksInVault(app, source, ['new.webm'], 'after');
-
-		expect(processedContents['note.md']).toBe(
-			'![[rec.webm]]\n![[new.webm]]',
-		);
+		expect(updated).toBe(1);
+		expect(contents['note.md']).toBe('see [[new.webm]] here');
 	});
 
-	it('should return zero and skip processing for the none action', async () => {
-		const source = createSourceFile('rec.webm', 'rec.webm');
-		const { app } = createVaultApp(
+	it('should rewrite Markdown-style embeds', async () => {
+		const source = createFile('rec.webm');
+		const content = 'audio: ![](rec.webm)';
+		const { app, contents, generateMarkdownLink } = createVaultApp(
 			{ 'note.md': { 'rec.webm': 1 } },
-			{ 'note.md': '![[rec.webm]]' },
+			{
+				'note.md': {
+					content,
+					embeds: [
+						createReference(content, '![](rec.webm)', 'rec.webm'),
+					],
+				},
+			},
+			{ 'rec.webm': source },
+		);
+		generateMarkdownLink.mockReturnValue('![](new.webm)');
+
+		const updated = await updateLinksInVault(
+			app,
+			source,
+			[createFile('new.webm')],
+			'replace',
+		);
+
+		expect(updated).toBe(1);
+		expect(contents['note.md']).toBe('audio: ![](new.webm)');
+	});
+
+	it('should leave references resolving to other files untouched', async () => {
+		const source = createFile('rec.webm');
+		const other = createFile('other.webm');
+		const content = '![[other.webm]] and ![[ghost.webm]]';
+		const { app, contents, processMock } = createVaultApp(
+			{ 'note.md': { 'rec.webm': 1 } },
+			{
+				'note.md': {
+					content,
+					embeds: [
+						createReference(
+							content,
+							'![[other.webm]]',
+							'other.webm',
+						),
+						createReference(
+							content,
+							'![[ghost.webm]]',
+							'ghost.webm',
+						),
+					],
+				},
+			},
+			// ghost.webm is deliberately unresolvable (returns null)
+			{ 'other.webm': other },
 		);
 
 		const updated = await updateLinksInVault(
 			app,
 			source,
-			['new.webm'],
-			'none',
-		);
-
-		expect(updated).toBe(0);
-		expect(app.vault.process).not.toHaveBeenCalled();
-	});
-
-	it('should skip notes that cannot be resolved to a file', async () => {
-		const source = createSourceFile('rec.webm', 'rec.webm');
-		const { app } = createVaultApp({ 'missing.md': { 'rec.webm': 1 } }, {});
-
-		const updated = await updateLinksInVault(
-			app,
-			source,
-			['new.webm'],
+			[createFile('new.webm')],
 			'replace',
 		);
 
 		expect(updated).toBe(0);
+		expect(processMock).not.toHaveBeenCalled();
+		expect(contents['note.md']).toBe(content);
 	});
 
-	it('should not count notes whose content did not change', async () => {
-		const source = createSourceFile('rec.webm', 'rec.webm');
-		const { app } = createVaultApp(
+	it('should append links below the original for the after action', async () => {
+		const source = createFile('rec.webm');
+		const content = '![[rec.webm]]';
+		const { app, contents, generateMarkdownLink } = createVaultApp(
 			{ 'note.md': { 'rec.webm': 1 } },
-			{ 'note.md': 'mentions rec.webm without a link' },
+			{
+				'note.md': {
+					content,
+					embeds: [
+						createReference(content, '![[rec.webm]]', 'rec.webm'),
+					],
+				},
+			},
+			{ 'rec.webm': source },
+		);
+		generateMarkdownLink.mockReturnValue('![[new.webm]]');
+
+		const updated = await updateLinksInVault(
+			app,
+			source,
+			[createFile('new.webm')],
+			'after',
+		);
+
+		expect(updated).toBe(1);
+		expect(contents['note.md']).toBe('![[rec.webm]]\n![[new.webm]]');
+	});
+
+	it('should return zero without processing for none action or empty file list', async () => {
+		const source = createFile('rec.webm');
+		const content = '![[rec.webm]]';
+		const { app, processMock } = createVaultApp(
+			{ 'note.md': { 'rec.webm': 1 } },
+			{
+				'note.md': {
+					content,
+					embeds: [
+						createReference(content, '![[rec.webm]]', 'rec.webm'),
+					],
+				},
+			},
+			{ 'rec.webm': source },
+		);
+
+		expect(
+			await updateLinksInVault(
+				app,
+				source,
+				[createFile('new.webm')],
+				'none',
+			),
+		).toBe(0);
+		expect(await updateLinksInVault(app, source, [], 'replace')).toBe(0);
+		expect(processMock).not.toHaveBeenCalled();
+	});
+
+	it('should skip stale references and warn instead of corrupting the note', async () => {
+		const warnSpy = jest
+			.spyOn(console, 'warn')
+			.mockImplementation(() => undefined);
+		const source = createFile('rec.webm');
+		const content = 'edited content ![[rec.webm]]';
+		// Offsets predate an edit, so the slice no longer matches original
+		const stale: ReferenceDouble = {
+			link: 'rec.webm',
+			original: '![[rec.webm]]',
+			position: { start: { offset: 0 }, end: { offset: 13 } },
+		};
+		const { app, contents, generateMarkdownLink } = createVaultApp(
+			{ 'note.md': { 'rec.webm': 1 } },
+			{ 'note.md': { content, embeds: [stale] } },
+			{ 'rec.webm': source },
+		);
+		generateMarkdownLink.mockReturnValue('![[new.webm]]');
+
+		const updated = await updateLinksInVault(
+			app,
+			source,
+			[createFile('new.webm')],
+			'replace',
+		);
+
+		expect(updated).toBe(0);
+		expect(contents['note.md']).toBe(content);
+		expect(warnSpy).toHaveBeenCalledTimes(1);
+		warnSpy.mockRestore();
+	});
+
+	it('should replace multiple references in one note from end to start', async () => {
+		const source = createFile('rec.webm');
+		const content = '![[rec.webm]] middle [[rec.webm#start|intro]] end';
+		const { app, contents, generateMarkdownLink } = createVaultApp(
+			{ 'note.md': { 'rec.webm': 2 } },
+			{
+				'note.md': {
+					content,
+					links: [
+						// Subpath link: getLinkpath must strip '#start'
+						createReference(
+							content,
+							'[[rec.webm#start|intro]]',
+							'rec.webm#start',
+						),
+					],
+					embeds: [
+						createReference(content, '![[rec.webm]]', 'rec.webm'),
+					],
+				},
+			},
+			{ 'rec.webm': source },
+		);
+		generateMarkdownLink.mockImplementation(
+			(file: TFile) => `[[${file.name}]]`,
 		);
 
 		const updated = await updateLinksInVault(
 			app,
 			source,
-			['new.webm'],
+			[createFile('part1.webm'), createFile('part2.webm')],
+			'replace',
+		);
+
+		expect(updated).toBe(1);
+		expect(contents['note.md']).toBe(
+			'![[part1.webm]]\n![[part2.webm]] middle [[part1.webm]]\n[[part2.webm]] end',
+		);
+	});
+
+	it('should skip referencing paths that do not resolve to a file', async () => {
+		const source = createFile('rec.webm');
+		const { app, processMock } = createVaultApp(
+			{ 'missing.md': { 'rec.webm': 1 } },
+			{},
+			{},
+		);
+
+		const updated = await updateLinksInVault(
+			app,
+			source,
+			[createFile('new.webm')],
 			'replace',
 		);
 
 		expect(updated).toBe(0);
+		expect(processMock).not.toHaveBeenCalled();
+	});
+
+	it('should skip notes whose metadata cache has no references', async () => {
+		const source = createFile('rec.webm');
+		const { app, processMock } = createVaultApp(
+			{ 'note.md': { 'rec.webm': 1 } },
+			{ 'note.md': { content: 'plain text mentioning rec.webm' } },
+			{ 'rec.webm': source },
+		);
+
+		const updated = await updateLinksInVault(
+			app,
+			source,
+			[createFile('new.webm')],
+			'replace',
+		);
+
+		expect(updated).toBe(0);
+		expect(processMock).not.toHaveBeenCalled();
+	});
+
+	it('should count only notes whose content changed', async () => {
+		const warnSpy = jest
+			.spyOn(console, 'warn')
+			.mockImplementation(() => undefined);
+		const source = createFile('rec.webm');
+		const goodContent = '![[rec.webm]]';
+		const staleContent = 'shifted ![[rec.webm]]';
+		const { app, contents, generateMarkdownLink } = createVaultApp(
+			{
+				'good.md': { 'rec.webm': 1 },
+				'stale.md': { 'rec.webm': 1 },
+			},
+			{
+				'good.md': {
+					content: goodContent,
+					embeds: [
+						createReference(
+							goodContent,
+							'![[rec.webm]]',
+							'rec.webm',
+						),
+					],
+				},
+				'stale.md': {
+					content: staleContent,
+					embeds: [
+						{
+							link: 'rec.webm',
+							original: '![[rec.webm]]',
+							// Offsets miss the shifted link on purpose
+							position: {
+								start: { offset: 0 },
+								end: { offset: 13 },
+							},
+						},
+					],
+				},
+			},
+			{ 'rec.webm': source },
+		);
+		generateMarkdownLink.mockReturnValue('![[new.webm]]');
+
+		const updated = await updateLinksInVault(
+			app,
+			source,
+			[createFile('new.webm')],
+			'replace',
+		);
+
+		expect(updated).toBe(1);
+		expect(contents['good.md']).toBe('![[new.webm]]');
+		expect(contents['stale.md']).toBe(staleContent);
+		warnSpy.mockRestore();
 	});
 });

--- a/tests/unit/RecordingManager.test.ts
+++ b/tests/unit/RecordingManager.test.ts
@@ -1740,6 +1740,9 @@ describe('RecordingManager', () => {
 			pendingWrite: Promise<void>;
 			partPaths: string[];
 			partIndex: number;
+			pcmBuffers: ArrayBuffer[];
+			pcmBufferedBytes: number;
+			partPcmBytes: number;
 		}
 
 		interface ManagerInternals {
@@ -1752,6 +1755,7 @@ describe('RecordingManager', () => {
 			stop: jest.Mock;
 			pause: jest.Mock;
 			resume: jest.Mock;
+			state: string;
 			ondataavailable: ((event: BlobEvent) => void) | null;
 			onerror: ((event: Event) => void) | null;
 			addEventListener: jest.Mock;
@@ -1804,6 +1808,7 @@ describe('RecordingManager', () => {
 				stop: jest.fn(),
 				pause: jest.fn(),
 				resume: jest.fn(),
+				state: 'recording',
 				ondataavailable: null,
 				onerror: null,
 				addEventListener: jest.fn(
@@ -2041,6 +2046,304 @@ describe('RecordingManager', () => {
 			// Recorders were restarted despite the failure
 			expect(global.MediaRecorder).toHaveBeenCalledTimes(2);
 			expect(manager.getStatus()).toBe(RecordingStatus.Recording);
+		});
+
+		it('should preserve buffered PCM audio when a part save fails', async () => {
+			createManagerWithSettings({
+				recordingFormat: 'wav',
+				autoSplitEnabled: true,
+				splitChunkMinutes: 1,
+			});
+			// Fail only the PCM segment write that backs the part assembly
+			(mockApp.vault.createBinary as jest.Mock).mockImplementation(
+				(path: string) =>
+					path.includes('-pcm-part')
+						? Promise.reject(new Error('disk full'))
+						: Promise.resolve(),
+			);
+
+			await manager.startRecording();
+
+			// Part limit: 1 min * 60 s * 44100 Hz * 1 ch * 2 B = 5,292,000 B
+			capturedPcmChunkCallback?.(new ArrayBuffer(6_000_000));
+			await getInternals(manager).chunkTargets[0].pendingWrite;
+
+			const { Notice } = jest.requireMock('obsidian');
+			expect(Notice).toHaveBeenCalledWith(
+				'Failed to save recording part. Recording continues; data is kept for the next part.',
+			);
+			const target = getInternals(manager).chunkTargets[0];
+			expect(target.partIndex).toBe(0);
+			expect(target.partPaths).toHaveLength(0);
+			// All captured bytes stay buffered: front portion plus the
+			// carry re-attached in capture order
+			const bufferedBytes = target.pcmBuffers.reduce(
+				(sum, buffer) => sum + buffer.byteLength,
+				0,
+			);
+			expect(bufferedBytes).toBe(6_000_000);
+			expect(target.pcmBufferedBytes).toBe(6_000_000);
+			// Part accounting restarts so the save is retried one part later
+			expect(target.partPcmBytes).toBe(0);
+
+			// Disk recovers: the preserved audio must reach the final file
+			(mockApp.vault.createBinary as jest.Mock).mockResolvedValue(
+				undefined,
+			);
+			await manager.stopRecording();
+
+			expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
+				expect.stringMatching(/\.wav$/),
+				expect.anything(),
+			);
+			const partWavCalls = (
+				mockApp.vault.createBinary as jest.Mock
+			).mock.calls.filter((call: unknown[]) =>
+				/-part\d+\.wav$/.test(String(call[0])),
+			);
+			expect(partWavCalls).toHaveLength(0);
+		});
+
+		it('should restart recorders before transcoding the rotated part', async () => {
+			jest.useFakeTimers();
+			jest.setSystemTime(0);
+			createManagerWithSettings({
+				recordingFormat: 'webm',
+				autoSplitEnabled: true,
+				splitChunkMinutes: 1,
+			});
+
+			// Shared log capturing recorder construction vs part writes
+			const callLog: string[] = [];
+			(global as Record<string, unknown>).MediaRecorder = jest.fn(() => {
+				callLog.push('recorder-created');
+				return mockMediaRecorder;
+			});
+			(global as Record<string, unknown>).MediaRecorder.isTypeSupported =
+				jest.fn().mockReturnValue(true);
+			(mockApp.vault.createBinary as jest.Mock).mockImplementation(
+				(path: string) => {
+					if (/-part1\.webm$/.test(path)) {
+						callLog.push('part-file-written');
+					}
+					return Promise.resolve();
+				},
+			);
+
+			await manager.startRecording();
+
+			jest.setSystemTime(61_000);
+			const chunk = new Blob([new Uint8Array([1, 2, 3])], {
+				type: 'audio/webm',
+			});
+			mockMediaRecorder.ondataavailable?.({ data: chunk } as BlobEvent);
+			await getInternals(manager).chunkTargets[0].pendingWrite;
+			await flushMicrotasks();
+			await getInternals(manager).rotationPromise;
+
+			// Restart (2nd construction) precedes the part file write so
+			// the capture gap excludes the transcoding time
+			expect(callLog).toEqual([
+				'recorder-created',
+				'recorder-created',
+				'part-file-written',
+			]);
+		});
+
+		it('should skip pausing recorders that are inactive during rotation', async () => {
+			createManagerWithSettings({
+				recordingFormat: 'webm',
+				autoSplitEnabled: true,
+				splitChunkMinutes: 1,
+			});
+
+			await manager.startRecording();
+
+			// Rotation window: recorders are momentarily stopped
+			mockMediaRecorder.state = 'inactive';
+			expect(() => manager.togglePauseResume()).not.toThrow();
+			expect(mockMediaRecorder.pause).not.toHaveBeenCalled();
+			expect(manager.getStatus()).toBe(RecordingStatus.Paused);
+
+			// Resume skips inactive recorders the same way
+			expect(() => manager.togglePauseResume()).not.toThrow();
+			expect(mockMediaRecorder.resume).not.toHaveBeenCalled();
+			expect(manager.getStatus()).toBe(RecordingStatus.Recording);
+
+			// Active recorders keep the normal pause path
+			mockMediaRecorder.state = 'recording';
+			manager.togglePauseResume();
+			expect(mockMediaRecorder.pause).toHaveBeenCalledTimes(1);
+			expect(manager.getStatus()).toBe(RecordingStatus.Paused);
+		});
+
+		it('should stop and salvage the session when recorder restart fails', async () => {
+			jest.useFakeTimers();
+			jest.setSystemTime(0);
+			createManagerWithSettings({
+				recordingFormat: 'webm',
+				autoSplitEnabled: true,
+				splitChunkMinutes: 1,
+			});
+
+			// The 2nd construction is the rotation restart; it fails as if
+			// the input device disappeared mid-session
+			let constructionCount = 0;
+			(global as Record<string, unknown>).MediaRecorder = jest.fn(() => {
+				constructionCount += 1;
+				if (constructionCount === 2) {
+					throw new Error('device disappeared');
+				}
+				return mockMediaRecorder;
+			});
+			(global as Record<string, unknown>).MediaRecorder.isTypeSupported =
+				jest.fn().mockReturnValue(true);
+
+			await manager.startRecording();
+
+			jest.setSystemTime(61_000);
+			const chunk = new Blob([new Uint8Array([1, 2, 3])], {
+				type: 'audio/webm',
+			});
+			mockMediaRecorder.ondataavailable?.({ data: chunk } as BlobEvent);
+			await getInternals(manager).chunkTargets[0].pendingWrite;
+			await flushMicrotasks();
+			await getInternals(manager).rotationPromise;
+
+			// The internally fired stopRecording is not awaitable from the
+			// outside; drain microtasks until its chain settles
+			for (let i = 0; i < 20; i++) {
+				if (manager.getStatus() === RecordingStatus.Idle) {
+					break;
+				}
+				await flushMicrotasks();
+			}
+
+			const { Notice } = jest.requireMock('obsidian');
+			expect(Notice).toHaveBeenCalledWith(
+				'Could not restart recording after saving a part. Stopping and saving the recording.',
+			);
+			// Session was salvaged: the part saved before the failure is
+			// kept and the session ends cleanly instead of going dead
+			expect(Notice).toHaveBeenCalledWith('Recording stopped');
+			expect(manager.getStatus()).toBe(RecordingStatus.Idle);
+		});
+
+		it('should keep the session output format when settings change mid-session', async () => {
+			jest.useFakeTimers();
+			jest.setSystemTime(0);
+			createManagerWithSettings({
+				recordingFormat: 'webm',
+				autoSplitEnabled: true,
+				splitChunkMinutes: 1,
+			});
+
+			await manager.startRecording();
+
+			// Settings change mid-session must not leak into the session
+			manager.updateSettings({ ...mockSettings, recordingFormat: 'ogg' });
+
+			jest.setSystemTime(61_000);
+			const chunk = new Blob([new Uint8Array([1, 2, 3])], {
+				type: 'audio/webm',
+			});
+			mockMediaRecorder.ondataavailable?.({ data: chunk } as BlobEvent);
+			await getInternals(manager).chunkTargets[0].pendingWrite;
+			await flushMicrotasks();
+			await getInternals(manager).rotationPromise;
+
+			expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
+				expect.stringMatching(/-part1\.webm$/),
+				expect.anything(),
+			);
+			const oggCalls = (
+				mockApp.vault.createBinary as jest.Mock
+			).mock.calls.filter((call: unknown[]) =>
+				String(call[0]).endsWith('.ogg'),
+			);
+			expect(oggCalls).toHaveLength(0);
+		});
+
+		it('should ignore a reentrant stopRecording call', async () => {
+			createManagerWithSettings({
+				recordingFormat: 'webm',
+				autoSplitEnabled: true,
+				splitChunkMinutes: 1,
+			});
+
+			await manager.startRecording();
+			const chunk = new Blob([new Uint8Array([1, 2, 3])], {
+				type: 'audio/webm',
+			});
+			mockMediaRecorder.ondataavailable?.({ data: chunk } as BlobEvent);
+			await getInternals(manager).chunkTargets[0].pendingWrite;
+
+			// Second concurrent call must return without a second save
+			const firstStop = manager.stopRecording();
+			const secondStop = manager.stopRecording();
+			await Promise.all([firstStop, secondStop]);
+
+			const { Notice } = jest.requireMock('obsidian');
+			const stopNotices = (Notice as jest.Mock).mock.calls.filter(
+				(call: unknown[]) => call[0] === 'Recording stopped',
+			);
+			expect(stopNotices).toHaveLength(1);
+			// Exactly one final track file write (segments end in .tmp)
+			const finalWrites = (
+				mockApp.vault.createBinary as jest.Mock
+			).mock.calls.filter((call: unknown[]) =>
+				/\.webm$/.test(String(call[0])),
+			);
+			expect(finalWrites).toHaveLength(1);
+		});
+
+		it('should stop cleanly while a rotation is in flight', async () => {
+			jest.useFakeTimers();
+			jest.setSystemTime(0);
+			createManagerWithSettings({
+				recordingFormat: 'webm',
+				autoSplitEnabled: true,
+				splitChunkMinutes: 1,
+			});
+
+			// Gate the rotation's segment flush so the stop request
+			// deterministically lands while the rotation is in flight
+			let releaseFlush: (() => void) | undefined;
+			const flushGate = new Promise<void>((resolve) => {
+				releaseFlush = resolve;
+			});
+			(mockApp.vault.createBinary as jest.Mock).mockImplementation(
+				(path: string) =>
+					path.endsWith('.tmp') ? flushGate : Promise.resolve(),
+			);
+
+			await manager.startRecording();
+
+			jest.setSystemTime(61_000);
+			const chunk = new Blob([new Uint8Array([1, 2, 3])], {
+				type: 'audio/webm',
+			});
+			mockMediaRecorder.ondataavailable?.({ data: chunk } as BlobEvent);
+			await getInternals(manager).chunkTargets[0].pendingWrite;
+			await flushMicrotasks();
+			expect(getInternals(manager).rotationPromise).not.toBeNull();
+
+			// The rotation already stopped the recorders; the stop call
+			// in this window must not throw or stop them a second time
+			mockMediaRecorder.state = 'inactive';
+			const stopPromise = manager.stopRecording();
+			releaseFlush?.();
+			await stopPromise;
+
+			// Stop won the race: capture was not restarted, the rotated
+			// part was still written, and the session ended cleanly
+			expect(global.MediaRecorder).toHaveBeenCalledTimes(1);
+			expect(mockMediaRecorder.stop).toHaveBeenCalledTimes(1);
+			expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
+				expect.stringMatching(/-part1\.webm$/),
+				expect.anything(),
+			);
+			expect(manager.getStatus()).toBe(RecordingStatus.Idle);
 		});
 	});
 });

--- a/tests/unit/RecordingManager.test.ts
+++ b/tests/unit/RecordingManager.test.ts
@@ -1734,4 +1734,313 @@ describe('RecordingManager', () => {
 			expect(context).toBeNull();
 		});
 	});
+
+	describe('auto-split', () => {
+		interface TargetInternals {
+			pendingWrite: Promise<void>;
+			partPaths: string[];
+			partIndex: number;
+		}
+
+		interface ManagerInternals {
+			chunkTargets: TargetInternals[];
+			rotationPromise: Promise<void> | null;
+		}
+
+		let mockMediaRecorder: {
+			start: jest.Mock;
+			stop: jest.Mock;
+			pause: jest.Mock;
+			resume: jest.Mock;
+			ondataavailable: ((event: BlobEvent) => void) | null;
+			onerror: ((event: Event) => void) | null;
+			addEventListener: jest.Mock;
+		};
+
+		function getInternals(instance: RecordingManager): ManagerInternals {
+			return instance as unknown as ManagerInternals;
+		}
+
+		/**
+		 * Lets the voided handleChunk continuation run to completion so
+		 * rotationPromise is observable after awaiting pendingWrite.
+		 */
+		async function flushMicrotasks(): Promise<void> {
+			for (let i = 0; i < 10; i++) {
+				await Promise.resolve();
+			}
+		}
+
+		function createManagerWithSettings(
+			overrides: Partial<AudioRecorderSettings>,
+		): void {
+			mockSettings = { ...DEFAULT_SETTINGS, ...overrides };
+			manager = new RecordingManager(
+				mockApp,
+				mockSettings,
+				statusChangeCallback,
+			);
+		}
+
+		function setupStreams(count: number): void {
+			const { getAudioStreams } = jest.requireMock(
+				'../../src/recording/AudioStreamHandler',
+			);
+			getAudioStreams.mockResolvedValue({
+				streams: Array.from({ length: count }, () => ({
+					getTracks: () => [{ stop: jest.fn() }],
+				})),
+				trackOrder: [],
+			});
+		}
+
+		beforeEach(() => {
+			const { Platform } = jest.requireMock('obsidian');
+			Platform.isMobile = false;
+			Platform.isMobileApp = false;
+
+			mockMediaRecorder = {
+				start: jest.fn(),
+				stop: jest.fn(),
+				pause: jest.fn(),
+				resume: jest.fn(),
+				ondataavailable: null,
+				onerror: null,
+				addEventListener: jest.fn(
+					(event: string, handler: () => void) => {
+						if (event === 'stop') {
+							handler();
+						}
+					},
+				),
+			};
+
+			(global as Record<string, unknown>).MediaRecorder = jest.fn(
+				() => mockMediaRecorder,
+			);
+			(global as Record<string, unknown>).MediaRecorder.isTypeSupported =
+				jest.fn().mockReturnValue(true);
+
+			setupStreams(1);
+
+			(mockApp.vault.adapter.readBinary as jest.Mock).mockResolvedValue(
+				new Uint8Array([1, 2, 3]).buffer,
+			);
+		});
+
+		afterEach(() => {
+			jest.useRealTimers();
+		});
+
+		it('should save PCM parts at byte boundaries and a residual part at stop', async () => {
+			createManagerWithSettings({
+				recordingFormat: 'wav',
+				autoSplitEnabled: true,
+				splitChunkMinutes: 1,
+			});
+
+			await manager.startRecording();
+
+			// Part limit: 1 min * 60 s * 44100 Hz * 1 ch * 2 B = 5,292,000 B
+			capturedPcmChunkCallback?.(new ArrayBuffer(3_000_000));
+			await getInternals(manager).chunkTargets[0].pendingWrite;
+			capturedPcmChunkCallback?.(new ArrayBuffer(3_000_000));
+			await getInternals(manager).chunkTargets[0].pendingWrite;
+
+			expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
+				expect.stringMatching(/-part1\.wav$/),
+				expect.anything(),
+			);
+			const target = getInternals(manager).chunkTargets[0];
+			expect(target.partIndex).toBe(1);
+			expect(target.partPaths).toHaveLength(1);
+
+			await manager.stopRecording();
+
+			// The 708,000-byte carry becomes the residual second part
+			expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
+				expect.stringMatching(/-part2\.wav$/),
+				expect.anything(),
+			);
+		});
+
+		it('should not split PCM recordings when auto-split is disabled', async () => {
+			createManagerWithSettings({
+				recordingFormat: 'wav',
+				autoSplitEnabled: false,
+				splitChunkMinutes: 1,
+			});
+
+			await manager.startRecording();
+
+			capturedPcmChunkCallback?.(new ArrayBuffer(6_000_000));
+			await getInternals(manager).chunkTargets[0].pendingWrite;
+
+			const partCalls = (
+				mockApp.vault.createBinary as jest.Mock
+			).mock.calls.filter((call: unknown[]) =>
+				/-part\d+\.wav$/.test(String(call[0])),
+			);
+			expect(partCalls).toHaveLength(0);
+		});
+
+		it('should use the configured suffix for PCM part files', async () => {
+			createManagerWithSettings({
+				recordingFormat: 'wav',
+				autoSplitEnabled: true,
+				splitChunkMinutes: 1,
+				splitPartSuffix: 'chunk',
+			});
+
+			await manager.startRecording();
+
+			capturedPcmChunkCallback?.(new ArrayBuffer(6_000_000));
+			await getInternals(manager).chunkTargets[0].pendingWrite;
+
+			expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
+				expect.stringMatching(/-chunk1\.wav$/),
+				expect.anything(),
+			);
+		});
+
+		it('should rotate MediaRecorder parts after the configured duration', async () => {
+			jest.useFakeTimers();
+			jest.setSystemTime(0);
+			createManagerWithSettings({
+				recordingFormat: 'webm',
+				autoSplitEnabled: true,
+				splitChunkMinutes: 1,
+			});
+
+			await manager.startRecording();
+			expect(global.MediaRecorder).toHaveBeenCalledTimes(1);
+
+			jest.setSystemTime(61_000);
+			const chunk = new Blob([new Uint8Array([1, 2, 3])], {
+				type: 'audio/webm',
+			});
+			mockMediaRecorder.ondataavailable?.({ data: chunk } as BlobEvent);
+			await getInternals(manager).chunkTargets[0].pendingWrite;
+			await flushMicrotasks();
+
+			const rotation = getInternals(manager).rotationPromise;
+			expect(rotation).not.toBeNull();
+			await rotation;
+
+			// Part finalized as a real file and recorders restarted
+			expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
+				expect.stringMatching(/-part1\.webm$/),
+				expect.anything(),
+			);
+			expect(global.MediaRecorder).toHaveBeenCalledTimes(2);
+			expect(
+				getInternals(manager).chunkTargets[0].partPaths,
+			).toHaveLength(1);
+
+			// Residual data recorded after rotation becomes the next part
+			jest.setSystemTime(70_000);
+			mockMediaRecorder.ondataavailable?.({ data: chunk } as BlobEvent);
+			await getInternals(manager).chunkTargets[0].pendingWrite;
+			await manager.stopRecording();
+
+			expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
+				expect.stringMatching(/-part2\.webm$/),
+				expect.anything(),
+			);
+		});
+
+		it('should not count paused time toward the part duration', async () => {
+			jest.useFakeTimers();
+			jest.setSystemTime(0);
+			createManagerWithSettings({
+				recordingFormat: 'webm',
+				autoSplitEnabled: true,
+				splitChunkMinutes: 1,
+			});
+
+			await manager.startRecording();
+
+			jest.setSystemTime(30_000);
+			manager.togglePauseResume();
+			jest.setSystemTime(130_000);
+			manager.togglePauseResume();
+
+			// Active time is 30 s + 10 s = 40 s, below the 60 s boundary
+			jest.setSystemTime(140_000);
+			const chunk = new Blob([new Uint8Array([1, 2, 3])], {
+				type: 'audio/webm',
+			});
+			mockMediaRecorder.ondataavailable?.({ data: chunk } as BlobEvent);
+			await getInternals(manager).chunkTargets[0].pendingWrite;
+			await flushMicrotasks();
+			expect(getInternals(manager).rotationPromise).toBeNull();
+
+			// Active time reaches 30 s + 35 s = 65 s, beyond the boundary
+			jest.setSystemTime(165_000);
+			mockMediaRecorder.ondataavailable?.({ data: chunk } as BlobEvent);
+			await getInternals(manager).chunkTargets[0].pendingWrite;
+			await flushMicrotasks();
+
+			const rotation = getInternals(manager).rotationPromise;
+			expect(rotation).not.toBeNull();
+			await rotation;
+			expect(global.MediaRecorder).toHaveBeenCalledTimes(2);
+		});
+
+		it('should skip auto-split for merged multi-track recordings', async () => {
+			setupStreams(2);
+			createManagerWithSettings({
+				recordingFormat: 'webm',
+				autoSplitEnabled: true,
+				splitChunkMinutes: 1,
+				outputMode: 'single',
+			});
+
+			await manager.startRecording();
+
+			const { Notice } = jest.requireMock('obsidian');
+			expect(Notice).toHaveBeenCalledWith(
+				'Auto-split is skipped for merged multi-track recordings.',
+			);
+		});
+
+		it('should keep recording when part finalization fails', async () => {
+			jest.useFakeTimers();
+			jest.setSystemTime(0);
+			createManagerWithSettings({
+				recordingFormat: 'webm',
+				autoSplitEnabled: true,
+				splitChunkMinutes: 1,
+			});
+			// Fail only the final part write; segment (.tmp) writes succeed
+			(mockApp.vault.createBinary as jest.Mock).mockImplementation(
+				(path: string) =>
+					/-part1\.webm$/.test(path)
+						? Promise.reject(new Error('disk full'))
+						: Promise.resolve(),
+			);
+
+			await manager.startRecording();
+
+			jest.setSystemTime(61_000);
+			const chunk = new Blob([new Uint8Array([1, 2, 3])], {
+				type: 'audio/webm',
+			});
+			mockMediaRecorder.ondataavailable?.({ data: chunk } as BlobEvent);
+			await getInternals(manager).chunkTargets[0].pendingWrite;
+			await flushMicrotasks();
+			await getInternals(manager).rotationPromise;
+
+			const { Notice } = jest.requireMock('obsidian');
+			expect(Notice).toHaveBeenCalledWith(
+				'Failed to save recording part. Recording continues; data is kept for the next part.',
+			);
+			const target = getInternals(manager).chunkTargets[0];
+			expect(target.partIndex).toBe(0);
+			expect(target.partPaths).toHaveLength(0);
+			// Recorders were restarted despite the failure
+			expect(global.MediaRecorder).toHaveBeenCalledTimes(2);
+			expect(manager.getStatus()).toBe(RecordingStatus.Recording);
+		});
+	});
 });

--- a/tests/unit/RecordingManager.test.ts
+++ b/tests/unit/RecordingManager.test.ts
@@ -1908,6 +1908,83 @@ describe('RecordingManager', () => {
 			);
 		});
 
+		it('should notify that auto-split is unavailable on mobile', async () => {
+			const { Platform } = jest.requireMock('obsidian');
+			Platform.isMobile = true;
+			createManagerWithSettings({
+				recordingFormat: 'webm',
+				autoSplitEnabled: true,
+				splitChunkMinutes: 1,
+			});
+
+			await manager.startRecording();
+
+			const { Notice } = jest.requireMock('obsidian');
+			expect(Notice).toHaveBeenCalledWith(
+				'Auto-split is not available in the mobile app.',
+			);
+			await manager.stopRecording();
+		});
+
+		it('should keep the part file when segment cleanup fails', async () => {
+			createManagerWithSettings({
+				recordingFormat: 'wav',
+				autoSplitEnabled: true,
+				splitChunkMinutes: 1,
+			});
+			// Segment removal fails after the part file was assembled
+			(mockApp.vault.adapter.remove as jest.Mock).mockRejectedValue(
+				new Error('locked'),
+			);
+
+			await manager.startRecording();
+
+			capturedPcmChunkCallback?.(new ArrayBuffer(6_000_000));
+			await getInternals(manager).chunkTargets[0].pendingWrite;
+
+			// The assembled part is kept: the removed segments would
+			// otherwise be the only copy of the audio
+			const target = getInternals(manager).chunkTargets[0];
+			expect(target.partIndex).toBe(1);
+			expect(target.partPaths).toHaveLength(1);
+			const { Notice } = jest.requireMock('obsidian');
+			expect(Notice).toHaveBeenCalledWith(
+				expect.stringContaining(
+					'Recording saved, but temporary files could not be removed',
+				),
+			);
+			expect(manager.getStatus()).toBe(RecordingStatus.Recording);
+		});
+
+		it('should name the residual from the base name snapshotted at start', async () => {
+			createManagerWithSettings({
+				recordingFormat: 'wav',
+				autoSplitEnabled: true,
+				splitChunkMinutes: 1,
+			});
+
+			await manager.startRecording();
+
+			capturedPcmChunkCallback?.(new ArrayBuffer(6_000_000));
+			await getInternals(manager).chunkTargets[0].pendingWrite;
+
+			// Changing the prefix mid-session must not affect this session
+			manager.updateSettings({
+				...mockSettings,
+				filePrefix: 'changed',
+			});
+			await manager.stopRecording();
+
+			const residualCall = (
+				mockApp.vault.createBinary as jest.Mock
+			).mock.calls.find((call: unknown[]) =>
+				/-part2\.wav$/.test(String(call[0])),
+			);
+			expect(residualCall).toBeDefined();
+			expect(String(residualCall?.[0])).toContain('recording-');
+			expect(String(residualCall?.[0])).not.toContain('changed-');
+		});
+
 		it('should rotate MediaRecorder parts after the configured duration', async () => {
 			jest.useFakeTimers();
 			jest.setSystemTime(0);

--- a/tests/unit/Settings.test.ts
+++ b/tests/unit/Settings.test.ts
@@ -85,6 +85,22 @@ describe('Settings', () => {
 			expect(DEFAULT_SETTINGS.insertAtOriginalPosition).toBe(false);
 		});
 
+		it('should have auto-split disabled by default', () => {
+			expect(DEFAULT_SETTINGS.autoSplitEnabled).toBe(false);
+		});
+
+		it('should have 15-minute split parts by default', () => {
+			expect(DEFAULT_SETTINGS.splitChunkMinutes).toBe(15);
+		});
+
+		it('should have "part" as the default split suffix', () => {
+			expect(DEFAULT_SETTINGS.splitPartSuffix).toBe('part');
+		});
+
+		it('should have delete source after split disabled by default', () => {
+			expect(DEFAULT_SETTINGS.deleteSourceAfterSplit).toBe(false);
+		});
+
 		it('should be a complete AudioRecorderSettings object', () => {
 			const expectedKeys: (keyof AudioRecorderSettings)[] = [
 				'recordingFormat',
@@ -105,6 +121,12 @@ describe('Settings', () => {
 				'trackAudioSources',
 				'debug',
 				'insertAtOriginalPosition',
+				'deleteSourceAfterConversion',
+				'conversionLinkAction',
+				'autoSplitEnabled',
+				'splitChunkMinutes',
+				'splitPartSuffix',
+				'deleteSourceAfterSplit',
 			];
 
 			expectedKeys.forEach((key) => {
@@ -197,6 +219,10 @@ describe('Settings', () => {
 				insertAtOriginalPosition: true,
 				deleteSourceAfterConversion: false,
 				conversionLinkAction: 'after',
+				autoSplitEnabled: true,
+				splitChunkMinutes: 30,
+				splitPartSuffix: 'chunk',
+				deleteSourceAfterSplit: true,
 			};
 
 			const result = mergeSettings(fullSettings);

--- a/tests/unit/Settings.validation.test.ts
+++ b/tests/unit/Settings.validation.test.ts
@@ -106,6 +106,91 @@ describe('validateSettings', () => {
 		);
 	});
 
+	it('should throw when split part suffix contains illegal characters', () => {
+		const settings: AudioRecorderSettings = {
+			...DEFAULT_SETTINGS,
+			audioDeviceId: 'valid-device',
+			splitPartSuffix: 'pa/rt',
+		};
+		expect(() => validateSettings(settings)).toThrow(
+			SettingsValidationError,
+		);
+		expect(() => validateSettings(settings)).toThrow(
+			/Part suffix may contain only letters, digits, hyphens, and underscores/,
+		);
+	});
+
+	it('should throw when split part suffix is empty', () => {
+		const settings: AudioRecorderSettings = {
+			...DEFAULT_SETTINGS,
+			audioDeviceId: 'valid-device',
+			splitPartSuffix: '',
+		};
+		expect(() => validateSettings(settings)).toThrow(
+			SettingsValidationError,
+		);
+	});
+
+	it('should throw when auto-split is enabled with non-integer minutes', () => {
+		const settings: AudioRecorderSettings = {
+			...DEFAULT_SETTINGS,
+			audioDeviceId: 'valid-device',
+			autoSplitEnabled: true,
+			splitChunkMinutes: 2.5,
+		};
+		expect(() => validateSettings(settings)).toThrow(
+			SettingsValidationError,
+		);
+		expect(() => validateSettings(settings)).toThrow(
+			/Part duration must be an integer between 1 and 180 minutes/,
+		);
+	});
+
+	it('should throw when auto-split is enabled with zero minutes', () => {
+		const settings: AudioRecorderSettings = {
+			...DEFAULT_SETTINGS,
+			audioDeviceId: 'valid-device',
+			autoSplitEnabled: true,
+			splitChunkMinutes: 0,
+		};
+		expect(() => validateSettings(settings)).toThrow(
+			SettingsValidationError,
+		);
+	});
+
+	it('should throw when auto-split is enabled with minutes above the maximum', () => {
+		const settings: AudioRecorderSettings = {
+			...DEFAULT_SETTINGS,
+			audioDeviceId: 'valid-device',
+			autoSplitEnabled: true,
+			splitChunkMinutes: 181,
+		};
+		expect(() => validateSettings(settings)).toThrow(
+			SettingsValidationError,
+		);
+	});
+
+	it('should not validate split minutes when auto-split is disabled', () => {
+		const settings: AudioRecorderSettings = {
+			...DEFAULT_SETTINGS,
+			audioDeviceId: 'valid-device',
+			autoSplitEnabled: false,
+			splitChunkMinutes: 0,
+		};
+		expect(() => validateSettings(settings)).not.toThrow();
+	});
+
+	it('should pass validation with valid auto-split settings', () => {
+		const settings: AudioRecorderSettings = {
+			...DEFAULT_SETTINGS,
+			audioDeviceId: 'valid-device',
+			autoSplitEnabled: true,
+			splitChunkMinutes: 30,
+			splitPartSuffix: 'chunk_1-a',
+		};
+		expect(() => validateSettings(settings)).not.toThrow();
+	});
+
 	it('should pass validation with valid settings', () => {
 		const settings: AudioRecorderSettings = {
 			...DEFAULT_SETTINGS,

--- a/tests/unit/Settings.validation.test.ts
+++ b/tests/unit/Settings.validation.test.ts
@@ -170,14 +170,18 @@ describe('validateSettings', () => {
 		);
 	});
 
-	it('should not validate split minutes when auto-split is disabled', () => {
+	it('should validate split minutes even when auto-split is disabled', () => {
+		// The value is also the default part duration for manual splitting,
+		// so it must be valid regardless of the auto-split toggle
 		const settings: AudioRecorderSettings = {
 			...DEFAULT_SETTINGS,
 			audioDeviceId: 'valid-device',
 			autoSplitEnabled: false,
 			splitChunkMinutes: 0,
 		};
-		expect(() => validateSettings(settings)).not.toThrow();
+		expect(() => validateSettings(settings)).toThrow(
+			SettingsValidationError,
+		);
 	});
 
 	it('should pass validation with valid auto-split settings', () => {

--- a/tests/unit/SplitModal.test.ts
+++ b/tests/unit/SplitModal.test.ts
@@ -1,0 +1,675 @@
+/**
+ * Unit tests for SplitModal module.
+ * @module tests/unit/SplitModal.test
+ */
+/** @jest-environment jsdom */
+
+import { SplitModal } from '../../src/ui/SplitModal';
+import { App, Notice, TFile } from 'obsidian';
+import { createWavHeader } from '../../src/recording/WavEncoder';
+import { createMockAudioBuffer } from '../helpers/createMockAudioBuffer';
+import type { AudioRecorderSettings } from '../../src/settings/Settings';
+
+/**
+ * Extends an HTMLElement with Obsidian's custom DOM methods.
+ */
+function addObsidianDomMethods(el: HTMLElement): HTMLElement {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- augmenting HTMLElement with Obsidian DOM methods
+	(el as any).empty = function () {
+		while (this.firstChild) {
+			this.removeChild(this.firstChild);
+		}
+	};
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- augmenting HTMLElement with Obsidian DOM methods
+	(el as any).createEl = function (
+		tag: string,
+		opts?: { text?: string; cls?: string; attr?: Record<string, string> },
+	) {
+		const child = document.createElement(tag);
+		if (opts?.text) child.textContent = opts.text;
+		if (opts?.cls) child.className = opts.cls;
+		if (opts?.attr) {
+			for (const [k, v] of Object.entries(opts.attr)) {
+				child.setAttribute(k, v);
+			}
+		}
+		addObsidianDomMethods(child);
+		this.appendChild(child);
+		return child;
+	};
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- augmenting HTMLElement with Obsidian DOM methods
+	(el as any).createDiv = function (opts?: { cls?: string }) {
+		return this.createEl('div', opts);
+	};
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- augmenting HTMLElement with Obsidian DOM methods
+	(el as any).setText = function (text: string) {
+		this.textContent = text;
+	};
+	return el;
+}
+
+/** Captured UI control handlers, filled while onOpen runs. */
+const mockCapturedControls = {
+	sliders: [] as ((value: number) => void)[],
+	texts: [] as ((value: string) => void)[],
+	toggles: [] as ((value: boolean) => void)[],
+	dropdowns: [] as ((value: string) => void)[],
+	buttons: [] as { click: () => void; setDisabled: jest.Mock }[],
+};
+
+// Mock obsidian with interactive Setting components so that the
+// onChange/onClick wiring inside onOpen can be exercised by tests
+jest.mock('obsidian', () => ({
+	App: jest.fn(),
+	Modal: class {
+		app: unknown;
+		contentEl: HTMLElement;
+		constructor(app: unknown) {
+			this.app = app;
+			this.contentEl = addObsidianDomMethods(
+				document.createElement('div'),
+			);
+		}
+		open = jest.fn();
+		close = jest.fn();
+	},
+	Notice: jest.fn(),
+	Setting: jest.fn().mockImplementation(() => {
+		const chain = {
+			setName: jest.fn(),
+			setDesc: jest.fn(),
+			setHeading: jest.fn(),
+			addSlider: jest.fn(),
+			addText: jest.fn(),
+			addToggle: jest.fn(),
+			addDropdown: jest.fn(),
+			addButton: jest.fn(),
+		};
+		chain.setName.mockReturnValue(chain);
+		chain.setDesc.mockReturnValue(chain);
+		chain.setHeading.mockReturnValue(chain);
+		chain.addSlider.mockImplementation((cb: (slider: unknown) => void) => {
+			const slider = {
+				setLimits: jest.fn(),
+				setValue: jest.fn(),
+				setDynamicTooltip: jest.fn(),
+				onChange: jest.fn((handler: (value: number) => void) => {
+					mockCapturedControls.sliders.push(handler);
+					return slider;
+				}),
+			};
+			slider.setLimits.mockReturnValue(slider);
+			slider.setValue.mockReturnValue(slider);
+			slider.setDynamicTooltip.mockReturnValue(slider);
+			cb(slider);
+			return chain;
+		});
+		chain.addText.mockImplementation((cb: (text: unknown) => void) => {
+			const text = {
+				setPlaceholder: jest.fn(),
+				setValue: jest.fn(),
+				onChange: jest.fn((handler: (value: string) => void) => {
+					mockCapturedControls.texts.push(handler);
+					return text;
+				}),
+			};
+			text.setPlaceholder.mockReturnValue(text);
+			text.setValue.mockReturnValue(text);
+			cb(text);
+			return chain;
+		});
+		chain.addToggle.mockImplementation((cb: (toggle: unknown) => void) => {
+			const toggle = {
+				setValue: jest.fn(),
+				onChange: jest.fn((handler: (value: boolean) => void) => {
+					mockCapturedControls.toggles.push(handler);
+					return toggle;
+				}),
+			};
+			toggle.setValue.mockReturnValue(toggle);
+			cb(toggle);
+			return chain;
+		});
+		chain.addDropdown.mockImplementation(
+			(cb: (dropdown: unknown) => void) => {
+				const dropdown = {
+					addOption: jest.fn(),
+					setValue: jest.fn(),
+					onChange: jest.fn((handler: (value: string) => void) => {
+						mockCapturedControls.dropdowns.push(handler);
+						return dropdown;
+					}),
+				};
+				dropdown.addOption.mockReturnValue(dropdown);
+				dropdown.setValue.mockReturnValue(dropdown);
+				cb(dropdown);
+				return chain;
+			},
+		);
+		chain.addButton.mockImplementation((cb: (button: unknown) => void) => {
+			const setDisabled = jest.fn();
+			const button = {
+				setButtonText: jest.fn(),
+				setCta: jest.fn(),
+				setDisabled,
+				onClick: jest.fn((handler: () => void) => {
+					mockCapturedControls.buttons.push({
+						click: handler,
+						setDisabled,
+					});
+					return button;
+				}),
+			};
+			button.setButtonText.mockReturnValue(button);
+			button.setCta.mockReturnValue(button);
+			cb(button);
+			return chain;
+		});
+		return chain;
+	}),
+	TFile: jest.fn(),
+	normalizePath: (path: string) =>
+		path.replace(/\\/g, '/').replace(/\/+/g, '/'),
+}));
+
+// Mock AudioEncoder
+jest.mock('../../src/recording/AudioEncoder', () => ({
+	encodeAudioBuffer: jest
+		.fn()
+		.mockResolvedValue(new Blob(['encoded'], { type: 'audio/webm' })),
+	isOfflineEncodingSupported: jest.fn().mockReturnValue(true),
+	getEncoderDescription: jest.fn().mockReturnValue('Test Encoder'),
+}));
+
+// Mock AudioCapabilityDetector
+jest.mock('../../src/recording/AudioCapabilityDetector', () => ({
+	getSupportedBitrates: jest
+		.fn()
+		.mockReturnValue([64000, 96000, 128000, 192000, 256000, 320000]),
+}));
+
+// Mock the decoder: the compressed path decodes once via this function
+jest.mock('../../src/recording/AudioFormatConverter', () => ({
+	decodeAudioDataAtNativeRate: jest.fn(),
+}));
+
+// Mock the vault-wide link updater
+jest.mock('../../src/utils/LinkUpdater', () => ({
+	updateLinksInVault: jest.fn().mockResolvedValue(1),
+}));
+
+import { encodeAudioBuffer } from '../../src/recording/AudioEncoder';
+import { decodeAudioDataAtNativeRate } from '../../src/recording/AudioFormatConverter';
+import { updateLinksInVault } from '../../src/utils/LinkUpdater';
+
+/** WAV header size produced by createWavHeader. */
+const WAV_HEADER_SIZE = 44;
+
+/**
+ * Builds a complete in-memory WAV file for the lossless split path.
+ */
+function buildTestWav(
+	numChannels: number,
+	sampleRate: number,
+	dataBytes: number,
+): ArrayBuffer {
+	const header = createWavHeader(numChannels, sampleRate, dataBytes);
+	const wav = new Uint8Array(WAV_HEADER_SIZE + dataBytes);
+	wav.set(new Uint8Array(header), 0);
+	return wav.buffer;
+}
+
+/** Typed access to the private split pipeline. */
+interface SplitModalInternals {
+	runSplit(progressEl: HTMLElement): Promise<void>;
+	partMinutes: number;
+	partSuffix: string;
+	deleteSource: boolean;
+	linkAction: string;
+}
+
+function internals(modal: SplitModal): SplitModalInternals {
+	return modal as unknown as SplitModalInternals;
+}
+
+if (!Blob.prototype.arrayBuffer) {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- test polyfill
+	(Blob.prototype as any).arrayBuffer = function (): Promise<ArrayBuffer> {
+		return Promise.resolve(new ArrayBuffer(8));
+	};
+}
+
+describe('SplitModal', () => {
+	let mockApp: App;
+	let mockFile: TFile;
+	let progressEl: HTMLElement;
+	const mockSettings = {
+		splitChunkMinutes: 1,
+		splitPartSuffix: 'part',
+		bitrate: 128000,
+		deleteSourceAfterSplit: false,
+	} as unknown as AudioRecorderSettings;
+
+	/**
+	 * Configures the mock file as a WAV in a subdirectory.
+	 */
+	function configureFile(name: string, extension: string): void {
+		const basename = name.replace(`.${extension}`, '');
+		Object.defineProperty(mockFile, 'name', {
+			value: name,
+			configurable: true,
+		});
+		Object.defineProperty(mockFile, 'basename', {
+			value: basename,
+			configurable: true,
+		});
+		Object.defineProperty(mockFile, 'extension', {
+			value: extension,
+			configurable: true,
+		});
+		Object.defineProperty(mockFile, 'path', {
+			value: `Recordings/${name}`,
+			configurable: true,
+		});
+		Object.defineProperty(mockFile, 'parent', {
+			value: { path: 'Recordings' },
+			configurable: true,
+		});
+	}
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockCapturedControls.sliders.length = 0;
+		mockCapturedControls.texts.length = 0;
+		mockCapturedControls.toggles.length = 0;
+		mockCapturedControls.dropdowns.length = 0;
+		mockCapturedControls.buttons.length = 0;
+
+		// activeWindow is an Obsidian global; map it to the jsdom window
+		(global as Record<string, unknown>).activeWindow = window;
+
+		mockApp = {
+			vault: {
+				adapter: {
+					readBinary: jest.fn(),
+					exists: jest.fn().mockResolvedValue(false),
+					remove: jest.fn().mockResolvedValue(undefined),
+				},
+				createBinary: jest.fn().mockResolvedValue(undefined),
+			},
+			fileManager: {
+				trashFile: jest.fn().mockResolvedValue(undefined),
+			},
+		} as unknown as App;
+
+		mockFile = new TFile();
+		configureFile('recording.wav', 'wav');
+
+		progressEl = addObsidianDomMethods(document.createElement('div'));
+	});
+
+	it('should instantiate with defaults from settings', () => {
+		const modal = new SplitModal(mockApp, mockFile, mockSettings);
+
+		expect(internals(modal).partMinutes).toBe(1);
+		expect(internals(modal).partSuffix).toBe('part');
+		expect(internals(modal).deleteSource).toBe(false);
+		expect(internals(modal).linkAction).toBe('replace');
+	});
+
+	it('should fall back to the default suffix for an invalid configured suffix', () => {
+		const modal = new SplitModal(mockApp, mockFile, {
+			...mockSettings,
+			splitPartSuffix: 'bad/suffix',
+		} as unknown as AudioRecorderSettings);
+
+		expect(internals(modal).partSuffix).toBe('part');
+	});
+
+	it('should render source file info on open and clear on close', () => {
+		const modal = new SplitModal(mockApp, mockFile, mockSettings);
+		modal.onOpen();
+
+		const source = modal.contentEl.querySelector('.aar-split-source');
+		expect(source?.textContent).toContain('recording.wav');
+
+		modal.onClose();
+		expect(modal.contentEl.children.length).toBe(0);
+	});
+
+	it('should update split options from UI controls', () => {
+		const modal = new SplitModal(mockApp, mockFile, mockSettings);
+		modal.onOpen();
+
+		// WAV source: one slider, one suffix text, one delete toggle,
+		// one link-action dropdown (no bitrate dropdown)
+		expect(mockCapturedControls.dropdowns).toHaveLength(1);
+
+		mockCapturedControls.sliders[0](5);
+		expect(internals(modal).partMinutes).toBe(5);
+
+		mockCapturedControls.texts[0]('seg');
+		expect(internals(modal).partSuffix).toBe('seg');
+
+		mockCapturedControls.toggles[0](true);
+		expect(internals(modal).deleteSource).toBe(true);
+
+		mockCapturedControls.dropdowns[0]('after');
+		expect(internals(modal).linkAction).toBe('after');
+	});
+
+	it('should show the bitrate dropdown only for compressed sources', () => {
+		configureFile('recording.webm', 'webm');
+		const modal = new SplitModal(mockApp, mockFile, mockSettings);
+		modal.onOpen();
+
+		// Compressed source: bitrate dropdown plus link-action dropdown
+		expect(mockCapturedControls.dropdowns).toHaveLength(2);
+
+		mockCapturedControls.dropdowns[0]('192000');
+		expect((modal as unknown as { bitrate: number }).bitrate).toBe(192000);
+	});
+
+	it('should run the split when the split button is clicked', async () => {
+		(mockApp.vault.adapter.readBinary as jest.Mock).mockResolvedValue(
+			buildTestWav(1, 1000, 250000),
+		);
+		const modal = new SplitModal(mockApp, mockFile, mockSettings);
+		modal.onOpen();
+
+		const button = mockCapturedControls.buttons[0];
+		button.click();
+		// The click handler runs the async pipeline in the background
+		await new Promise((resolve) => setTimeout(resolve, 20));
+
+		expect(mockApp.vault.createBinary).toHaveBeenCalledTimes(3);
+		expect(button.setDisabled).toHaveBeenCalledWith(true);
+		expect(button.setDisabled).toHaveBeenLastCalledWith(false);
+	});
+
+	describe('WAV fast path', () => {
+		beforeEach(() => {
+			// 1000 Hz mono 16-bit: byteRate 2000 B/s; 1-minute part = 120000 B
+			(mockApp.vault.adapter.readBinary as jest.Mock).mockResolvedValue(
+				buildTestWav(1, 1000, 250000),
+			);
+		});
+
+		it('should split WAV bytes without decoding', async () => {
+			const modal = new SplitModal(mockApp, mockFile, mockSettings);
+
+			await internals(modal).runSplit(progressEl);
+
+			expect(decodeAudioDataAtNativeRate).not.toHaveBeenCalled();
+			expect(mockApp.vault.createBinary).toHaveBeenCalledTimes(3);
+			const paths = (
+				mockApp.vault.createBinary as jest.Mock
+			).mock.calls.map((call: unknown[]) => call[0]);
+			expect(paths).toEqual([
+				'Recordings/recording-part1.wav',
+				'Recordings/recording-part2.wav',
+				'Recordings/recording-part3.wav',
+			]);
+		});
+
+		it('should write standalone WAV parts with patched sizes', async () => {
+			const modal = new SplitModal(mockApp, mockFile, mockSettings);
+
+			await internals(modal).runSplit(progressEl);
+
+			const calls = (mockApp.vault.createBinary as jest.Mock).mock
+				.calls as [string, ArrayBuffer][];
+			const firstPart = calls[0][1];
+			const lastPart = calls[2][1];
+			expect(firstPart.byteLength).toBe(WAV_HEADER_SIZE + 120000);
+			expect(lastPart.byteLength).toBe(WAV_HEADER_SIZE + 10000);
+			expect(new DataView(lastPart).getUint32(40, true)).toBe(10000);
+		});
+
+		it('should update links in the vault with all part names', async () => {
+			const modal = new SplitModal(mockApp, mockFile, mockSettings);
+
+			await internals(modal).runSplit(progressEl);
+
+			expect(updateLinksInVault).toHaveBeenCalledWith(
+				mockApp,
+				mockFile,
+				[
+					'recording-part1.wav',
+					'recording-part2.wav',
+					'recording-part3.wav',
+				],
+				'replace',
+			);
+		});
+
+		it('should not update links for the none action', async () => {
+			const modal = new SplitModal(mockApp, mockFile, mockSettings);
+			internals(modal).linkAction = 'none';
+
+			await internals(modal).runSplit(progressEl);
+
+			expect(updateLinksInVault).not.toHaveBeenCalled();
+		});
+
+		it('should not delete the source by default', async () => {
+			const modal = new SplitModal(mockApp, mockFile, mockSettings);
+
+			await internals(modal).runSplit(progressEl);
+
+			expect(mockApp.fileManager.trashFile).not.toHaveBeenCalled();
+		});
+
+		it('should delete the source only after all parts are written', async () => {
+			const modal = new SplitModal(mockApp, mockFile, mockSettings);
+			internals(modal).deleteSource = true;
+
+			await internals(modal).runSplit(progressEl);
+
+			expect(mockApp.fileManager.trashFile).toHaveBeenCalledWith(
+				mockFile,
+			);
+			const lastWriteOrder = Math.max(
+				...(mockApp.vault.createBinary as jest.Mock).mock
+					.invocationCallOrder,
+			);
+			const trashOrder = (mockApp.fileManager.trashFile as jest.Mock).mock
+				.invocationCallOrder[0];
+			expect(trashOrder).toBeGreaterThan(lastWriteOrder);
+		});
+
+		it('should abort when a target part file already exists', async () => {
+			(mockApp.vault.adapter.exists as jest.Mock).mockImplementation(
+				(path: string) =>
+					Promise.resolve(path === 'Recordings/recording-part2.wav'),
+			);
+			const modal = new SplitModal(mockApp, mockFile, mockSettings);
+
+			await internals(modal).runSplit(progressEl);
+
+			expect(mockApp.vault.createBinary).not.toHaveBeenCalled();
+			expect(Notice).toHaveBeenCalledWith(
+				expect.stringContaining('already exists'),
+			);
+		});
+
+		it('should abort when the file is shorter than one part', async () => {
+			(mockApp.vault.adapter.readBinary as jest.Mock).mockResolvedValue(
+				buildTestWav(1, 1000, 60000),
+			);
+			const modal = new SplitModal(mockApp, mockFile, mockSettings);
+
+			await internals(modal).runSplit(progressEl);
+
+			expect(mockApp.vault.createBinary).not.toHaveBeenCalled();
+			expect(Notice).toHaveBeenCalledWith(
+				'File is shorter than one part.',
+			);
+		});
+
+		it('should remove written parts and keep the source when a write fails', async () => {
+			(mockApp.vault.createBinary as jest.Mock)
+				.mockResolvedValueOnce(undefined)
+				.mockRejectedValueOnce(new Error('disk full'));
+			const modal = new SplitModal(mockApp, mockFile, mockSettings);
+			internals(modal).deleteSource = true;
+
+			await internals(modal).runSplit(progressEl);
+
+			expect(mockApp.vault.adapter.remove).toHaveBeenCalledWith(
+				'Recordings/recording-part1.wav',
+			);
+			expect(mockApp.fileManager.trashFile).not.toHaveBeenCalled();
+			expect(Notice).toHaveBeenCalledWith(
+				expect.stringContaining('Split failed'),
+			);
+		});
+
+		it('should write parts next to a file in the vault root', async () => {
+			Object.defineProperty(mockFile, 'parent', {
+				value: null,
+				configurable: true,
+			});
+			const modal = new SplitModal(mockApp, mockFile, mockSettings);
+
+			await internals(modal).runSplit(progressEl);
+
+			expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
+				'recording-part1.wav',
+				expect.anything(),
+			);
+		});
+
+		it('should stringify non-Error failures', async () => {
+			(mockApp.vault.adapter.readBinary as jest.Mock).mockRejectedValue(
+				'raw failure',
+			);
+			const modal = new SplitModal(mockApp, mockFile, mockSettings);
+
+			await internals(modal).runSplit(progressEl);
+
+			expect(Notice).toHaveBeenCalledWith('Split failed: raw failure');
+		});
+
+		it('should log and continue when rollback of a written part fails', async () => {
+			(mockApp.vault.createBinary as jest.Mock)
+				.mockResolvedValueOnce(undefined)
+				.mockRejectedValueOnce(new Error('disk full'));
+			(mockApp.vault.adapter.remove as jest.Mock).mockRejectedValue(
+				new Error('locked'),
+			);
+			const consoleSpy = jest
+				.spyOn(console, 'error')
+				.mockImplementation(() => {});
+			const modal = new SplitModal(mockApp, mockFile, mockSettings);
+
+			await internals(modal).runSplit(progressEl);
+
+			expect(consoleSpy).toHaveBeenCalled();
+			expect(Notice).toHaveBeenCalledWith(
+				expect.stringContaining('Split failed'),
+			);
+			consoleSpy.mockRestore();
+		});
+	});
+
+	describe('compressed path', () => {
+		beforeEach(() => {
+			configureFile('recording.webm', 'webm');
+			(mockApp.vault.adapter.readBinary as jest.Mock).mockResolvedValue(
+				new ArrayBuffer(100),
+			);
+			// 150 s at 44100 Hz with 1-minute parts -> 3 parts
+			(decodeAudioDataAtNativeRate as jest.Mock).mockResolvedValue(
+				createMockAudioBuffer(1, 150 * 44100, 44100),
+			);
+			(global as Record<string, unknown>).AudioBuffer = class {
+				numberOfChannels: number;
+				length: number;
+				sampleRate: number;
+				constructor(options: {
+					numberOfChannels: number;
+					length: number;
+					sampleRate: number;
+				}) {
+					this.numberOfChannels = options.numberOfChannels;
+					this.length = options.length;
+					this.sampleRate = options.sampleRate;
+				}
+				copyToChannel = jest.fn();
+				getChannelData = jest.fn(() => new Float32Array(this.length));
+			};
+		});
+
+		it('should decode once and encode each part', async () => {
+			const modal = new SplitModal(mockApp, mockFile, mockSettings);
+
+			await internals(modal).runSplit(progressEl);
+
+			expect(decodeAudioDataAtNativeRate).toHaveBeenCalledTimes(1);
+			expect(encodeAudioBuffer).toHaveBeenCalledTimes(3);
+			expect(encodeAudioBuffer).toHaveBeenCalledWith(
+				expect.objectContaining({ length: 60 * 44100 }),
+				{ format: 'webm', bitrate: 128000 },
+			);
+			const paths = (
+				mockApp.vault.createBinary as jest.Mock
+			).mock.calls.map((call: unknown[]) => call[0]);
+			expect(paths).toEqual([
+				'Recordings/recording-part1.webm',
+				'Recordings/recording-part2.webm',
+				'Recordings/recording-part3.webm',
+			]);
+		});
+
+		it('should abort when the audio is shorter than one part', async () => {
+			(decodeAudioDataAtNativeRate as jest.Mock).mockResolvedValue(
+				createMockAudioBuffer(1, 30 * 44100, 44100),
+			);
+			const modal = new SplitModal(mockApp, mockFile, mockSettings);
+
+			await internals(modal).runSplit(progressEl);
+
+			expect(mockApp.vault.createBinary).not.toHaveBeenCalled();
+			expect(Notice).toHaveBeenCalledWith(
+				'File is shorter than one part.',
+			);
+		});
+
+		it('should fall back to WAV when the source format cannot be encoded', async () => {
+			const { isOfflineEncodingSupported } = jest.requireMock(
+				'../../src/recording/AudioEncoder',
+			);
+			(isOfflineEncodingSupported as jest.Mock).mockReturnValue(false);
+			const modal = new SplitModal(mockApp, mockFile, mockSettings);
+
+			await internals(modal).runSplit(progressEl);
+
+			expect(encodeAudioBuffer).toHaveBeenCalledWith(
+				expect.anything(),
+				expect.objectContaining({ format: 'wav' }),
+			);
+			const paths = (
+				mockApp.vault.createBinary as jest.Mock
+			).mock.calls.map((call: unknown[]) => call[0]);
+			expect(paths[0]).toBe('Recordings/recording-part1.wav');
+			expect(Notice).toHaveBeenCalledWith(
+				expect.stringContaining('parts are saved as WAV'),
+			);
+		});
+
+		it('should report errors from decoding', async () => {
+			(decodeAudioDataAtNativeRate as jest.Mock).mockRejectedValue(
+				new Error('decode failed'),
+			);
+			const modal = new SplitModal(mockApp, mockFile, mockSettings);
+
+			await internals(modal).runSplit(progressEl);
+
+			expect(Notice).toHaveBeenCalledWith(
+				expect.stringContaining('Split failed: decode failed'),
+			);
+			expect(mockApp.vault.createBinary).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/tests/unit/SplitModal.test.ts
+++ b/tests/unit/SplitModal.test.ts
@@ -52,6 +52,7 @@ function addObsidianDomMethods(el: HTMLElement): HTMLElement {
 const mockCapturedControls = {
 	sliders: [] as ((value: number) => void)[],
 	texts: [] as ((value: string) => void)[],
+	textInputs: [] as { toggleClass: jest.Mock }[],
 	toggles: [] as ((value: boolean) => void)[],
 	dropdowns: [] as ((value: string) => void)[],
 	buttons: [] as { click: () => void; setDisabled: jest.Mock }[],
@@ -106,10 +107,13 @@ jest.mock('obsidian', () => ({
 		});
 		chain.addText.mockImplementation((cb: (text: unknown) => void) => {
 			const text = {
+				// onChange validation feedback toggles a CSS class here
+				inputEl: { toggleClass: jest.fn() },
 				setPlaceholder: jest.fn(),
 				setValue: jest.fn(),
 				onChange: jest.fn((handler: (value: string) => void) => {
 					mockCapturedControls.texts.push(handler);
+					mockCapturedControls.textInputs.push(text.inputEl);
 					return text;
 				}),
 			};
@@ -219,6 +223,17 @@ function buildTestWav(
 	return wav.buffer;
 }
 
+/**
+ * Creates a TFile instance (of the mocked class) for a created part path,
+ * mirroring what vault.createBinary returns in production.
+ */
+function makePartFile(path: string): TFile {
+	const file = new TFile();
+	file.path = path;
+	file.name = path.split('/').pop() ?? path;
+	return file;
+}
+
 /** Typed access to the private split pipeline. */
 interface SplitModalInternals {
 	runSplit(progressEl: HTMLElement): Promise<void>;
@@ -281,6 +296,7 @@ describe('SplitModal', () => {
 		jest.clearAllMocks();
 		mockCapturedControls.sliders.length = 0;
 		mockCapturedControls.texts.length = 0;
+		mockCapturedControls.textInputs.length = 0;
 		mockCapturedControls.toggles.length = 0;
 		mockCapturedControls.dropdowns.length = 0;
 		mockCapturedControls.buttons.length = 0;
@@ -295,7 +311,12 @@ describe('SplitModal', () => {
 					exists: jest.fn().mockResolvedValue(false),
 					remove: jest.fn().mockResolvedValue(undefined),
 				},
-				createBinary: jest.fn().mockResolvedValue(undefined),
+				// createBinary returns the created TFile, like the real vault
+				createBinary: jest
+					.fn()
+					.mockImplementation((path: string) =>
+						Promise.resolve(makePartFile(path)),
+					),
 			},
 			fileManager: {
 				trashFile: jest.fn().mockResolvedValue(undefined),
@@ -324,6 +345,20 @@ describe('SplitModal', () => {
 		} as unknown as AudioRecorderSettings);
 
 		expect(internals(modal).partSuffix).toBe('part');
+	});
+
+	it('should clamp out-of-range configured part durations', () => {
+		const tooLarge = new SplitModal(mockApp, mockFile, {
+			...mockSettings,
+			splitChunkMinutes: 10000,
+		} as unknown as AudioRecorderSettings);
+		expect(internals(tooLarge).partMinutes).toBe(180);
+
+		const nonFinite = new SplitModal(mockApp, mockFile, {
+			...mockSettings,
+			splitChunkMinutes: Number.NaN,
+		} as unknown as AudioRecorderSettings);
+		expect(internals(nonFinite).partMinutes).toBe(15);
 	});
 
 	it('should render source file info on open and clear on close', () => {
@@ -356,6 +391,33 @@ describe('SplitModal', () => {
 
 		mockCapturedControls.dropdowns[0]('after');
 		expect(internals(modal).linkAction).toBe('after');
+	});
+
+	it('should toggle the invalid-input class on the suffix field', () => {
+		const modal = new SplitModal(mockApp, mockFile, mockSettings);
+		modal.onOpen();
+
+		const handler = mockCapturedControls.texts[0];
+		const inputEl = mockCapturedControls.textInputs[0];
+
+		handler('bad/suffix');
+		expect(inputEl.toggleClass).toHaveBeenLastCalledWith(
+			'aar-input-invalid',
+			true,
+		);
+
+		handler('good-suffix');
+		expect(inputEl.toggleClass).toHaveBeenLastCalledWith(
+			'aar-input-invalid',
+			false,
+		);
+
+		// Empty input is valid: it falls back to the default suffix
+		handler('');
+		expect(inputEl.toggleClass).toHaveBeenLastCalledWith(
+			'aar-input-invalid',
+			false,
+		);
 	});
 
 	it('should show the bitrate dropdown only for compressed sources', () => {
@@ -426,7 +488,7 @@ describe('SplitModal', () => {
 			expect(new DataView(lastPart).getUint32(40, true)).toBe(10000);
 		});
 
-		it('should update links in the vault with all part names', async () => {
+		it('should update links in the vault with the created part files', async () => {
 			const modal = new SplitModal(mockApp, mockFile, mockSettings);
 
 			await internals(modal).runSplit(progressEl);
@@ -434,11 +496,38 @@ describe('SplitModal', () => {
 			expect(updateLinksInVault).toHaveBeenCalledWith(
 				mockApp,
 				mockFile,
-				[
-					'recording-part1.wav',
-					'recording-part2.wav',
-					'recording-part3.wav',
-				],
+				expect.arrayContaining([
+					expect.objectContaining({
+						path: 'Recordings/recording-part1.wav',
+					}),
+					expect.objectContaining({
+						path: 'Recordings/recording-part2.wav',
+					}),
+					expect.objectContaining({
+						path: 'Recordings/recording-part3.wav',
+					}),
+				]),
+				'replace',
+			);
+			const partFiles = (updateLinksInVault as jest.Mock).mock
+				.calls[0][2] as unknown[];
+			expect(partFiles).toHaveLength(3);
+			expect(partFiles.every((file) => file instanceof TFile)).toBe(true);
+		});
+
+		it('should pass only TFile results from createBinary to the link updater', async () => {
+			// Simulate an adapter that does not resolve to a TFile
+			(mockApp.vault.createBinary as jest.Mock).mockResolvedValue(
+				undefined,
+			);
+			const modal = new SplitModal(mockApp, mockFile, mockSettings);
+
+			await internals(modal).runSplit(progressEl);
+
+			expect(updateLinksInVault).toHaveBeenCalledWith(
+				mockApp,
+				mockFile,
+				[],
 				'replace',
 			);
 		});
@@ -476,6 +565,64 @@ describe('SplitModal', () => {
 			const trashOrder = (mockApp.fileManager.trashFile as jest.Mock).mock
 				.invocationCallOrder[0];
 			expect(trashOrder).toBeGreaterThan(lastWriteOrder);
+		});
+
+		it('should abort with the suffix rule before reading the source for an invalid suffix', async () => {
+			const modal = new SplitModal(mockApp, mockFile, mockSettings);
+			internals(modal).partSuffix = 'bad suffix';
+
+			await internals(modal).runSplit(progressEl);
+
+			expect(Notice).toHaveBeenCalledWith(
+				'Part suffix may contain only letters, digits, hyphens, and underscores.',
+			);
+			expect(mockApp.vault.adapter.readBinary).not.toHaveBeenCalled();
+			expect(mockApp.vault.createBinary).not.toHaveBeenCalled();
+		});
+
+		it('should fall back to the default suffix when the field is blank', async () => {
+			const modal = new SplitModal(mockApp, mockFile, mockSettings);
+			internals(modal).partSuffix = '   ';
+
+			await internals(modal).runSplit(progressEl);
+
+			const paths = (
+				mockApp.vault.createBinary as jest.Mock
+			).mock.calls.map((call: unknown[]) => call[0]);
+			expect(paths).toEqual([
+				'Recordings/recording-part1.wav',
+				'Recordings/recording-part2.wav',
+				'Recordings/recording-part3.wav',
+			]);
+		});
+
+		it('should clamp a zero part duration up to one minute', async () => {
+			const modal = new SplitModal(mockApp, mockFile, mockSettings);
+			internals(modal).partMinutes = 0;
+
+			await internals(modal).runSplit(progressEl);
+
+			// An unclamped zero-length part would abort the split;
+			// one-minute parts of the 250000-byte file yield three parts
+			expect(mockApp.vault.createBinary).toHaveBeenCalledTimes(3);
+		});
+
+		it('should clamp an oversized part duration down to 180 minutes', async () => {
+			// 10 Hz mono 16-bit: byteRate 20 B/s; a 180-minute part = 216000 B
+			(mockApp.vault.adapter.readBinary as jest.Mock).mockResolvedValue(
+				buildTestWav(1, 10, 250000),
+			);
+			const modal = new SplitModal(mockApp, mockFile, mockSettings);
+			internals(modal).partMinutes = 10000;
+
+			await internals(modal).runSplit(progressEl);
+
+			// Unclamped 10000-minute parts would exceed the file and abort
+			expect(mockApp.vault.createBinary).toHaveBeenCalledTimes(2);
+			const calls = (mockApp.vault.createBinary as jest.Mock).mock
+				.calls as [string, ArrayBuffer][];
+			expect(calls[0][1].byteLength).toBe(WAV_HEADER_SIZE + 216000);
+			expect(calls[1][1].byteLength).toBe(WAV_HEADER_SIZE + 34000);
 		});
 
 		it('should abort when a target part file already exists', async () => {
@@ -633,6 +780,21 @@ describe('SplitModal', () => {
 			expect(mockApp.vault.createBinary).not.toHaveBeenCalled();
 			expect(Notice).toHaveBeenCalledWith(
 				'File is shorter than one part.',
+			);
+		});
+
+		it('should decode a WAV file without a raw sample data chunk', async () => {
+			// readBinary returns a non-RIFF buffer, so the lossless WAV
+			// path is rejected and the decode pipeline takes over
+			configureFile('recording.wav', 'wav');
+			const modal = new SplitModal(mockApp, mockFile, mockSettings);
+
+			await internals(modal).runSplit(progressEl);
+
+			expect(decodeAudioDataAtNativeRate).toHaveBeenCalledTimes(1);
+			expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
+				'Recordings/recording-part1.wav',
+				expect.anything(),
 			);
 		});
 

--- a/tests/unit/SplitModal.test.ts
+++ b/tests/unit/SplitModal.test.ts
@@ -74,7 +74,12 @@ jest.mock('obsidian', () => ({
 		open = jest.fn();
 		close = jest.fn();
 	},
-	Notice: jest.fn(),
+	// Notice instances expose the methods used by the background
+	// progress notice (setMessage/hide)
+	Notice: jest.fn().mockImplementation(() => ({
+		setMessage: jest.fn(),
+		hide: jest.fn(),
+	})),
 	Setting: jest.fn().mockImplementation(() => {
 		const chain = {
 			setName: jest.fn(),
@@ -199,7 +204,11 @@ jest.mock('../../src/recording/AudioFormatConverter', () => ({
 
 // Mock the vault-wide link updater
 jest.mock('../../src/utils/LinkUpdater', () => ({
-	updateLinksInVault: jest.fn().mockResolvedValue(1),
+	updateLinksInVault: jest.fn().mockResolvedValue({
+		updatedNotes: 1,
+		skippedReferences: 0,
+		frontmatterReferences: 0,
+	}),
 }));
 
 import { encodeAudioBuffer } from '../../src/recording/AudioEncoder';
@@ -263,6 +272,7 @@ describe('SplitModal', () => {
 		splitPartSuffix: 'part',
 		bitrate: 128000,
 		deleteSourceAfterSplit: false,
+		conversionLinkAction: 'replace',
 	} as unknown as AudioRecorderSettings;
 
 	/**
@@ -336,6 +346,120 @@ describe('SplitModal', () => {
 		expect(internals(modal).partSuffix).toBe('part');
 		expect(internals(modal).deleteSource).toBe(false);
 		expect(internals(modal).linkAction).toBe('replace');
+	});
+
+	it('should seed the link action from the conversion link action setting', () => {
+		const modal = new SplitModal(mockApp, mockFile, {
+			...mockSettings,
+			conversionLinkAction: 'after',
+		} as unknown as AudioRecorderSettings);
+
+		expect(internals(modal).linkAction).toBe('after');
+	});
+
+	it('should snap an unsupported configured bitrate to the closest option', () => {
+		configureFile('recording.webm', 'webm');
+		const modal = new SplitModal(mockApp, mockFile, {
+			...mockSettings,
+			bitrate: 100000,
+		} as unknown as AudioRecorderSettings);
+		modal.onOpen();
+
+		expect((modal as unknown as { bitrate: number }).bitrate).toBe(96000);
+	});
+
+	it('should refresh the part name example when the suffix changes', () => {
+		const { Setting } = jest.requireMock('obsidian');
+		const modal = new SplitModal(mockApp, mockFile, mockSettings);
+		modal.onOpen();
+
+		const collectDescs = (): string[] =>
+			(Setting as jest.Mock).mock.results.flatMap(
+				(result: { value: { setDesc: jest.Mock } }) =>
+					result.value.setDesc.mock.calls.map((call: unknown[]) =>
+						String(call[0]),
+					),
+			);
+		expect(collectDescs()).toContainEqual(
+			expect.stringContaining('"recording-part1.wav"'),
+		);
+
+		mockCapturedControls.texts[0]('seg');
+		expect(collectDescs()).toContainEqual(
+			expect.stringContaining('"recording-seg1.wav"'),
+		);
+	});
+
+	it('should show the WAV extension in the example when encoding falls back', () => {
+		const { isOfflineEncodingSupported } = jest.requireMock(
+			'../../src/recording/AudioEncoder',
+		);
+		(isOfflineEncodingSupported as jest.Mock).mockReturnValue(false);
+		configureFile('recording.webm', 'webm');
+		const { Setting } = jest.requireMock('obsidian');
+		const modal = new SplitModal(mockApp, mockFile, mockSettings);
+		modal.onOpen();
+
+		const descs = (Setting as jest.Mock).mock.results.flatMap(
+			(result: { value: { setDesc: jest.Mock } }) =>
+				result.value.setDesc.mock.calls.map((call: unknown[]) =>
+					String(call[0]),
+				),
+		);
+		expect(descs).toContainEqual(
+			expect.stringContaining('"recording-part1.wav"'),
+		);
+		(isOfflineEncodingSupported as jest.Mock).mockReturnValue(true);
+	});
+
+	it('should clear the progress text when aborting on a collision', async () => {
+		(mockApp.vault.adapter.readBinary as jest.Mock).mockResolvedValue(
+			buildTestWav(1, 1000, 250000),
+		);
+		(mockApp.vault.adapter.exists as jest.Mock).mockResolvedValue(true);
+		const modal = new SplitModal(mockApp, mockFile, mockSettings);
+
+		await internals(modal).runSplit(progressEl);
+
+		expect(Notice).toHaveBeenCalledWith(
+			expect.stringContaining('already exists'),
+		);
+		expect(progressEl.textContent).toBe('');
+	});
+
+	it('should keep reporting progress in a notice when the modal closes mid-split', async () => {
+		let resolveRead!: (bytes: ArrayBuffer) => void;
+		(mockApp.vault.adapter.readBinary as jest.Mock).mockReturnValue(
+			new Promise<ArrayBuffer>((resolve) => {
+				resolveRead = resolve;
+			}),
+		);
+		const modal = new SplitModal(mockApp, mockFile, mockSettings);
+
+		const split = internals(modal).runSplit(progressEl);
+		modal.onClose();
+		// A repeated close must not spawn a second background notice
+		modal.onClose();
+		resolveRead(buildTestWav(1, 1000, 250000));
+		await split;
+
+		const backgroundNotices = (Notice as jest.Mock).mock.calls.filter(
+			(call: unknown[]) =>
+				String(call[0]).includes('continues in the background'),
+		);
+		expect(backgroundNotices).toHaveLength(1);
+		const backgroundIndex = (Notice as jest.Mock).mock.calls.findIndex(
+			(call: unknown[]) =>
+				String(call[0]).includes('continues in the background'),
+		);
+		expect(backgroundIndex).toBeGreaterThanOrEqual(0);
+		// The notice mirrors pipeline progress and is hidden at the end
+		const notice = (Notice as jest.Mock).mock.results[backgroundIndex]
+			.value as { setMessage: jest.Mock; hide: jest.Mock };
+		expect(notice.setMessage).toHaveBeenCalledWith(
+			expect.stringContaining('Writing part'),
+		);
+		expect(notice.hide).toHaveBeenCalled();
 	});
 
 	it('should fall back to the default suffix for an invalid configured suffix', () => {
@@ -441,8 +565,19 @@ describe('SplitModal', () => {
 
 		const button = mockCapturedControls.buttons[0];
 		button.click();
-		// The click handler runs the async pipeline in the background
-		await new Promise((resolve) => setTimeout(resolve, 20));
+		// The click handler runs the async pipeline in the background;
+		// the button is re-enabled in its finally block, so wait for that
+		// instead of a fixed delay (slow under coverage instrumentation)
+		for (let i = 0; i < 400; i++) {
+			if (
+				button.setDisabled.mock.calls.some(
+					(call: unknown[]) => call[0] === false,
+				)
+			) {
+				break;
+			}
+			await new Promise((resolve) => setTimeout(resolve, 5));
+		}
 
 		expect(mockApp.vault.createBinary).toHaveBeenCalledTimes(3);
 		expect(button.setDisabled).toHaveBeenCalledWith(true);
@@ -696,6 +831,119 @@ describe('SplitModal', () => {
 			await internals(modal).runSplit(progressEl);
 
 			expect(Notice).toHaveBeenCalledWith('Split failed: raw failure');
+		});
+
+		it('should roll back written parts by trashing them when a write fails', async () => {
+			(mockApp.vault.createBinary as jest.Mock)
+				.mockImplementationOnce((path: string) =>
+					Promise.resolve(makePartFile(path)),
+				)
+				.mockRejectedValueOnce(new Error('disk full'));
+			const modal = new SplitModal(mockApp, mockFile, mockSettings);
+
+			await internals(modal).runSplit(progressEl);
+
+			// trashFile keeps the rollback recoverable; the raw adapter
+			// path is only a fallback for non-TFile createBinary results
+			expect(mockApp.fileManager.trashFile).toHaveBeenCalledWith(
+				expect.objectContaining({
+					path: 'Recordings/recording-part1.wav',
+				}),
+			);
+			expect(mockApp.vault.adapter.remove).not.toHaveBeenCalled();
+		});
+
+		it('should report partial success when updating links fails after parts are written', async () => {
+			(updateLinksInVault as jest.Mock).mockRejectedValueOnce(
+				new Error('cache busy'),
+			);
+			const modal = new SplitModal(mockApp, mockFile, mockSettings);
+			internals(modal).deleteSource = true;
+
+			await internals(modal).runSplit(progressEl);
+
+			expect(mockApp.vault.createBinary).toHaveBeenCalledTimes(3);
+			// The parts are kept: no rollback after a post-write failure
+			expect(mockApp.vault.adapter.remove).not.toHaveBeenCalled();
+			expect(mockApp.fileManager.trashFile).not.toHaveBeenCalled();
+			expect(Notice).toHaveBeenCalledWith(
+				expect.stringContaining(
+					'Parts were created, but updating links failed',
+				),
+			);
+			const totalFailures = (Notice as jest.Mock).mock.calls.filter(
+				(call: unknown[]) => String(call[0]).startsWith('Split failed'),
+			);
+			expect(totalFailures).toHaveLength(0);
+		});
+
+		it('should report partial success when deleting the source fails', async () => {
+			(mockApp.fileManager.trashFile as jest.Mock).mockRejectedValueOnce(
+				new Error('locked'),
+			);
+			const modal = new SplitModal(mockApp, mockFile, mockSettings);
+			internals(modal).deleteSource = true;
+
+			await internals(modal).runSplit(progressEl);
+
+			expect(Notice).toHaveBeenCalledWith(
+				expect.stringContaining('the source file could not be deleted'),
+			);
+		});
+
+		it('should stringify non-Error post-write failures', async () => {
+			(updateLinksInVault as jest.Mock).mockRejectedValueOnce(
+				'raw link failure',
+			);
+			const modal = new SplitModal(mockApp, mockFile, mockSettings);
+			await internals(modal).runSplit(progressEl);
+			expect(Notice).toHaveBeenCalledWith(
+				expect.stringContaining('raw link failure'),
+			);
+
+			(mockApp.fileManager.trashFile as jest.Mock).mockRejectedValueOnce(
+				'raw delete failure',
+			);
+			const second = new SplitModal(mockApp, mockFile, mockSettings);
+			internals(second).deleteSource = true;
+			await internals(second).runSplit(progressEl);
+			expect(Notice).toHaveBeenCalledWith(
+				expect.stringContaining('raw delete failure'),
+			);
+		});
+
+		it('should keep the source when some links could not be updated', async () => {
+			(updateLinksInVault as jest.Mock).mockResolvedValueOnce({
+				updatedNotes: 1,
+				skippedReferences: 2,
+				frontmatterReferences: 0,
+			});
+			const modal = new SplitModal(mockApp, mockFile, mockSettings);
+			internals(modal).deleteSource = true;
+
+			await internals(modal).runSplit(progressEl);
+
+			expect(mockApp.fileManager.trashFile).not.toHaveBeenCalled();
+			expect(Notice).toHaveBeenCalledWith(
+				'Source file kept: 2 link(s) could not be updated.',
+			);
+		});
+
+		it('should warn about frontmatter links that stay on the source', async () => {
+			(updateLinksInVault as jest.Mock).mockResolvedValueOnce({
+				updatedNotes: 1,
+				skippedReferences: 0,
+				frontmatterReferences: 1,
+			});
+			const modal = new SplitModal(mockApp, mockFile, mockSettings);
+
+			await internals(modal).runSplit(progressEl);
+
+			expect(Notice).toHaveBeenCalledWith(
+				expect.stringContaining(
+					'frontmatter link(s) still point to the source file',
+				),
+			);
 		});
 
 		it('should log and continue when rollback of a written part fails', async () => {


### PR DESCRIPTION
## Summary

Adds audio splitting into fixed-duration parts, both automatically during recording and manually via the context menu.

- **Settings**: new "Audio splitting" section — auto-split toggle, part duration (1-180 min, also the default for manual splitting), configurable part name suffix (`part` -> `-part1`, `-part2`, ...), delete-source-after-split default. Validation rules added to `validateSettings`.
- **Auto-split during recording**:
  - PCM/WAV sessions split **sample-exactly** by byte count inside the `pendingWrite` chain; the overshoot is carried into the next part. Pause time is naturally excluded (the worklet discards frames while paused).
  - MediaRecorder sessions rotate recorders at the active-time boundary (blob streams cannot be cut — only the first chunk has container headers), so each part is a valid standalone container. Precision is ±5 s (chunk timeslice) with a sub-second capture gap at boundaries.
  - Parts are finalized while recording continues; status stays `Recording` (no `Saving` flicker). The residual after the last boundary becomes the final part. Merged multi-track output skips auto-split with a notice. Split settings are snapshotted at session start. Part finalization failures are contained: the recording continues and data lands in the next part.
- **Manual split**: new "Split audio into parts" context menu item (file explorer, editor links, embedded players) opens `SplitModal`. WAV files are split **losslessly at the byte level** via RIFF chunk parsing (no decode, constant memory); compressed formats are decoded once and re-encoded per part. All part paths are pre-checked for collisions; on mid-split failure written parts are rolled back and the source is kept. Links are rewritten **vault-wide** (`metadataCache.resolvedLinks` + `vault.process`) — required when the source file is deleted.
- **Refactoring** (no behavior change): extracted `decodeAudioDataAtNativeRate` (was duplicated in `ConversionModal` and `convertBlobToFormat`), extracted link rewriting into `utils/LinkUpdater`, extracted `finalizeMediaTrackToFile`/`createAndStartMediaRecorders` so rotation and stop finalization share one implementation.
- **Docs**: README — Features, Automatic splitting workflow section, Split context menu action, Audio splitting settings table.

## Test plan

- [x] `npm test -- --no-coverage` — 25 suites, 523 tests passing
- [x] `npm run lint` — 0 errors (5 pre-existing warnings in old test files)
- [x] `npm run build` — passes
- [x] New modules at 100% statements/branch/functions/lines coverage: `AudioSplitter`, `LinkUpdater`, `SplitModal`
- [x] New `RecordingManager` auto-split suite: PCM byte-boundary parts + residual, MediaRecorder rotation (fake timers), pause-time exclusion, merged multi-track skip, failure containment
- [x] Updated suites: `Settings`, `Settings.validation`, `ContextMenu` (menu item count 3 -> 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)