### PR TITLE
Settings reset protection and faster compressed-audio saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,12 +122,12 @@ The modal includes a **Copy as Markdown** button that copies all metadata as a f
 
 Opens a conversion dialog to transcode the audio file to a different format. Options:
 
-- **Target format** with encoder description (e.g., `FLAC (flac-encoder)`, `MP3 (lamejs)`).
+- **Target format** with encoder description (e.g., `FLAC (Mediabunny FLAC Encoder)`, `MP3 (Mediabunny MP3 Encoder)`).
 - **Bitrate** selection (64-320 kbps).
 - **Delete source file** toggle to remove the original after successful conversion.
 - **Update links in notes**: `Do nothing`, `Replace source link`, or `Insert after source link`.
 
-The conversion reads the source file, decodes it at its native sample rate (to avoid resampling artifacts), re-encodes it in the target format, and saves the new file alongside the original.
+The conversion reads the source file and transcodes it to the target format through the streaming mediabunny pipeline: the audio is processed in chunks instead of being decoded fully into memory, and when the source codec already matches the target codec the audio packets are copied without re-encoding. If the source container cannot be processed by the pipeline, the plugin falls back to a full decode and re-encode. The new file is saved alongside the original. Converting to WAV always performs a full decode.
 
 ### Split audio into parts
 
@@ -156,16 +156,16 @@ Moves the audio file to the system trash **and** removes the corresponding embed
 
 Available recording formats depend on your platform's **MediaRecorder** support. The plugin detects supported formats at runtime.
 
-| Format | Codec | Encoding | Notes |
-|--------|-------|----------|-------|
-| **WebM** | Opus | Online | Default format. Widely supported on desktop. |
-| **OGG** | Opus/Vorbis | Online | Good compatibility on most systems. |
-| **WAV** | PCM | Online (streaming) | Uncompressed. Captured as raw PCM in real time and assembled into a WAV file on save. Supports long recordings reliably without memory issues. |
-| **MP3** | MP3 | Offline (lamejs) | Encoded after recording stops using the lamejs library. |
-| **FLAC** | FLAC | Offline (flac-encoder) | Lossless compression. Encoded after recording using flac-encoder. |
-| **MP4** | AAC | Online/Offline | Browser-dependent. May use offline encoding via mediabunny. |
-| **M4A** | AAC | Online/Offline | Same as MP4, different container extension. |
-| **AAC** | AAC | Online/Offline | Raw AAC stream. Browser-dependent support. |
+| Format   | Codec       | Encoding                          | Notes                                                                                                                                          |
+| -------- | ----------- | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| **WebM** | Opus        | Online                            | Default format. Widely supported on desktop.                                                                                                   |
+| **OGG**  | Opus/Vorbis | Online                            | Good compatibility on most systems.                                                                                                            |
+| **WAV**  | PCM         | Online (streaming)                | Uncompressed. Captured as raw PCM in real time and assembled into a WAV file on save. Supports long recordings reliably without memory issues. |
+| **MP3**  | MP3         | Offline (Mediabunny MP3 Encoder)  | Encoded after recording stops using the Mediabunny MP3 encoder extension.                                                                      |
+| **FLAC** | FLAC        | Offline (Mediabunny FLAC Encoder) | Lossless compression. Encoded after recording using the Mediabunny FLAC encoder extension.                                                     |
+| **MP4**  | AAC         | Online/Offline                    | Browser-dependent. May use offline encoding via mediabunny.                                                                                    |
+| **M4A**  | AAC         | Online/Offline                    | Same as MP4, different container extension.                                                                                                    |
+| **AAC**  | AAC         | Online/Offline                    | Raw AAC stream. Browser-dependent support.                                                                                                     |
 
 **Online encoding** means the browser's MediaRecorder writes data in real time during recording.
 **Offline encoding** means the audio is captured in a supported intermediate format (e.g., WebM) and then re-encoded after recording stops. The settings tab marks offline formats with an `(offline)` label.
@@ -192,6 +192,8 @@ Record from multiple input devices simultaneously (up to 8 tracks).
 ## Settings reference
 
 Open **Settings > Advanced Audio Recorder** to configure the plugin.
+
+The plugin keeps an automatic backup of its settings in `data.json.bak` next to `data.json` in the plugin folder. The backup is refreshed on every successful settings load and save and is used to restore the settings automatically when `data.json` goes missing or becomes unreadable. If the settings cannot be read at startup (for example, when the file is temporarily locked during a plugin update), the plugin leaves the stored file untouched, disables saving for the session to protect it, and shows a notice; restarting Obsidian recovers the settings.
 
 ### Audio input
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Record from multiple input devices simultaneously (up to 8 tracks).
 
 Open **Settings > Advanced Audio Recorder** to configure the plugin.
 
-The plugin keeps an automatic backup of its settings in `data.json.bak` next to `data.json` in the plugin folder. The backup is refreshed on every successful settings load and save and is used to restore the settings automatically when `data.json` goes missing or becomes unreadable. When `data.json` is missing and the backup is restored, a new `data.json` is written immediately so the backup is never the only copy. If the settings cannot be read at startup (for example, when the file is temporarily locked during a plugin update), the plugin leaves the stored file untouched, disables saving for the session to protect it, and shows a notice; restarting Obsidian recovers the settings.
+The plugin keeps an automatic backup of its settings in `data.json.bak` next to `data.json` in the plugin folder. The backup is refreshed on every successful settings load and save and is used to restore the settings automatically when `data.json` goes missing. When the backup is restored, a new `data.json` is written immediately so the backup is never the only copy. If `data.json` exists but cannot be read at startup (for example, when the file is temporarily locked during a plugin update), the plugin leaves the stored file untouched, keeps the session on the backup copy when one is readable (defaults otherwise), disables saving to protect the stored settings, and shows a notice; restarting Obsidian recovers the settings.
 
 ### Audio input
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Record from multiple input devices simultaneously (up to 8 tracks).
 
 Open **Settings > Advanced Audio Recorder** to configure the plugin.
 
-The plugin keeps an automatic backup of its settings in `data.json.bak` next to `data.json` in the plugin folder. The backup is refreshed on every successful settings load and save and is used to restore the settings automatically when `data.json` goes missing or becomes unreadable. If the settings cannot be read at startup (for example, when the file is temporarily locked during a plugin update), the plugin leaves the stored file untouched, disables saving for the session to protect it, and shows a notice; restarting Obsidian recovers the settings.
+The plugin keeps an automatic backup of its settings in `data.json.bak` next to `data.json` in the plugin folder. The backup is refreshed on every successful settings load and save and is used to restore the settings automatically when `data.json` goes missing or becomes unreadable. When `data.json` is missing and the backup is restored, a new `data.json` is written immediately so the backup is never the only copy. If the settings cannot be read at startup (for example, when the file is temporarily locked during a plugin update), the plugin leaves the stored file untouched, disables saving for the session to protect it, and shows a notice; restarting Obsidian recovers the settings.
 
 ### Audio input
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Opens a conversion dialog to transcode the audio file to a different format. Opt
 - **Delete source file** toggle to remove the original after successful conversion.
 - **Update links in notes**: `Do nothing`, `Replace source link`, or `Insert after source link`.
 
-The conversion reads the source file and transcodes it to the target format through the streaming mediabunny pipeline: the audio is processed in chunks instead of being decoded fully into memory, and when the source codec already matches the target codec the audio packets are copied without re-encoding. If the source container cannot be processed by the pipeline, the plugin falls back to a full decode and re-encode. The new file is saved alongside the original. Converting to WAV always performs a full decode.
+The conversion reads the source file and transcodes it to the target format through the streaming mediabunny pipeline: the audio is processed in chunks instead of being decoded fully into memory and is always re-encoded at the selected bitrate. If the source container cannot be processed by the pipeline, the plugin falls back to a full decode and re-encode. The new file is saved alongside the original. Converting to WAV always performs a full decode.
 
 ### Split audio into parts
 
@@ -168,7 +168,7 @@ Available recording formats depend on your platform's **MediaRecorder** support.
 | **AAC**  | AAC         | Online/Offline                    | Raw AAC stream. Browser-dependent support.                                                                                                     |
 
 **Online encoding** means the browser's MediaRecorder writes data in real time during recording.
-**Offline encoding** means the audio is captured in a supported intermediate format (e.g., WebM) and then re-encoded after recording stops. The settings tab marks offline formats with an `(offline)` label.
+**Offline encoding** means the audio is captured in a supported intermediate format (e.g., WebM) and then re-encoded after recording stops. When the intermediate codec already matches the target codec, the audio packets are copied without re-encoding. The settings tab marks offline formats with an `(offline)` label.
 
 ## Multi-track recording
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@mediabunny/flac-encoder": "1.39.2",
-        "lamejs": "1.2.1",
+        "@mediabunny/mp3-encoder": "1.39.2",
         "mediabunny": "1.39.2"
       },
       "devDependencies": {
@@ -1988,6 +1988,19 @@
       "version": "1.39.2",
       "resolved": "https://registry.npmjs.org/@mediabunny/flac-encoder/-/flac-encoder-1.39.2.tgz",
       "integrity": "sha512-VwBr3AzZTPEEPvt4aladZiXwOf3W293eq213zDupGQi/taS8WWNqDd3eBdf8FfvlbXATfbRiycXDKyQ0HlOZaQ==",
+      "license": "MPL-2.0",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/Vanilagy"
+      },
+      "peerDependencies": {
+        "mediabunny": "^1.0.0"
+      }
+    },
+    "node_modules/@mediabunny/mp3-encoder": {
+      "version": "1.39.2",
+      "resolved": "https://registry.npmjs.org/@mediabunny/mp3-encoder/-/mp3-encoder-1.39.2.tgz",
+      "integrity": "sha512-3rrodrGnUpUP8F2d1aRUl8IvjqK3jegkupbOzvOokooSAO5rXk2Lr5jZe7TnPeiVGiXfmnoJ7s9uyUOHlCd8qw==",
       "license": "MPL-2.0",
       "funding": {
         "type": "individual",
@@ -6952,15 +6965,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/lamejs": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/lamejs/-/lamejs-1.2.1.tgz",
-      "integrity": "sha512-s7bxvjvYthw6oPLCm5pFxvA84wUROODB8jEO2+CE1adhKgrIvVOlmMgY8zyugxGrvRaDHNJanOiS21/emty6dQ==",
-      "license": "LGPL-3.0",
-      "dependencies": {
-        "use-strict": "1.0.1"
-      }
-    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -9238,12 +9242,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/use-strict": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/use-strict/-/use-strict-1.0.1.tgz",
-      "integrity": "sha512-IeiWvvEXfW5ltKVMkxq6FvNf2LojMKvB2OCeja6+ct24S1XOmQw2dGr2JyndwACWAGJva9B7yPHwAmeA9QCqAQ==",
-      "license": "ISC"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "moduleNameMapper": {
       "^obsidian$": "<rootDir>/tests/mocks/obsidian.ts",
       "^@mediabunny/flac-encoder$": "<rootDir>/tests/mocks/flac-encoder.ts",
+      "^@mediabunny/mp3-encoder$": "<rootDir>/tests/mocks/mp3-encoder.ts",
       "src/(.*)": "<rootDir>/src/$1"
     },
     "moduleFileExtensions": [
@@ -79,7 +80,7 @@
   },
   "dependencies": {
     "@mediabunny/flac-encoder": "1.39.2",
-    "lamejs": "1.2.1",
+    "@mediabunny/mp3-encoder": "1.39.2",
     "mediabunny": "1.39.2"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -198,6 +198,11 @@ export default class AudioRecorderPlugin extends Plugin {
 				'Settings were not loaded correctly; changes are not saved ' +
 					'to protect your stored settings. Restart Obsidian.',
 			);
+			// The settings tab mutates the in-memory settings before
+			// calling saveSettings: propagate them so every subsystem
+			// sees the same session state even though nothing is
+			// persisted
+			this.recordingManager.updateSettings(this.settings);
 			return;
 		}
 		await this.saveData(serializeSettings(this.settings));

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,9 +34,8 @@ const SETTINGS_BACKUP_FILE = 'data.json.bak';
  */
 interface StoredSettingsReadResult {
 	/**
-	 * Stored settings, null when no settings exist on disk (saving
-	 * stays enabled), or undefined when settings exist on disk but
-	 * could not be read (saving gets blocked).
+	 * Stored settings, null when no settings exist on disk, or
+	 * undefined when no readable settings source is available.
 	 */
 	data: Partial<AudioRecorderSettings> | null | undefined;
 	/**
@@ -45,6 +44,13 @@ interface StoredSettingsReadResult {
 	 * recreated and the backup stops being the only copy on disk.
 	 */
 	restoredFromBackup: boolean;
+	/**
+	 * True when a settings file exists on disk but could not be
+	 * read: saving stays blocked so the possibly intact (and
+	 * possibly newer) stored settings are never overwritten by
+	 * values derived from this session's fallback.
+	 */
+	blockSaving: boolean;
 }
 
 /**
@@ -119,31 +125,48 @@ export default class AudioRecorderPlugin extends Plugin {
 	 * Distinguishes "data.json is missing" (first install, defaults are
 	 * correct) from "data.json exists but could not be read" (transient
 	 * file lock during a plugin update, truncated file): the latter
-	 * falls back to defaults only in memory and blocks saving, so the
-	 * stored settings are never overwritten by the fallback. The two
+	 * keeps the session on the backup copy or defaults in memory and
+	 * blocks saving, so the stored settings are never overwritten by
+	 * the fallback. The two
 	 * cases are told apart by an explicit adapter.exists() check, not
 	 * by the loadData() return value: loadData() maps a missing file
 	 * to null only when the failed read carries an ENOENT error code,
 	 * and on some filesystems the read fails with a different code.
 	 */
 	async loadSettings(): Promise<void> {
-		const { data, restoredFromBackup } = await this.readStoredSettings();
+		const { data, restoredFromBackup, blockSaving } =
+			await this.readStoredSettings();
 
-		if (data === undefined) {
+		if (blockSaving) {
 			this.settingsLoadFailed = true;
+			// A readable backup keeps the session usable on the
+			// initial load; a failed reload keeps the current
+			// in-memory settings (external change while the file is
+			// locked). Saving stays blocked either way so the possibly
+			// intact and possibly newer stored settings are never
+			// overwritten by this session.
+			const backupApplies =
+				!this.settingsInitialized &&
+				data !== undefined &&
+				data !== null;
 			new Notice(
-				'Advanced Audio Recorder: the settings file could not be read. ' +
-					'Settings stored on disk are untouched, and saving is ' +
-					'disabled to protect them. Restart Obsidian to recover.',
+				backupApplies
+					? 'Advanced Audio Recorder: the settings file could not ' +
+							'be read. Settings from the backup file are used ' +
+							'for this session, and saving is disabled to ' +
+							'protect the stored file. Restart Obsidian to ' +
+							'recover.'
+					: 'Advanced Audio Recorder: the settings file could not ' +
+							'be read. Settings stored on disk are untouched, ' +
+							'and saving is disabled to protect them. Restart ' +
+							'Obsidian to recover.',
 			);
-			// Keep the current in-memory settings on a failed reload
-			// (external change while the file is locked); fall back to
-			// defaults only on the initial load when nothing has been
-			// loaded yet
-			if (!this.settingsInitialized) {
+			if (backupApplies) {
+				this.settings = await mergeSettingsAsync(data);
+			} else if (!this.settingsInitialized) {
 				this.settings = await mergeSettingsAsync({});
-				this.settingsInitialized = true;
 			}
+			this.settingsInitialized = true;
 			return;
 		}
 
@@ -151,6 +174,9 @@ export default class AudioRecorderPlugin extends Plugin {
 		this.settings = await mergeSettingsAsync(data ?? {});
 		this.settingsInitialized = true;
 		if (restoredFromBackup) {
+			new Notice(
+				'Advanced Audio Recorder: settings were restored from the backup file.',
+			);
 			// Complete the recovery: recreate the missing data.json
 			// right away instead of leaving the backup as the only
 			// copy until the user happens to change a setting.
@@ -167,7 +193,7 @@ export default class AudioRecorderPlugin extends Plugin {
 	async saveSettings(): Promise<void> {
 		if (this.settingsLoadFailed) {
 			// Never overwrite a possibly intact data.json with the
-			// in-memory defaults that replaced the unreadable settings
+			// in-memory fallback that replaced the unreadable settings
 			new Notice(
 				'Settings were not loaded correctly; changes are not saved ' +
 					'to protect your stored settings. Restart Obsidian.',
@@ -205,12 +231,13 @@ export default class AudioRecorderPlugin extends Plugin {
 	 * saving instead of being overwritten with defaults.
 	 * @returns Read result: stored settings, null when no settings
 	 * exist on disk, or undefined when stored settings could not be
-	 * read
+	 * read; blockSaving is set whenever an existing settings file
+	 * could not be read
 	 */
 	private async readStoredSettings(): Promise<StoredSettingsReadResult> {
 		let data = await this.tryLoadData();
 		if (data !== undefined && data !== null) {
-			return { data, restoredFromBackup: false };
+			return { data, restoredFromBackup: false, blockSaving: false };
 		}
 
 		if (!(await this.pluginFileExists(SETTINGS_DATA_FILE))) {
@@ -218,29 +245,38 @@ export default class AudioRecorderPlugin extends Plugin {
 				// First install: no settings anywhere, defaults apply
 				// and saving stays enabled so data.json gets created
 				// on the next change
-				return { data: null, restoredFromBackup: false };
+				return {
+					data: null,
+					restoredFromBackup: false,
+					blockSaving: false,
+				};
 			}
 			// Missing data.json with a backup present: restore the
-			// lost settings and have the caller persist them
+			// lost settings and have the caller persist them. An
+			// unreadable backup is the only remaining copy of the
+			// settings, so it blocks saving instead.
 			const backup = await this.readSettingsBackup();
 			return {
 				data: backup,
 				restoredFromBackup: backup !== undefined,
+				blockSaving: backup === undefined,
 			};
 		}
 
 		await delay(SETTINGS_READ_RETRY_DELAY_MS);
 		data = await this.tryLoadData();
 		if (data !== undefined && data !== null) {
-			return { data, restoredFromBackup: false };
+			return { data, restoredFromBackup: false, blockSaving: false };
 		}
 
 		// data.json exists but is unreadable: a readable backup keeps
-		// the session usable; data.json itself stays untouched until
-		// the user changes a setting
+		// the session usable in memory, while saving stays blocked so
+		// the possibly newer data.json is never overwritten with
+		// backup-derived values
 		return {
 			data: await this.readSettingsBackup(),
 			restoredFromBackup: false,
+			blockSaving: true,
 		};
 	}
 
@@ -287,8 +323,10 @@ export default class AudioRecorderPlugin extends Plugin {
 	}
 
 	/**
-	 * Restores settings from the backup file written on every
-	 * successful load and save.
+	 * Reads and parses the settings backup file written on every
+	 * successful load and save. User-facing messaging is left to the
+	 * callers, which know whether the backup replaces a missing
+	 * data.json or only carries the session over an unreadable one.
 	 * @returns Parsed backup settings, or undefined when the backup is
 	 * missing or unreadable
 	 */
@@ -301,11 +339,7 @@ export default class AudioRecorderPlugin extends Plugin {
 		}
 		try {
 			const raw = await this.app.vault.adapter.read(backupPath);
-			const parsed = JSON.parse(raw) as Partial<AudioRecorderSettings>;
-			new Notice(
-				'Advanced Audio Recorder: settings were restored from the backup file.',
-			);
-			return parsed;
+			return JSON.parse(raw) as Partial<AudioRecorderSettings>;
 		} catch {
 			return undefined;
 		}

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,9 @@ import { ContextMenu } from './ui/ContextMenu';
 /** Delay before retrying a failed settings read, in milliseconds. */
 const SETTINGS_READ_RETRY_DELAY_MS = 250;
 
+/** Settings file name used by Obsidian's loadData/saveData. */
+const SETTINGS_DATA_FILE = 'data.json';
+
 /** Backup file name for settings, stored next to data.json. */
 const SETTINGS_BACKUP_FILE = 'data.json.bak';
 
@@ -92,7 +95,11 @@ export default class AudioRecorderPlugin extends Plugin {
 	 * correct) from "data.json exists but could not be read" (transient
 	 * file lock during a plugin update, truncated file): the latter
 	 * falls back to defaults only in memory and blocks saving, so the
-	 * stored settings are never overwritten by the fallback.
+	 * stored settings are never overwritten by the fallback. The two
+	 * cases are told apart by an explicit adapter.exists() check, not
+	 * by the loadData() return value: loadData() maps a missing file
+	 * to null only when the failed read carries an ENOENT error code,
+	 * and on some filesystems the read fails with a different code.
 	 */
 	async loadSettings(): Promise<void> {
 		const data = await this.readStoredSettings();
@@ -143,12 +150,17 @@ export default class AudioRecorderPlugin extends Plugin {
 	}
 
 	/**
-	 * Reads settings from disk, separating the three loadData outcomes:
-	 * an object (file read), null (file missing, ENOENT), and undefined
-	 * (file exists but reading or parsing failed). A failed read is
-	 * retried once, then the backup file is tried.
-	 * @returns Stored settings, null for a missing file, or undefined
-	 * when neither data.json nor the backup could be read
+	 * Reads settings from disk. loadData() reports a missing data.json
+	 * as null only when the underlying read fails with an ENOENT error
+	 * code; other filesystems surface a different code for the same
+	 * condition and loadData() then returns undefined, exactly like a
+	 * corrupt or locked file. The adapter's exists() check is therefore
+	 * the only reliable discriminator between "file missing" and "file
+	 * exists but could not be read". A failed read of an existing file
+	 * is retried once, then the backup file is tried.
+	 * @returns Stored settings, null when data.json is missing (saving
+	 * stays enabled), or undefined when data.json exists but neither it
+	 * nor the backup could be read
 	 */
 	private async readStoredSettings(): Promise<
 		Partial<AudioRecorderSettings> | null | undefined
@@ -157,8 +169,15 @@ export default class AudioRecorderPlugin extends Plugin {
 			| Partial<AudioRecorderSettings>
 			| null
 			| undefined;
-		if (data !== undefined) {
+		if (data !== undefined && data !== null) {
 			return data;
+		}
+
+		if (!(await this.settingsFileExists())) {
+			// Missing data.json: restore a lost file from the backup,
+			// or apply defaults on a first install. Saving stays
+			// enabled so the file gets created on the next change.
+			return (await this.readSettingsBackup()) ?? null;
 		}
 
 		await new Promise<void>((resolve) =>
@@ -168,11 +187,29 @@ export default class AudioRecorderPlugin extends Plugin {
 			| Partial<AudioRecorderSettings>
 			| null
 			| undefined;
-		if (data !== undefined) {
+		if (data !== undefined && data !== null) {
 			return data;
 		}
 
 		return this.readSettingsBackup();
+	}
+
+	/**
+	 * Checks whether data.json is present on disk.
+	 * @returns True when data.json exists, or when its existence cannot
+	 * be determined: the protective assumption keeps saveSettings from
+	 * overwriting a file that may still be intact
+	 */
+	private async settingsFileExists(): Promise<boolean> {
+		const dataPath = this.getPluginFilePath(SETTINGS_DATA_FILE);
+		if (!dataPath) {
+			return false;
+		}
+		try {
+			return await this.app.vault.adapter.exists(dataPath);
+		} catch {
+			return true;
+		}
 	}
 
 	/**
@@ -228,11 +265,20 @@ export default class AudioRecorderPlugin extends Plugin {
 	 * @returns Backup path, or null when the plugin directory is unknown
 	 */
 	private getSettingsBackupPath(): string | null {
+		return this.getPluginFilePath(SETTINGS_BACKUP_FILE);
+	}
+
+	/**
+	 * Resolves the vault-relative path of a file in the plugin folder.
+	 * @param fileName - File name inside the plugin folder
+	 * @returns File path, or null when the plugin directory is unknown
+	 */
+	private getPluginFilePath(fileName: string): string | null {
 		const pluginDir = this.manifest.dir;
 		if (!pluginDir) {
 			return null;
 		}
-		return `${pluginDir}/${SETTINGS_BACKUP_FILE}`;
+		return `${pluginDir}/${fileName}`;
 	}
 
 	/**

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,7 @@ import { updateStatusBar, initializeStatusBar } from './ui/StatusBar';
 import { updateRibbonIcon, initializeRibbonIcon } from './ui/RibbonIcon';
 import { showDeviceSelectionModal } from './ui/DeviceSelectionModal';
 import { ContextMenu } from './ui/ContextMenu';
+import { delay } from './utils/TimeUtils';
 
 /** Delay before retrying a failed settings read, in milliseconds. */
 const SETTINGS_READ_RETRY_DELAY_MS = 250;
@@ -43,6 +44,12 @@ export default class AudioRecorderPlugin extends Plugin {
 	 * intact file is never overwritten with defaults.
 	 */
 	private settingsLoadFailed = false;
+	/**
+	 * True once settings have been assigned at least once. Lets a
+	 * failed reload keep the current in-memory settings instead of
+	 * replacing them with defaults.
+	 */
+	private settingsInitialized = false;
 
 	/**
 	 * Called when the plugin is loaded.
@@ -108,15 +115,23 @@ export default class AudioRecorderPlugin extends Plugin {
 			this.settingsLoadFailed = true;
 			new Notice(
 				'Advanced Audio Recorder: the settings file could not be read. ' +
-					'Using defaults for this session; settings stored on disk are untouched. ' +
-					'Restart Obsidian to recover them.',
+					'Settings stored on disk are untouched, and saving is ' +
+					'disabled to protect them. Restart Obsidian to recover.',
 			);
-			this.settings = await mergeSettingsAsync({});
+			// Keep the current in-memory settings on a failed reload
+			// (external change while the file is locked); fall back to
+			// defaults only on the initial load when nothing has been
+			// loaded yet
+			if (!this.settingsInitialized) {
+				this.settings = await mergeSettingsAsync({});
+				this.settingsInitialized = true;
+			}
 			return;
 		}
 
 		this.settingsLoadFailed = false;
 		this.settings = await mergeSettingsAsync(data ?? {});
+		this.settingsInitialized = true;
 		await this.backupSettings();
 	}
 
@@ -165,10 +180,7 @@ export default class AudioRecorderPlugin extends Plugin {
 	private async readStoredSettings(): Promise<
 		Partial<AudioRecorderSettings> | null | undefined
 	> {
-		let data = (await this.loadData()) as
-			| Partial<AudioRecorderSettings>
-			| null
-			| undefined;
+		let data = await this.tryLoadData();
 		if (data !== undefined && data !== null) {
 			return data;
 		}
@@ -180,18 +192,36 @@ export default class AudioRecorderPlugin extends Plugin {
 			return (await this.readSettingsBackup()) ?? null;
 		}
 
-		await new Promise<void>((resolve) =>
-			activeWindow.setTimeout(resolve, SETTINGS_READ_RETRY_DELAY_MS),
-		);
-		data = (await this.loadData()) as
-			| Partial<AudioRecorderSettings>
-			| null
-			| undefined;
+		await delay(SETTINGS_READ_RETRY_DELAY_MS);
+		data = await this.tryLoadData();
 		if (data !== undefined && data !== null) {
 			return data;
 		}
 
 		return this.readSettingsBackup();
+	}
+
+	/**
+	 * Calls loadData() and maps a rejected read to undefined. The
+	 * current Obsidian implementation never rejects (read and parse
+	 * failures are caught internally and reported as undefined), but
+	 * that behavior is undocumented; mapping a rejection to the
+	 * failed-read result keeps the missing-vs-unreadable
+	 * discrimination independent of Obsidian internals.
+	 * @returns Stored settings, null for a missing file, or undefined
+	 * when the read failed
+	 */
+	private async tryLoadData(): Promise<
+		Partial<AudioRecorderSettings> | null | undefined
+	> {
+		try {
+			return (await this.loadData()) as
+				| Partial<AudioRecorderSettings>
+				| null
+				| undefined;
+		} catch {
+			return undefined;
+		}
 	}
 
 	/**

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,6 +30,24 @@ const SETTINGS_DATA_FILE = 'data.json';
 const SETTINGS_BACKUP_FILE = 'data.json.bak';
 
 /**
+ * Result of reading the stored settings from disk.
+ */
+interface StoredSettingsReadResult {
+	/**
+	 * Stored settings, null when no settings exist on disk (saving
+	 * stays enabled), or undefined when settings exist on disk but
+	 * could not be read (saving gets blocked).
+	 */
+	data: Partial<AudioRecorderSettings> | null | undefined;
+	/**
+	 * True when data.json is missing and the settings were recovered
+	 * from the backup file: the caller persists them so data.json is
+	 * recreated and the backup stops being the only copy on disk.
+	 */
+	restoredFromBackup: boolean;
+}
+
+/**
  * Advanced Audio Recorder plugin for Obsidian.
  */
 export default class AudioRecorderPlugin extends Plugin {
@@ -109,7 +127,7 @@ export default class AudioRecorderPlugin extends Plugin {
 	 * and on some filesystems the read fails with a different code.
 	 */
 	async loadSettings(): Promise<void> {
-		const data = await this.readStoredSettings();
+		const { data, restoredFromBackup } = await this.readStoredSettings();
 
 		if (data === undefined) {
 			this.settingsLoadFailed = true;
@@ -132,6 +150,14 @@ export default class AudioRecorderPlugin extends Plugin {
 		this.settingsLoadFailed = false;
 		this.settings = await mergeSettingsAsync(data ?? {});
 		this.settingsInitialized = true;
+		if (restoredFromBackup) {
+			// Complete the recovery: recreate the missing data.json
+			// right away instead of leaving the backup as the only
+			// copy until the user happens to change a setting.
+			// saveSettings() is not usable here: loadSettings() runs
+			// before the RecordingManager is constructed in onload.
+			await this.saveData(serializeSettings(this.settings));
+		}
 		await this.backupSettings();
 	}
 
@@ -172,33 +198,50 @@ export default class AudioRecorderPlugin extends Plugin {
 	 * corrupt or locked file. The adapter's exists() check is therefore
 	 * the only reliable discriminator between "file missing" and "file
 	 * exists but could not be read". A failed read of an existing file
-	 * is retried once, then the backup file is tried.
-	 * @returns Stored settings, null when data.json is missing (saving
-	 * stays enabled), or undefined when data.json exists but neither it
-	 * nor the backup could be read
+	 * is retried once, then the backup file is tried. The same
+	 * missing-vs-unreadable distinction applies to the backup itself:
+	 * when data.json is missing, the backup is the only copy of the
+	 * settings, so a backup that exists but cannot be read blocks
+	 * saving instead of being overwritten with defaults.
+	 * @returns Read result: stored settings, null when no settings
+	 * exist on disk, or undefined when stored settings could not be
+	 * read
 	 */
-	private async readStoredSettings(): Promise<
-		Partial<AudioRecorderSettings> | null | undefined
-	> {
+	private async readStoredSettings(): Promise<StoredSettingsReadResult> {
 		let data = await this.tryLoadData();
 		if (data !== undefined && data !== null) {
-			return data;
+			return { data, restoredFromBackup: false };
 		}
 
-		if (!(await this.settingsFileExists())) {
-			// Missing data.json: restore a lost file from the backup,
-			// or apply defaults on a first install. Saving stays
-			// enabled so the file gets created on the next change.
-			return (await this.readSettingsBackup()) ?? null;
+		if (!(await this.pluginFileExists(SETTINGS_DATA_FILE))) {
+			if (!(await this.pluginFileExists(SETTINGS_BACKUP_FILE))) {
+				// First install: no settings anywhere, defaults apply
+				// and saving stays enabled so data.json gets created
+				// on the next change
+				return { data: null, restoredFromBackup: false };
+			}
+			// Missing data.json with a backup present: restore the
+			// lost settings and have the caller persist them
+			const backup = await this.readSettingsBackup();
+			return {
+				data: backup,
+				restoredFromBackup: backup !== undefined,
+			};
 		}
 
 		await delay(SETTINGS_READ_RETRY_DELAY_MS);
 		data = await this.tryLoadData();
 		if (data !== undefined && data !== null) {
-			return data;
+			return { data, restoredFromBackup: false };
 		}
 
-		return this.readSettingsBackup();
+		// data.json exists but is unreadable: a readable backup keeps
+		// the session usable; data.json itself stays untouched until
+		// the user changes a setting
+		return {
+			data: await this.readSettingsBackup(),
+			restoredFromBackup: false,
+		};
 	}
 
 	/**
@@ -225,18 +268,19 @@ export default class AudioRecorderPlugin extends Plugin {
 	}
 
 	/**
-	 * Checks whether data.json is present on disk.
-	 * @returns True when data.json exists, or when its existence cannot
-	 * be determined: the protective assumption keeps saveSettings from
-	 * overwriting a file that may still be intact
+	 * Checks whether a file in the plugin folder is present on disk.
+	 * @param fileName - File name inside the plugin folder
+	 * @returns True when the file exists, or when its existence cannot
+	 * be determined: the protective assumption treats an unverifiable
+	 * file as present so it is never overwritten while possibly intact
 	 */
-	private async settingsFileExists(): Promise<boolean> {
-		const dataPath = this.getPluginFilePath(SETTINGS_DATA_FILE);
-		if (!dataPath) {
+	private async pluginFileExists(fileName: string): Promise<boolean> {
+		const filePath = this.getPluginFilePath(fileName);
+		if (!filePath) {
 			return false;
 		}
 		try {
-			return await this.app.vault.adapter.exists(dataPath);
+			return await this.app.vault.adapter.exists(filePath);
 		} catch {
 			return true;
 		}

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,9 +3,10 @@
  * @module main
  */
 
-import { Plugin } from 'obsidian';
+import { Notice, Plugin } from 'obsidian';
 import { RecordingStatus } from './types';
 import type { SaveProgress, RecordingControls } from './types';
+import { PLUGIN_LOG_PREFIX } from './constants';
 import {
 	AudioRecorderSettings,
 	mergeSettingsAsync,
@@ -18,6 +19,12 @@ import { updateRibbonIcon, initializeRibbonIcon } from './ui/RibbonIcon';
 import { showDeviceSelectionModal } from './ui/DeviceSelectionModal';
 import { ContextMenu } from './ui/ContextMenu';
 
+/** Delay before retrying a failed settings read, in milliseconds. */
+const SETTINGS_READ_RETRY_DELAY_MS = 250;
+
+/** Backup file name for settings, stored next to data.json. */
+const SETTINGS_BACKUP_FILE = 'data.json.bak';
+
 /**
  * Advanced Audio Recorder plugin for Obsidian.
  */
@@ -27,6 +34,12 @@ export default class AudioRecorderPlugin extends Plugin {
 	private statusBarItem: HTMLElement | null = null;
 	private ribbonIconEl: HTMLElement | null = null;
 	private contextMenu!: ContextMenu;
+	/**
+	 * True when data.json exists on disk but could not be read at load
+	 * time. While set, saveSettings refuses to write so the possibly
+	 * intact file is never overwritten with defaults.
+	 */
+	private settingsLoadFailed = false;
 
 	/**
 	 * Called when the plugin is loaded.
@@ -75,19 +88,151 @@ export default class AudioRecorderPlugin extends Plugin {
 
 	/**
 	 * Loads plugin settings from storage.
+	 * Distinguishes "data.json is missing" (first install, defaults are
+	 * correct) from "data.json exists but could not be read" (transient
+	 * file lock during a plugin update, truncated file): the latter
+	 * falls back to defaults only in memory and blocks saving, so the
+	 * stored settings are never overwritten by the fallback.
 	 */
 	async loadSettings(): Promise<void> {
-		const data =
-			(await this.loadData()) as Partial<AudioRecorderSettings> | null;
+		const data = await this.readStoredSettings();
+
+		if (data === undefined) {
+			this.settingsLoadFailed = true;
+			new Notice(
+				'Advanced Audio Recorder: the settings file could not be read. ' +
+					'Using defaults for this session; settings stored on disk are untouched. ' +
+					'Restart Obsidian to recover them.',
+			);
+			this.settings = await mergeSettingsAsync({});
+			return;
+		}
+
+		this.settingsLoadFailed = false;
 		this.settings = await mergeSettingsAsync(data ?? {});
+		await this.backupSettings();
 	}
 
 	/**
 	 * Saves plugin settings to storage.
 	 */
 	async saveSettings(): Promise<void> {
+		if (this.settingsLoadFailed) {
+			// Never overwrite a possibly intact data.json with the
+			// in-memory defaults that replaced the unreadable settings
+			new Notice(
+				'Settings were not loaded correctly; changes are not saved ' +
+					'to protect your stored settings. Restart Obsidian.',
+			);
+			return;
+		}
 		await this.saveData(serializeSettings(this.settings));
+		await this.backupSettings();
 		this.recordingManager.updateSettings(this.settings);
+	}
+
+	/**
+	 * Called by Obsidian when data.json changes externally (sync,
+	 * manual edit) while the plugin is loaded. Reloads settings so the
+	 * stale in-memory copy does not overwrite the external change on
+	 * the next save.
+	 */
+	async onExternalSettingsChange(): Promise<void> {
+		await this.loadSettings();
+		this.recordingManager.updateSettings(this.settings);
+	}
+
+	/**
+	 * Reads settings from disk, separating the three loadData outcomes:
+	 * an object (file read), null (file missing, ENOENT), and undefined
+	 * (file exists but reading or parsing failed). A failed read is
+	 * retried once, then the backup file is tried.
+	 * @returns Stored settings, null for a missing file, or undefined
+	 * when neither data.json nor the backup could be read
+	 */
+	private async readStoredSettings(): Promise<
+		Partial<AudioRecorderSettings> | null | undefined
+	> {
+		let data = (await this.loadData()) as
+			| Partial<AudioRecorderSettings>
+			| null
+			| undefined;
+		if (data !== undefined) {
+			return data;
+		}
+
+		await new Promise<void>((resolve) =>
+			activeWindow.setTimeout(resolve, SETTINGS_READ_RETRY_DELAY_MS),
+		);
+		data = (await this.loadData()) as
+			| Partial<AudioRecorderSettings>
+			| null
+			| undefined;
+		if (data !== undefined) {
+			return data;
+		}
+
+		return this.readSettingsBackup();
+	}
+
+	/**
+	 * Restores settings from the backup file written on every
+	 * successful load and save.
+	 * @returns Parsed backup settings, or undefined when the backup is
+	 * missing or unreadable
+	 */
+	private async readSettingsBackup(): Promise<
+		Partial<AudioRecorderSettings> | undefined
+	> {
+		const backupPath = this.getSettingsBackupPath();
+		if (!backupPath) {
+			return undefined;
+		}
+		try {
+			const raw = await this.app.vault.adapter.read(backupPath);
+			const parsed = JSON.parse(raw) as Partial<AudioRecorderSettings>;
+			new Notice(
+				'Advanced Audio Recorder: settings were restored from the backup file.',
+			);
+			return parsed;
+		} catch {
+			return undefined;
+		}
+	}
+
+	/**
+	 * Writes the current settings to the backup file next to data.json.
+	 * Failures only log a warning: the backup is a best-effort recovery
+	 * source and must not break loading or saving.
+	 */
+	private async backupSettings(): Promise<void> {
+		const backupPath = this.getSettingsBackupPath();
+		if (!backupPath) {
+			return;
+		}
+		try {
+			await this.app.vault.adapter.write(
+				backupPath,
+				JSON.stringify(serializeSettings(this.settings)),
+			);
+		} catch (error) {
+			console.warn(
+				`${PLUGIN_LOG_PREFIX} Failed to write settings backup:`,
+				error,
+			);
+		}
+	}
+
+	/**
+	 * Resolves the vault-relative path of the settings backup file.
+	 * @returns Backup path, or null when the plugin directory is unknown
+	 */
+	private getSettingsBackupPath(): string | null {
+		const pluginDir = this.manifest.dir;
+		if (!pluginDir) {
+			return null;
+		}
+		return `${pluginDir}/${SETTINGS_BACKUP_FILE}`;
 	}
 
 	/**

--- a/src/recording/AudioEncoder.ts
+++ b/src/recording/AudioEncoder.ts
@@ -1,7 +1,7 @@
 /**
  * Offline audio encoding module.
- * Converts AudioBuffer to compressed formats using Mediabunny (WebCodecs)
- * and lamejs (MP3).
+ * Converts AudioBuffer to compressed formats using Mediabunny
+ * (WebCodecs-backed, with extension encoders for FLAC and MP3).
  * @module recording/AudioEncoder
  */
 
@@ -13,9 +13,10 @@ import {
 	WebMOutputFormat,
 	OggOutputFormat,
 	FlacOutputFormat,
+	Mp3OutputFormat,
+	canEncodeAudio,
 } from 'mediabunny';
 import type { OutputFormat } from 'mediabunny';
-import { Mp3Encoder } from 'lamejs';
 import { bufferToWave } from './WavEncoder';
 import { EncodingError } from '../errors';
 import {
@@ -54,22 +55,20 @@ const WEBCODECS_FORMATS = new Set([
 ]);
 
 /** Codec used per format in Mediabunny AudioBufferSource. */
-const FORMAT_CODEC_MAP: Record<string, string> = {
+export const FORMAT_CODEC_MAP: Record<string, string> = {
 	[FORMAT_WEBM]: 'opus',
 	[FORMAT_OGG]: 'opus',
 	[FORMAT_MP4]: 'aac',
 	[FORMAT_M4A]: 'aac',
 	[FORMAT_AAC]: 'aac',
 	[FORMAT_FLAC]: 'flac',
+	[FORMAT_MP3]: 'mp3',
 };
-
-/** MP3 encoding chunk size (MPEG standard frame). */
-const MP3_SAMPLES_PER_FRAME = 1152;
 
 /**
  * Creates the appropriate Mediabunny OutputFormat for the given format.
  */
-function createOutputFormat(format: string): OutputFormat {
+export function createOutputFormat(format: string): OutputFormat {
 	switch (format) {
 		case FORMAT_WEBM:
 			return new WebMOutputFormat();
@@ -81,8 +80,29 @@ function createOutputFormat(format: string): OutputFormat {
 			return new Mp4OutputFormat();
 		case FORMAT_FLAC:
 			return new FlacOutputFormat();
+		case FORMAT_MP3:
+			return new Mp3OutputFormat();
 		default:
 			throw new EncodingError(`No output format for "${format}"`, format);
+	}
+}
+
+/**
+ * Ensures the encoder for the given format is available, registering
+ * the Mediabunny extension encoder (FLAC, MP3) when the platform has
+ * no native WebCodecs support. The canEncodeAudio guard makes repeat
+ * calls no-ops: a registered extension encoder counts as encodable.
+ * @param format - Target audio format
+ */
+export async function ensureEncoderRegistered(format: string): Promise<void> {
+	if (format === FORMAT_FLAC && !(await canEncodeAudio('flac'))) {
+		const { registerFlacEncoder } =
+			await import('@mediabunny/flac-encoder');
+		registerFlacEncoder();
+	}
+	if (format === FORMAT_MP3 && !(await canEncodeAudio('mp3'))) {
+		const { registerMp3Encoder } = await import('@mediabunny/mp3-encoder');
+		registerMp3Encoder();
 	}
 }
 
@@ -106,11 +126,11 @@ export async function encodeAudioBuffer(
 		return bufferToWave(buffer, buffer.length);
 	}
 
-	if (format === FORMAT_MP3) {
-		return encodeWithLamejs(buffer, options, onProgress);
-	}
-
-	if (WEBCODECS_FORMATS.has(format) || format === FORMAT_FLAC) {
+	if (
+		WEBCODECS_FORMATS.has(format) ||
+		format === FORMAT_FLAC ||
+		format === FORMAT_MP3
+	) {
 		return encodeWithMediabunny(buffer, options, onProgress);
 	}
 
@@ -119,7 +139,7 @@ export async function encodeAudioBuffer(
 
 /**
  * Encodes AudioBuffer using Mediabunny (WebCodecs-backed for Opus/AAC,
- * extension-backed for FLAC).
+ * extension-backed for FLAC and MP3).
  */
 async function encodeWithMediabunny(
 	buffer: AudioBuffer,
@@ -134,17 +154,14 @@ async function encodeWithMediabunny(
 	}
 
 	try {
-		// FLAC requires the encoder extension to be loaded first
-		if (format === FORMAT_FLAC) {
-			await import('@mediabunny/flac-encoder');
-		}
+		await ensureEncoderRegistered(format);
 
 		const outputFormat = createOutputFormat(format);
 		const target = new BufferTarget();
 		const output = new Output({ format: outputFormat, target });
 
 		const audioSource = new AudioBufferSource({
-			codec: codec as 'opus' | 'aac' | 'flac',
+			codec: codec as 'opus' | 'aac' | 'flac' | 'mp3',
 			bitrate,
 		});
 		output.addAudioTrack(audioSource);
@@ -172,80 +189,6 @@ async function encodeWithMediabunny(
 			error instanceof Error ? error.message : String(error),
 			format,
 			error,
-		);
-	}
-}
-
-/**
- * Converts Float32Array channel data to Int16Array for lamejs.
- */
-function floatTo16BitPCM(input: Float32Array): Int16Array {
-	const output = new Int16Array(input.length);
-	for (let i = 0; i < input.length; i++) {
-		const s = Math.max(-1, Math.min(1, input[i]));
-		output[i] = s < 0 ? s * 0x8000 : s * 0x7fff;
-	}
-	return output;
-}
-
-/**
- * Encodes AudioBuffer to MP3 using lamejs.
- */
-function encodeWithLamejs(
-	buffer: AudioBuffer,
-	options: EncodingOptions,
-	onProgress?: ProgressCallback,
-): Promise<Blob> {
-	try {
-		const { bitrate } = options;
-		const bitrateKbps = Math.round(bitrate / 1000);
-		const channels = buffer.numberOfChannels;
-		const sampleRate = buffer.sampleRate;
-
-		const encoder = new Mp3Encoder(channels, sampleRate, bitrateKbps);
-		const mp3Chunks: Uint8Array[] = [];
-
-		const left = floatTo16BitPCM(buffer.getChannelData(0));
-		const right =
-			channels >= 2
-				? floatTo16BitPCM(buffer.getChannelData(1))
-				: undefined;
-
-		const totalSamples = left.length;
-		let samplesProcessed = 0;
-
-		for (let i = 0; i < totalSamples; i += MP3_SAMPLES_PER_FRAME) {
-			const end = Math.min(i + MP3_SAMPLES_PER_FRAME, totalSamples);
-			const leftChunk = left.subarray(i, end);
-			const rightChunk = right?.subarray(i, end);
-
-			const mp3buf = encoder.encodeBuffer(leftChunk, rightChunk);
-			if (mp3buf.length > 0) {
-				mp3Chunks.push(new Uint8Array(mp3buf));
-			}
-
-			samplesProcessed = end;
-			if (onProgress && totalSamples > 0) {
-				onProgress(Math.round((samplesProcessed / totalSamples) * 90));
-			}
-		}
-
-		const finalBuf = encoder.flush();
-		if (finalBuf.length > 0) {
-			mp3Chunks.push(new Uint8Array(finalBuf));
-		}
-
-		onProgress?.(100);
-		return Promise.resolve(
-			new Blob(mp3Chunks as BlobPart[], { type: 'audio/mp3' }),
-		);
-	} catch (error) {
-		return Promise.reject(
-			new EncodingError(
-				error instanceof Error ? error.message : String(error),
-				FORMAT_MP3,
-				error,
-			),
 		);
 	}
 }
@@ -291,7 +234,7 @@ export function getEncoderDescription(format: string): string {
 		case FORMAT_AAC:
 			return 'AudioEncoder (AAC) + Mediabunny';
 		case FORMAT_MP3:
-			return 'lamejs (MP3)';
+			return 'Mediabunny MP3 Encoder';
 		case FORMAT_FLAC:
 			return 'Mediabunny FLAC Encoder';
 		default:

--- a/src/recording/AudioEncoder.ts
+++ b/src/recording/AudioEncoder.ts
@@ -16,7 +16,7 @@ import {
 	Mp3OutputFormat,
 	canEncodeAudio,
 } from 'mediabunny';
-import type { OutputFormat } from 'mediabunny';
+import type { OutputFormat, AudioCodec } from 'mediabunny';
 import { bufferToWave } from './WavEncoder';
 import { EncodingError } from '../errors';
 import {
@@ -55,7 +55,7 @@ const WEBCODECS_FORMATS = new Set([
 ]);
 
 /** Codec used per format in Mediabunny AudioBufferSource. */
-export const FORMAT_CODEC_MAP: Record<string, string> = {
+export const FORMAT_CODEC_MAP: Record<string, AudioCodec> = {
 	[FORMAT_WEBM]: 'opus',
 	[FORMAT_OGG]: 'opus',
 	[FORMAT_MP4]: 'aac',
@@ -147,7 +147,7 @@ async function encodeWithMediabunny(
 	onProgress?: ProgressCallback,
 ): Promise<Blob> {
 	const { format, bitrate } = options;
-	const codec = FORMAT_CODEC_MAP[format];
+	const codec: AudioCodec | undefined = FORMAT_CODEC_MAP[format];
 
 	if (!codec) {
 		throw new EncodingError(`No codec mapping for "${format}"`, format);
@@ -161,7 +161,7 @@ async function encodeWithMediabunny(
 		const output = new Output({ format: outputFormat, target });
 
 		const audioSource = new AudioBufferSource({
-			codec: codec as 'opus' | 'aac' | 'flac' | 'mp3',
+			codec,
 			bitrate,
 		});
 		output.addAudioTrack(audioSource);
@@ -195,23 +195,22 @@ async function encodeWithMediabunny(
 
 /**
  * Checks whether offline encoding is supported for the given format.
- * WAV and MP3 are always available; WebCodecs formats require
- * AudioEncoder global; FLAC depends on the Mediabunny extension.
+ * WAV is always available; MP3 and FLAC are always available through
+ * the bundled Mediabunny extension encoders; WebCodecs formats
+ * require the AudioEncoder global.
  * @param format - Audio format to check
  * @returns true if offline encoding to this format is possible
  */
 export function isOfflineEncodingSupported(format: string): boolean {
-	if (format === FORMAT_WAV) {
-		return true;
-	}
-	if (format === FORMAT_MP3) {
+	if (
+		format === FORMAT_WAV ||
+		format === FORMAT_MP3 ||
+		format === FORMAT_FLAC
+	) {
 		return true;
 	}
 	if (WEBCODECS_FORMATS.has(format)) {
 		return typeof AudioEncoder !== 'undefined';
-	}
-	if (format === FORMAT_FLAC) {
-		return true;
 	}
 	return false;
 }

--- a/src/recording/AudioFormatConverter.ts
+++ b/src/recording/AudioFormatConverter.ts
@@ -144,16 +144,31 @@ export async function decodeAudioBlob(
 }
 
 /**
+ * Options controlling blob-to-format conversion behavior.
+ */
+export interface BlobConversionOptions {
+	/**
+	 * Allows copying the audio packets without re-encoding (remux)
+	 * when the input codec already matches the target codec. Remux
+	 * ignores the requested bitrate, so it is only safe when the
+	 * input is known to be encoded at that bitrate already (the
+	 * recording pipeline configures the recorder with the session
+	 * bitrate). Conversions driven by an explicit user bitrate
+	 * choice must leave this off so the selection is always honored.
+	 */
+	allowRemux?: boolean;
+}
+
+/**
  * Converts a compressed audio blob to the target format using the
  * streaming mediabunny Conversion pipeline: audio is transcoded in
  * chunks without materializing the whole recording as PCM in memory.
- * When the input codec already matches the target codec the packets
- * are copied without re-encoding (remux); the matching input was
- * already encoded at the bitrate configured for the session, so the
- * remux preserves it exactly.
+ * With allowRemux, packets of an input whose codec already matches
+ * the target codec are copied without re-encoding.
  * @param recordedBlob - Intermediate compressed blob
  * @param targetFormat - Desired output format
  * @param bitrate - Bitrate in bits per second
+ * @param allowRemux - Allow packet copy when the codecs match
  * @param onProgress - Optional encoding progress callback (0-100)
  * @returns Re-encoded blob in the target format
  * @throws Error when the target format has no codec mapping, the
@@ -164,6 +179,7 @@ async function convertBlobWithConversion(
 	recordedBlob: Blob,
 	targetFormat: string,
 	bitrate: number,
+	allowRemux: boolean,
 	onProgress?: FormatProgressCallback,
 ): Promise<Blob> {
 	const codec: AudioCodec | undefined = FORMAT_CODEC_MAP[targetFormat];
@@ -190,13 +206,17 @@ async function convertBlobWithConversion(
 
 	// Omitting bitrate lets mediabunny copy packets (remux) when the
 	// input codec matches the target; setting it always forces a
-	// re-encode per the Conversion contract. Discarded tracks are
-	// handled explicitly below, so mediabunny's own console warnings
-	// about them are disabled.
+	// re-encode per the Conversion contract. Remux is allowed only
+	// when the caller knows the input is already at the requested
+	// bitrate. Discarded tracks are handled explicitly below, so
+	// mediabunny's own console warnings about them are disabled.
 	const conversion = await Conversion.init({
 		input,
 		output,
-		audio: audioTrack.codec === codec ? { codec } : { codec, bitrate },
+		audio:
+			allowRemux && audioTrack.codec === codec
+				? { codec }
+				: { codec, bitrate },
 		showWarnings: false,
 	});
 
@@ -245,6 +265,7 @@ async function convertBlobWithConversion(
  * @param targetFormat - Desired output format
  * @param bitrate - Bitrate in bits per second
  * @param onProgress - Optional encoding progress callback (0-100)
+ * @param options - Conversion behavior options
  * @returns Re-encoded blob in the target format
  */
 export async function convertBlobToFormat(
@@ -252,12 +273,14 @@ export async function convertBlobToFormat(
 	targetFormat: string,
 	bitrate: number,
 	onProgress?: FormatProgressCallback,
+	options: BlobConversionOptions = {},
 ): Promise<Blob> {
 	try {
 		return await convertBlobWithConversion(
 			recordedBlob,
 			targetFormat,
 			bitrate,
+			options.allowRemux ?? false,
 			onProgress,
 		);
 	} catch (error) {

--- a/src/recording/AudioFormatConverter.ts
+++ b/src/recording/AudioFormatConverter.ts
@@ -107,39 +107,29 @@ export async function convertBlobToWav(recordedBlob: Blob): Promise<Blob> {
 }
 
 /**
- * Decodes compressed audio bytes preserving the native sample rate.
- * First probes with a temporary AudioContext to discover the native
- * rate, then re-decodes with an OfflineAudioContext at that rate to
- * avoid resampling artifacts. The probe uses a copy of the buffer
- * because decodeAudioData detaches its input.
+ * Decodes compressed audio bytes into an AudioBuffer.
+ * Decodes exactly once: decodeAudioData resamples to the context rate
+ * by spec, so the previous probe-then-redecode-at-native-rate approach
+ * produced an identical buffer while doubling decode time and peak
+ * memory (two full PCM copies of the recording).
  * @param arrayBuffer - Encoded audio file bytes
- * @returns Decoded AudioBuffer at the native sample rate
+ * @returns Decoded AudioBuffer
  */
-export async function decodeAudioDataAtNativeRate(
+export async function decodeAudioBlob(
 	arrayBuffer: ArrayBuffer,
 ): Promise<AudioBuffer> {
-	const probeCtx = new AudioContext();
-	let probeBuffer: AudioBuffer;
+	const audioContext = new AudioContext();
 	try {
-		probeBuffer = await probeCtx.decodeAudioData(arrayBuffer.slice(0));
+		return await audioContext.decodeAudioData(arrayBuffer);
 	} finally {
 		// Close even when decoding fails (corrupted/unsupported input),
 		// otherwise the AudioContext leaks
-		await probeCtx.close();
+		await audioContext.close();
 	}
-
-	const offlineCtx = new OfflineAudioContext(
-		probeBuffer.numberOfChannels,
-		probeBuffer.length,
-		probeBuffer.sampleRate,
-	);
-	return offlineCtx.decodeAudioData(arrayBuffer);
 }
 
 /**
  * Decodes an intermediate blob and re-encodes it to the target format.
- * Uses OfflineAudioContext at the native sample rate to avoid
- * resampling artifacts.
  * @param recordedBlob - Intermediate compressed blob
  * @param targetFormat - Desired output format
  * @param bitrate - Bitrate in bits per second
@@ -153,7 +143,7 @@ export async function convertBlobToFormat(
 	onProgress?: FormatProgressCallback,
 ): Promise<Blob> {
 	const arrayBuffer = await recordedBlob.arrayBuffer();
-	const decodedBuffer = await decodeAudioDataAtNativeRate(arrayBuffer);
+	const decodedBuffer = await decodeAudioBlob(arrayBuffer);
 
 	return encodeAudioBuffer(
 		decodedBuffer,

--- a/src/recording/AudioFormatConverter.ts
+++ b/src/recording/AudioFormatConverter.ts
@@ -309,8 +309,15 @@ export async function mergeAudioTracks(
 	const longestDuration = Math.max(
 		...validBuffers.map((buffer) => buffer.duration),
 	);
-	const offlineContext = new OfflineAudioContext(
+	// Mix in mono when every input is mono: a stereo render would just
+	// duplicate the mix into both channels while doubling encode time
+	// and file size. Any stereo input keeps the stereo render.
+	const channelCount = Math.min(
 		2,
+		Math.max(...validBuffers.map((buffer) => buffer.numberOfChannels)),
+	);
+	const offlineContext = new OfflineAudioContext(
+		channelCount,
 		audioContext.sampleRate * longestDuration,
 		audioContext.sampleRate,
 	);

--- a/src/recording/AudioFormatConverter.ts
+++ b/src/recording/AudioFormatConverter.ts
@@ -12,6 +12,7 @@ import {
 	ALL_FORMATS,
 	Conversion,
 } from 'mediabunny';
+import type { AudioCodec } from 'mediabunny';
 import type { RecordingTarget } from '../types';
 import type { AudioRecorderSettings } from '../settings/Settings';
 import { bufferToWave } from './WavEncoder';
@@ -165,12 +166,7 @@ async function convertBlobWithConversion(
 	bitrate: number,
 	onProgress?: FormatProgressCallback,
 ): Promise<Blob> {
-	const codec = FORMAT_CODEC_MAP[targetFormat] as
-		| 'opus'
-		| 'aac'
-		| 'flac'
-		| 'mp3'
-		| undefined;
+	const codec: AudioCodec | undefined = FORMAT_CODEC_MAP[targetFormat];
 	if (!codec) {
 		throw new Error(`No codec mapping for format "${targetFormat}"`);
 	}
@@ -194,11 +190,14 @@ async function convertBlobWithConversion(
 
 	// Omitting bitrate lets mediabunny copy packets (remux) when the
 	// input codec matches the target; setting it always forces a
-	// re-encode per the Conversion contract
+	// re-encode per the Conversion contract. Discarded tracks are
+	// handled explicitly below, so mediabunny's own console warnings
+	// about them are disabled.
 	const conversion = await Conversion.init({
 		input,
 		output,
 		audio: audioTrack.codec === codec ? { codec } : { codec, bitrate },
+		showWarnings: false,
 	});
 
 	// Conversion.init does not throw for codec problems: it silently

--- a/src/recording/AudioFormatConverter.ts
+++ b/src/recording/AudioFormatConverter.ts
@@ -4,11 +4,25 @@
  * @module recording/AudioFormatConverter
  */
 
+import {
+	Input,
+	Output,
+	BlobSource,
+	BufferTarget,
+	ALL_FORMATS,
+	Conversion,
+} from 'mediabunny';
 import type { RecordingTarget } from '../types';
 import type { AudioRecorderSettings } from '../settings/Settings';
 import { bufferToWave } from './WavEncoder';
-import { encodeAudioBuffer, isOfflineEncodingSupported } from './AudioEncoder';
-import { MIME_TYPE_AUDIO_PREFIX } from '../constants';
+import {
+	encodeAudioBuffer,
+	isOfflineEncodingSupported,
+	ensureEncoderRegistered,
+	createOutputFormat,
+	FORMAT_CODEC_MAP,
+} from './AudioEncoder';
+import { MIME_TYPE_AUDIO_PREFIX, PLUGIN_LOG_PREFIX } from '../constants';
 import {
 	buildMimeType,
 	FORMAT_WEBM,
@@ -129,7 +143,74 @@ export async function decodeAudioBlob(
 }
 
 /**
+ * Converts a compressed audio blob to the target format using the
+ * streaming mediabunny Conversion pipeline: audio is transcoded in
+ * chunks without materializing the whole recording as PCM in memory,
+ * and matching codecs are remuxed without re-encoding.
+ * @param recordedBlob - Intermediate compressed blob
+ * @param targetFormat - Desired output format
+ * @param bitrate - Bitrate in bits per second
+ * @param onProgress - Optional encoding progress callback (0-100)
+ * @returns Re-encoded blob in the target format
+ */
+async function convertBlobWithConversion(
+	recordedBlob: Blob,
+	targetFormat: string,
+	bitrate: number,
+	onProgress?: FormatProgressCallback,
+): Promise<Blob> {
+	await ensureEncoderRegistered(targetFormat);
+
+	const input = new Input({
+		source: new BlobSource(recordedBlob),
+		formats: ALL_FORMATS,
+	});
+	const target = new BufferTarget();
+	const output = new Output({
+		format: createOutputFormat(targetFormat),
+		target,
+	});
+
+	const conversion = await Conversion.init({
+		input,
+		output,
+		audio: {
+			codec: FORMAT_CODEC_MAP[targetFormat] as
+				| 'opus'
+				| 'aac'
+				| 'flac'
+				| 'mp3',
+			bitrate,
+		},
+	});
+
+	if (onProgress) {
+		let lastPercent = -1;
+		conversion.onProgress = (progress: number): void => {
+			const percent = Math.round(progress * 100);
+			if (percent !== lastPercent) {
+				lastPercent = percent;
+				onProgress(percent);
+			}
+		};
+	}
+
+	await conversion.execute();
+
+	const resultBuffer = target.buffer;
+	if (!resultBuffer || resultBuffer.byteLength === 0) {
+		throw new Error(`Conversion to "${targetFormat}" produced no output`);
+	}
+	return new Blob([resultBuffer], {
+		type: `${MIME_TYPE_AUDIO_PREFIX}${targetFormat}`,
+	});
+}
+
+/**
  * Decodes an intermediate blob and re-encodes it to the target format.
+ * Tries the streaming Conversion pipeline first and falls back to the
+ * full decode-then-encode path on any failure, so every format keeps
+ * working even when the input container is not readable by mediabunny.
  * @param recordedBlob - Intermediate compressed blob
  * @param targetFormat - Desired output format
  * @param bitrate - Bitrate in bits per second
@@ -142,6 +223,20 @@ export async function convertBlobToFormat(
 	bitrate: number,
 	onProgress?: FormatProgressCallback,
 ): Promise<Blob> {
+	try {
+		return await convertBlobWithConversion(
+			recordedBlob,
+			targetFormat,
+			bitrate,
+			onProgress,
+		);
+	} catch (error) {
+		console.warn(
+			`${PLUGIN_LOG_PREFIX} Streaming conversion failed, falling back to decode and re-encode:`,
+			error,
+		);
+	}
+
 	const arrayBuffer = await recordedBlob.arrayBuffer();
 	const decodedBuffer = await decodeAudioBlob(arrayBuffer);
 

--- a/src/recording/AudioFormatConverter.ts
+++ b/src/recording/AudioFormatConverter.ts
@@ -145,13 +145,19 @@ export async function decodeAudioBlob(
 /**
  * Converts a compressed audio blob to the target format using the
  * streaming mediabunny Conversion pipeline: audio is transcoded in
- * chunks without materializing the whole recording as PCM in memory,
- * and matching codecs are remuxed without re-encoding.
+ * chunks without materializing the whole recording as PCM in memory.
+ * When the input codec already matches the target codec the packets
+ * are copied without re-encoding (remux); the matching input was
+ * already encoded at the bitrate configured for the session, so the
+ * remux preserves it exactly.
  * @param recordedBlob - Intermediate compressed blob
  * @param targetFormat - Desired output format
  * @param bitrate - Bitrate in bits per second
  * @param onProgress - Optional encoding progress callback (0-100)
  * @returns Re-encoded blob in the target format
+ * @throws Error when the target format has no codec mapping, the
+ * input has no audio track, or the conversion cannot process the
+ * audio track (the caller falls back to decode and re-encode)
  */
 async function convertBlobWithConversion(
 	recordedBlob: Blob,
@@ -159,30 +165,55 @@ async function convertBlobWithConversion(
 	bitrate: number,
 	onProgress?: FormatProgressCallback,
 ): Promise<Blob> {
+	const codec = FORMAT_CODEC_MAP[targetFormat] as
+		| 'opus'
+		| 'aac'
+		| 'flac'
+		| 'mp3'
+		| undefined;
+	if (!codec) {
+		throw new Error(`No codec mapping for format "${targetFormat}"`);
+	}
+
 	await ensureEncoderRegistered(targetFormat);
 
 	const input = new Input({
 		source: new BlobSource(recordedBlob),
 		formats: ALL_FORMATS,
 	});
+	const audioTrack = await input.getPrimaryAudioTrack();
+	if (!audioTrack) {
+		throw new Error('Input contains no audio track');
+	}
+
 	const target = new BufferTarget();
 	const output = new Output({
 		format: createOutputFormat(targetFormat),
 		target,
 	});
 
+	// Omitting bitrate lets mediabunny copy packets (remux) when the
+	// input codec matches the target; setting it always forces a
+	// re-encode per the Conversion contract
 	const conversion = await Conversion.init({
 		input,
 		output,
-		audio: {
-			codec: FORMAT_CODEC_MAP[targetFormat] as
-				| 'opus'
-				| 'aac'
-				| 'flac'
-				| 'mp3',
-			bitrate,
-		},
+		audio: audioTrack.codec === codec ? { codec } : { codec, bitrate },
 	});
+
+	// Conversion.init does not throw for codec problems: it silently
+	// discards the track (undecodable_source_codec or
+	// no_encodable_target_codec) and would emit a container without
+	// audio. Fail here instead, so the caller's decode-and-re-encode
+	// fallback processes the input.
+	const audioDiscarded = conversion.discardedTracks.some((discarded) =>
+		discarded.track.isAudioTrack(),
+	);
+	if (!conversion.isValid || audioDiscarded) {
+		throw new Error(
+			`Conversion to "${targetFormat}" cannot process the input audio track`,
+		);
+	}
 
 	if (onProgress) {
 		let lastPercent = -1;

--- a/src/recording/AudioStreamHandler.ts
+++ b/src/recording/AudioStreamHandler.ts
@@ -5,6 +5,7 @@
 
 import { PLUGIN_LOG_PREFIX } from '../constants';
 import { AudioStreamError } from '../errors';
+import { delay } from '../utils/TimeUtils';
 import type { AudioRecorderSettings } from '../settings/Settings';
 
 export interface TrackAudioSource {
@@ -30,13 +31,6 @@ const MAX_RETRIES = 2;
  * Delay between retry attempts in milliseconds.
  */
 const RETRY_DELAY_MS = 500;
-
-/**
- * Delays execution for specified milliseconds.
- */
-function delay(ms: number): Promise<void> {
-	return new Promise((resolve) => activeWindow.setTimeout(resolve, ms));
-}
 
 /**
  * Gets a MediaStream for the specified audio device.

--- a/src/recording/RecordingManager.ts
+++ b/src/recording/RecordingManager.ts
@@ -101,6 +101,10 @@ export class RecordingManager {
 	private rotationPromise: Promise<void> | null = null;
 	/** Whether the session is being stopped (blocks new part rotations). */
 	private isStopping: boolean = false;
+	/** Last save-progress percent reported to the status bar. */
+	private lastProgressPercent: number = -1;
+	/** Last save-progress description reported to the status bar. */
+	private lastProgressDescription: string = '';
 
 	/**
 	 * Creates a new RecordingManager.
@@ -462,6 +466,8 @@ export class RecordingManager {
 			this.partActiveMs = 0;
 			this.rotationPromise = null;
 			this.isStopping = false;
+			this.lastProgressPercent = -1;
+			this.lastProgressDescription = '';
 			this.setStatus(RecordingStatus.Idle);
 		}
 	}
@@ -555,8 +561,28 @@ export class RecordingManager {
 		this.onStatusChange(status, saveProgress);
 	}
 
+	/**
+	 * Reports save progress to the status bar, skipping updates whose
+	 * whole percent and description did not change. Encoders may emit
+	 * progress per audio frame (hundreds of thousands of calls for a
+	 * long recording), and every accepted update touches the DOM.
+	 * @param percent - Progress percentage (0-100)
+	 * @param description - Progress phase description
+	 */
 	private updateSaveProgress(percent: number, description: string): void {
-		this.setStatus(RecordingStatus.Saving, { percent, description });
+		const wholePercent = Math.round(percent);
+		if (
+			wholePercent === this.lastProgressPercent &&
+			description === this.lastProgressDescription
+		) {
+			return;
+		}
+		this.lastProgressPercent = wholePercent;
+		this.lastProgressDescription = description;
+		this.setStatus(RecordingStatus.Saving, {
+			percent: wholePercent,
+			description,
+		});
 	}
 
 	private async saveRecording(): Promise<void> {

--- a/src/recording/RecordingManager.ts
+++ b/src/recording/RecordingManager.ts
@@ -1334,6 +1334,9 @@ export class RecordingManager {
 						);
 					}
 				},
+				// The intermediate blob was recorded at the session
+				// bitrate, so a codec-matching remux preserves it
+				{ allowRemux: true },
 			);
 			if (reportProgress) {
 				this.updateSaveProgress(60, 'Writing file...');

--- a/src/recording/RecordingManager.ts
+++ b/src/recording/RecordingManager.ts
@@ -1015,8 +1015,10 @@ export class RecordingManager {
 			offset += buf.byteLength;
 		}
 
-		// Temporary segment: adapter write keeps the .tmp file out of
-		// vault indexing and file events; final files use createBinary
+		// Temporary segment: a plain adapter write skips createBinary's
+		// synchronous vault-index update and event dispatch on the hot
+		// recording path (the watcher reconciles the file later);
+		// final files use createBinary
 		await this.app.vault.adapter.writeBinary(segmentPath, merged.buffer);
 		target.segmentPaths.push(segmentPath);
 		target.pcmBuffers = [];
@@ -1129,8 +1131,10 @@ export class RecordingManager {
 			const combined = new Blob(target.bufferedChunks, {
 				type: getRecorderMediaType(this.activeRecorderFormat),
 			});
-			// Temporary segment: adapter write keeps the .tmp file out of
-			// vault indexing and file events; final files use createBinary
+			// Temporary segment: a plain adapter write skips
+			// createBinary's synchronous vault-index update and event
+			// dispatch on the hot recording path (the watcher
+			// reconciles the file later); final files use createBinary
 			await this.app.vault.adapter.writeBinary(
 				segmentPath,
 				await combined.arrayBuffer(),

--- a/src/recording/RecordingManager.ts
+++ b/src/recording/RecordingManager.ts
@@ -1015,7 +1015,9 @@ export class RecordingManager {
 			offset += buf.byteLength;
 		}
 
-		await this.app.vault.createBinary(segmentPath, merged.buffer);
+		// Temporary segment: adapter write keeps the .tmp file out of
+		// vault indexing and file events; final files use createBinary
+		await this.app.vault.adapter.writeBinary(segmentPath, merged.buffer);
 		target.segmentPaths.push(segmentPath);
 		target.pcmBuffers = [];
 		target.pcmBufferedBytes = 0;
@@ -1127,7 +1129,9 @@ export class RecordingManager {
 			const combined = new Blob(target.bufferedChunks, {
 				type: getRecorderMediaType(this.activeRecorderFormat),
 			});
-			await this.app.vault.createBinary(
+			// Temporary segment: adapter write keeps the .tmp file out of
+			// vault indexing and file events; final files use createBinary
+			await this.app.vault.adapter.writeBinary(
 				segmentPath,
 				await combined.arrayBuffer(),
 			);

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -10,6 +10,7 @@ import {
 	Setting,
 	TFolder,
 	Vault,
+	debounce,
 } from 'obsidian';
 import type { Plugin } from 'obsidian';
 import type {
@@ -35,6 +36,9 @@ import {
 import { SystemDiagnostics } from '../diagnostics/SystemDiagnostics';
 import { SystemInfoModal } from '../diagnostics/SystemInfoModal';
 
+/** Debounce delay for saving text settings, in milliseconds. */
+const TEXT_SETTING_SAVE_DEBOUNCE_MS = 500;
+
 /**
  * Plugin interface for settings tab.
  */
@@ -54,6 +58,18 @@ export class AudioRecorderSettingTab extends PluginSettingTab {
 	private testRecorder: MediaRecorder | null = null;
 	private testChunks: Blob[] = [];
 	private testAudioElement: HTMLAudioElement | null = null;
+	/**
+	 * Debounced settings save shared by the text fields, which fire
+	 * onChange on every keystroke and would otherwise rewrite data.json
+	 * per character. Toggles, dropdowns, and sliders save directly.
+	 */
+	private readonly saveTextSettingDebounced = debounce(
+		() => {
+			void this.plugin.saveSettings();
+		},
+		TEXT_SETTING_SAVE_DEBOUNCE_MS,
+		true,
+	);
 
 	/**
 	 * Creates a new AudioRecorderSettingTab.
@@ -274,9 +290,9 @@ export class AudioRecorderSettingTab extends PluginSettingTab {
 					datalist.createEl('option', { attr: { value: folder } });
 				});
 				text.setValue(this.plugin.settings.saveFolder);
-				text.onChange(async (value) => {
+				text.onChange((value) => {
 					this.plugin.settings.saveFolder = value;
-					await this.plugin.saveSettings();
+					this.saveTextSettingDebounced();
 				});
 			});
 
@@ -305,9 +321,9 @@ export class AudioRecorderSettingTab extends PluginSettingTab {
 					text
 						.setPlaceholder('Audio')
 						.setValue(this.plugin.settings.activeFileSubfolder)
-						.onChange(async (value) => {
+						.onChange((value) => {
 							this.plugin.settings.activeFileSubfolder = value;
-							await this.plugin.saveSettings();
+							this.saveTextSettingDebounced();
 						}),
 				);
 		}
@@ -319,9 +335,9 @@ export class AudioRecorderSettingTab extends PluginSettingTab {
 				text
 					.setPlaceholder('Enter file prefix')
 					.setValue(this.plugin.settings.filePrefix)
-					.onChange(async (value) => {
+					.onChange((value) => {
 						this.plugin.settings.filePrefix = value;
-						await this.plugin.saveSettings();
+						this.saveTextSettingDebounced();
 					}),
 			);
 
@@ -385,7 +401,7 @@ export class AudioRecorderSettingTab extends PluginSettingTab {
 				text
 					.setPlaceholder(DEFAULT_SPLIT_PART_SUFFIX)
 					.setValue(this.plugin.settings.splitPartSuffix)
-					.onChange(async (value) => {
+					.onChange((value) => {
 						// Mirror the manual split dialog: surrounding
 						// whitespace is ignored and an empty field means
 						// the default suffix. Only valid suffixes are
@@ -403,7 +419,7 @@ export class AudioRecorderSettingTab extends PluginSettingTab {
 							trimmed === ''
 								? DEFAULT_SPLIT_PART_SUFFIX
 								: trimmed;
-						await this.plugin.saveSettings();
+						this.saveTextSettingDebounced();
 					}),
 			);
 
@@ -745,9 +761,11 @@ export class AudioRecorderSettingTab extends PluginSettingTab {
 	}
 
 	/**
-	 * Cleans up test recording resources when settings tab is hidden.
+	 * Cleans up test recording resources when settings tab is hidden
+	 * and flushes a pending debounced text-setting save.
 	 */
 	hide(): void {
+		this.saveTextSettingDebounced.run();
 		void this.cleanupTestRecording();
 	}
 }

--- a/src/types/lamejs.d.ts
+++ b/src/types/lamejs.d.ts
@@ -1,7 +1,0 @@
-declare module 'lamejs' {
-	export class Mp3Encoder {
-		constructor(channels: number, sampleRate: number, kbps: number);
-		encodeBuffer(left: Int16Array, right?: Int16Array): Int8Array;
-		flush(): Int8Array;
-	}
-}

--- a/src/ui/ConversionModal.ts
+++ b/src/ui/ConversionModal.ts
@@ -11,7 +11,7 @@ import {
 } from '../recording/AudioEncoder';
 import { AUDIO_EXTENSIONS, FORMAT_WAV } from '../constants';
 import { getSupportedBitrates } from '../recording/AudioCapabilityDetector';
-import { decodeAudioDataAtNativeRate } from '../recording/AudioFormatConverter';
+import { decodeAudioBlob } from '../recording/AudioFormatConverter';
 import { updateLinksInOpenEditors } from '../utils/LinkUpdater';
 import type {
 	AudioRecorderSettings,
@@ -152,7 +152,7 @@ export class ConversionModal extends Modal {
 			);
 
 			progressEl.setText('Decoding audio...');
-			const audioBuffer = await decodeAudioDataAtNativeRate(arrayBuffer);
+			const audioBuffer = await decodeAudioBlob(arrayBuffer);
 
 			progressEl.setText('Encoding...');
 			const blob = await encodeAudioBuffer(

--- a/src/ui/ConversionModal.ts
+++ b/src/ui/ConversionModal.ts
@@ -11,7 +11,10 @@ import {
 } from '../recording/AudioEncoder';
 import { AUDIO_EXTENSIONS, FORMAT_WAV } from '../constants';
 import { getSupportedBitrates } from '../recording/AudioCapabilityDetector';
-import { decodeAudioBlob } from '../recording/AudioFormatConverter';
+import {
+	decodeAudioBlob,
+	convertBlobToFormat,
+} from '../recording/AudioFormatConverter';
 import { updateLinksInOpenEditors } from '../utils/LinkUpdater';
 import type {
 	AudioRecorderSettings,
@@ -151,20 +154,34 @@ export class ConversionModal extends Modal {
 				this.sourceFile.path,
 			);
 
-			progressEl.setText('Decoding audio...');
-			const audioBuffer = await decodeAudioBlob(arrayBuffer);
-
-			progressEl.setText('Encoding...');
-			const blob = await encodeAudioBuffer(
-				audioBuffer,
-				{
-					format: this.targetFormat,
-					bitrate: this.bitrate,
-				},
-				(percent) => {
-					progressEl.setText(`Encoding... ${String(percent)}%`);
-				},
-			);
+			let blob: Blob;
+			if (this.targetFormat === FORMAT_WAV) {
+				// WAV needs a full decode; the streaming pipeline only
+				// targets compressed formats
+				progressEl.setText('Decoding audio...');
+				const audioBuffer = await decodeAudioBlob(arrayBuffer);
+				progressEl.setText('Encoding...');
+				blob = await encodeAudioBuffer(
+					audioBuffer,
+					{
+						format: this.targetFormat,
+						bitrate: this.bitrate,
+					},
+					(percent) => {
+						progressEl.setText(`Encoding... ${String(percent)}%`);
+					},
+				);
+			} else {
+				progressEl.setText('Converting...');
+				blob = await convertBlobToFormat(
+					new Blob([arrayBuffer]),
+					this.targetFormat,
+					this.bitrate,
+					(percent) => {
+						progressEl.setText(`Converting... ${String(percent)}%`);
+					},
+				);
+			}
 
 			progressEl.setText('Saving...');
 			await this.app.vault.createBinary(

--- a/src/ui/SplitModal.ts
+++ b/src/ui/SplitModal.ts
@@ -21,7 +21,7 @@ import {
 	SPLIT_PART_SUFFIX_RULE_TEXT,
 } from '../constants';
 import { getSupportedBitrates } from '../recording/AudioCapabilityDetector';
-import { decodeAudioDataAtNativeRate } from '../recording/AudioFormatConverter';
+import { decodeAudioBlob } from '../recording/AudioFormatConverter';
 import {
 	parseWavLayout,
 	buildWavPart,
@@ -456,7 +456,7 @@ export class SplitModal extends Modal {
 		}
 
 		this.setProgress(progressEl, 'Decoding audio...');
-		const audioBuffer = await decodeAudioDataAtNativeRate(sourceBytes);
+		const audioBuffer = await decodeAudioBlob(sourceBytes);
 		const partSamples = partSeconds * audioBuffer.sampleRate;
 		if (audioBuffer.length <= partSamples) {
 			new Notice('File is shorter than one part.');

--- a/src/ui/SplitModal.ts
+++ b/src/ui/SplitModal.ts
@@ -34,6 +34,7 @@ import {
 } from '../recording/AudioSplitter';
 import { updateLinksInVault } from '../utils/LinkUpdater';
 import type { VaultLinkUpdateResult } from '../utils/LinkUpdater';
+import { delay } from '../utils/TimeUtils';
 import type {
 	AudioRecorderSettings,
 	ConversionLinkAction,
@@ -543,10 +544,8 @@ export class SplitModal extends Modal {
 					path: partPaths[i],
 					file: created instanceof TFile ? created : null,
 				});
-				// Yield to the UI between parts: MP3 encoding is synchronous
-				await new Promise<void>((resolve) =>
-					activeWindow.setTimeout(resolve, 0),
-				);
+				// Yield to the UI between parts so the progress text repaints
+				await delay(0);
 			}
 		} catch (error) {
 			for (const part of written) {

--- a/src/utils/TimeUtils.ts
+++ b/src/utils/TimeUtils.ts
@@ -1,0 +1,15 @@
+/**
+ * Time-related utilities shared across modules.
+ * @module utils/TimeUtils
+ */
+
+/**
+ * Delays execution for the specified number of milliseconds.
+ * Uses activeWindow so the timer is attached to the active Obsidian
+ * window (multi-window support).
+ * @param ms - Delay duration in milliseconds
+ * @returns Promise resolved after the delay
+ */
+export function delay(ms: number): Promise<void> {
+	return new Promise((resolve) => activeWindow.setTimeout(resolve, ms));
+}

--- a/tests/mocks/flac-encoder.ts
+++ b/tests/mocks/flac-encoder.ts
@@ -1,6 +1,8 @@
 /**
  * Mock for @mediabunny/flac-encoder.
- * The real module is a side-effect import that registers the FLAC codec.
- * In tests, this is a no-op.
+ * The real module registers a custom FLAC encoder with mediabunny.
+ * In tests, registration is a no-op.
  */
-export {};
+export const registerFlacEncoder = (): void => {
+	// Mock implementation
+};

--- a/tests/mocks/mp3-encoder.ts
+++ b/tests/mocks/mp3-encoder.ts
@@ -1,0 +1,8 @@
+/**
+ * Mock for @mediabunny/mp3-encoder.
+ * The real module registers a custom MP3 encoder with mediabunny.
+ * In tests, registration is a no-op.
+ */
+export const registerMp3Encoder = (): void => {
+	// Mock implementation
+};

--- a/tests/mocks/obsidian.ts
+++ b/tests/mocks/obsidian.ts
@@ -8,7 +8,7 @@
  */
 export class Plugin {
 	app: App;
-	manifest: PluginManifest | null = null;
+	manifest: PluginManifest;
 
 	constructor(app: App, manifest: PluginManifest) {
 		this.app = app;
@@ -58,6 +58,10 @@ export class App {
 export class Vault {
 	adapter = {
 		exists: async (_path: string): Promise<boolean> => false,
+		read: async (_path: string): Promise<string> => '',
+		write: async (_path: string, _data: string): Promise<void> => {
+			// Mock implementation
+		},
 		append: async (_path: string, _data: ArrayBuffer): Promise<void> => {
 			// Mock implementation
 		},
@@ -430,11 +434,69 @@ export const Platform = {
 	isMobileApp: false,
 };
 
+/**
+ * Debounced function type returned by the debounce mock.
+ */
+export type Debouncer<T extends unknown[], V> = ((...args: T) => void) & {
+	cancel: () => void;
+	run: () => V | undefined;
+};
+
+/**
+ * Mock debounce function. Defers the callback to a timer like the real
+ * implementation so tests can flush it with fake timers or run().
+ */
+export function debounce<T extends unknown[], V>(
+	cb: (...args: T) => V,
+	timeout?: number,
+	_resetTimer?: boolean,
+): Debouncer<T, V> {
+	let timer: ReturnType<typeof setTimeout> | null = null;
+	let pendingArgs: T | null = null;
+
+	const debounced = ((...args: T): void => {
+		pendingArgs = args;
+		if (timer !== null) {
+			clearTimeout(timer);
+		}
+		timer = setTimeout(() => {
+			timer = null;
+			if (pendingArgs) {
+				const callArgs = pendingArgs;
+				pendingArgs = null;
+				cb(...callArgs);
+			}
+		}, timeout ?? 0);
+	}) as Debouncer<T, V>;
+
+	debounced.cancel = (): void => {
+		if (timer !== null) {
+			clearTimeout(timer);
+			timer = null;
+		}
+		pendingArgs = null;
+	};
+
+	debounced.run = (): V | undefined => {
+		if (timer === null || !pendingArgs) {
+			return undefined;
+		}
+		clearTimeout(timer);
+		timer = null;
+		const callArgs = pendingArgs;
+		pendingArgs = null;
+		return cb(...callArgs);
+	};
+
+	return debounced;
+}
+
 // Type definitions
 export interface PluginManifest {
 	id: string;
 	name: string;
 	version: string;
+	dir?: string;
 }
 
 export interface Command {

--- a/tests/unit/AudioEncoder.test.ts
+++ b/tests/unit/AudioEncoder.test.ts
@@ -44,20 +44,16 @@ jest.mock('mediabunny', () => ({
 	WebMOutputFormat: jest.fn(),
 	OggOutputFormat: jest.fn(),
 	FlacOutputFormat: jest.fn(),
+	Mp3OutputFormat: jest.fn(),
+	canEncodeAudio: jest.fn().mockResolvedValue(false),
 }));
 
-// Mock @mediabunny/flac-encoder (side-effect only import)
-jest.mock('@mediabunny/flac-encoder', () => ({}));
-
-// Mock lamejs
-const mockEncodeBuffer = jest.fn().mockReturnValue(new Int8Array([1, 2, 3]));
-const mockFlush = jest.fn().mockReturnValue(new Int8Array([4, 5]));
-
-jest.mock('lamejs', () => ({
-	Mp3Encoder: jest.fn().mockImplementation(() => ({
-		encodeBuffer: mockEncodeBuffer,
-		flush: mockFlush,
-	})),
+// Mock encoder extensions (register custom encoders with mediabunny)
+jest.mock('@mediabunny/flac-encoder', () => ({
+	registerFlacEncoder: jest.fn(),
+}));
+jest.mock('@mediabunny/mp3-encoder', () => ({
+	registerMp3Encoder: jest.fn(),
 }));
 
 describe('AudioEncoder', () => {
@@ -87,8 +83,9 @@ describe('AudioEncoder', () => {
 			expect(result.type).toBe('audio/wav');
 		});
 
-		it('should encode MP3 using lamejs', async () => {
-			const { Mp3Encoder } = jest.requireMock('lamejs');
+		it('should encode MP3 using Mediabunny with the MP3 codec', async () => {
+			const { Mp3OutputFormat, AudioBufferSource } =
+				jest.requireMock('mediabunny');
 			const buffer = createMockAudioBuffer(1, 2304, 44100);
 
 			const result = await encodeAudioBuffer(buffer, {
@@ -97,26 +94,63 @@ describe('AudioEncoder', () => {
 				bitrate: 128000,
 			});
 
-			expect(Mp3Encoder).toHaveBeenCalledWith(1, 44100, 128);
-			expect(mockEncodeBuffer).toHaveBeenCalled();
-			expect(mockFlush).toHaveBeenCalled();
+			expect(Mp3OutputFormat).toHaveBeenCalled();
+			expect(AudioBufferSource).toHaveBeenCalledWith(
+				expect.objectContaining({ codec: 'mp3', bitrate: 128000 }),
+			);
 			expect(result).toBeInstanceOf(Blob);
 			expect(result.type).toBe('audio/mp3');
 		});
 
-		it('should encode stereo MP3 with both channels', async () => {
-			const buffer = createMockAudioBuffer(2, 2304, 44100);
+		it('should register the MP3 extension encoder when not natively supported', async () => {
+			const { canEncodeAudio } = jest.requireMock('mediabunny');
+			const { registerMp3Encoder } = jest.requireMock(
+				'@mediabunny/mp3-encoder',
+			);
+			canEncodeAudio.mockResolvedValue(false);
+			const buffer = createMockAudioBuffer(1, 2304, 44100);
 
 			await encodeAudioBuffer(buffer, {
 				...defaultOptions,
 				format: 'mp3',
 			});
 
-			// Should pass right channel to encodeBuffer
-			expect(mockEncodeBuffer).toHaveBeenCalledWith(
-				expect.any(Int16Array),
-				expect.any(Int16Array),
+			expect(canEncodeAudio).toHaveBeenCalledWith('mp3');
+			expect(registerMp3Encoder).toHaveBeenCalledTimes(1);
+		});
+
+		it('should skip MP3 encoder registration when natively supported', async () => {
+			const { canEncodeAudio } = jest.requireMock('mediabunny');
+			const { registerMp3Encoder } = jest.requireMock(
+				'@mediabunny/mp3-encoder',
 			);
+			canEncodeAudio.mockResolvedValue(true);
+			const buffer = createMockAudioBuffer(1, 2304, 44100);
+
+			await encodeAudioBuffer(buffer, {
+				...defaultOptions,
+				format: 'mp3',
+			});
+
+			expect(registerMp3Encoder).not.toHaveBeenCalled();
+			canEncodeAudio.mockResolvedValue(false);
+		});
+
+		it('should register the FLAC extension encoder when not natively supported', async () => {
+			const { canEncodeAudio } = jest.requireMock('mediabunny');
+			const { registerFlacEncoder } = jest.requireMock(
+				'@mediabunny/flac-encoder',
+			);
+			canEncodeAudio.mockResolvedValue(false);
+			const buffer = createMockAudioBuffer(1, 4096, 44100);
+
+			await encodeAudioBuffer(buffer, {
+				...defaultOptions,
+				format: 'flac',
+			});
+
+			expect(canEncodeAudio).toHaveBeenCalledWith('flac');
+			expect(registerFlacEncoder).toHaveBeenCalledTimes(1);
 		});
 
 		it('should encode WebM using Mediabunny', async () => {
@@ -261,10 +295,9 @@ describe('AudioEncoder', () => {
 				onProgress,
 			);
 
-			expect(onProgress).toHaveBeenCalled();
-			const lastCall =
-				onProgress.mock.calls[onProgress.mock.calls.length - 1];
-			expect(lastCall[0]).toBe(100);
+			expect(onProgress).toHaveBeenCalledWith(10);
+			expect(onProgress).toHaveBeenCalledWith(80);
+			expect(onProgress).toHaveBeenCalledWith(100);
 		});
 
 		it('should call progress callback during Mediabunny encoding', async () => {
@@ -294,10 +327,8 @@ describe('AudioEncoder', () => {
 			).rejects.toThrow(EncodingError);
 		});
 
-		it('should wrap lamejs errors in EncodingError', async () => {
-			mockEncodeBuffer.mockImplementationOnce(() => {
-				throw new Error('Encoding failed');
-			});
+		it('should wrap MP3 encoding errors in EncodingError', async () => {
+			mockStart.mockRejectedValueOnce(new Error('Encoding failed'));
 			const buffer = createMockAudioBuffer(1, 2304, 44100);
 
 			await expect(
@@ -382,7 +413,7 @@ describe('AudioEncoder', () => {
 		});
 
 		it('should return correct description for MP3', () => {
-			expect(getEncoderDescription('mp3')).toBe('lamejs (MP3)');
+			expect(getEncoderDescription('mp3')).toBe('Mediabunny MP3 Encoder');
 		});
 
 		it('should return correct description for FLAC', () => {

--- a/tests/unit/AudioEncoder.test.ts
+++ b/tests/unit/AudioEncoder.test.ts
@@ -59,6 +59,11 @@ jest.mock('@mediabunny/mp3-encoder', () => ({
 describe('AudioEncoder', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
+		// Re-arm the default: clearAllMocks does not reset
+		// implementations, so a test that flips this mock would
+		// otherwise leak its value into the following tests
+		const { canEncodeAudio } = jest.requireMock('mediabunny');
+		canEncodeAudio.mockResolvedValue(false);
 	});
 
 	describe('encodeAudioBuffer', () => {
@@ -133,7 +138,6 @@ describe('AudioEncoder', () => {
 			});
 
 			expect(registerMp3Encoder).not.toHaveBeenCalled();
-			canEncodeAudio.mockResolvedValue(false);
 		});
 
 		it('should register the FLAC extension encoder when not natively supported', async () => {

--- a/tests/unit/AudioFormatConverter.test.ts
+++ b/tests/unit/AudioFormatConverter.test.ts
@@ -98,7 +98,7 @@ import {
 	getRecorderMediaType,
 	convertBlobToWav,
 	convertBlobToFormat,
-	decodeAudioDataAtNativeRate,
+	decodeAudioBlob,
 	buildOutputBlob,
 	mergeAudioTracks,
 } from '../../src/recording/AudioFormatConverter';
@@ -332,22 +332,23 @@ describe('AudioFormatConverter', () => {
 	});
 
 	// ---------------------------------------------------------------
-	// decodeAudioDataAtNativeRate
+	// decodeAudioBlob
 	// ---------------------------------------------------------------
-	describe('decodeAudioDataAtNativeRate', () => {
-		it('should probe, close the probe context, and re-decode offline', async () => {
+	describe('decodeAudioBlob', () => {
+		it('should decode exactly once and close the context', async () => {
 			const buffer = new ArrayBuffer(8);
-			await decodeAudioDataAtNativeRate(buffer);
+			await decodeAudioBlob(buffer);
 
 			expect(AudioContext).toHaveBeenCalledTimes(1);
-			const probeCtx = (AudioContext as unknown as jest.Mock).mock
-				.results[0].value;
-			expect(probeCtx.decodeAudioData).toHaveBeenCalledTimes(1);
-			expect(probeCtx.close).toHaveBeenCalledTimes(1);
-			expect(OfflineAudioContext).toHaveBeenCalledWith(1, 44100, 44100);
+			const ctx = (AudioContext as unknown as jest.Mock).mock.results[0]
+				.value;
+			expect(ctx.decodeAudioData).toHaveBeenCalledTimes(1);
+			expect(ctx.close).toHaveBeenCalledTimes(1);
+			// No second decode through an OfflineAudioContext
+			expect(OfflineAudioContext).not.toHaveBeenCalled();
 		});
 
-		it('should close the probe context when decoding fails', async () => {
+		it('should close the context when decoding fails', async () => {
 			const decodeError = new Error('decode failed');
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- required for mock override
 			(AudioContext as any).mockImplementationOnce(() => ({
@@ -355,15 +356,14 @@ describe('AudioFormatConverter', () => {
 				close: jest.fn().mockResolvedValue(undefined),
 			}));
 
-			await expect(
-				decodeAudioDataAtNativeRate(new ArrayBuffer(8)),
-			).rejects.toThrow('decode failed');
+			await expect(decodeAudioBlob(new ArrayBuffer(8))).rejects.toThrow(
+				'decode failed',
+			);
 
-			// The probe AudioContext must not leak on corrupted input
-			const probeCtx = (AudioContext as unknown as jest.Mock).mock
-				.results[0].value;
-			expect(probeCtx.close).toHaveBeenCalledTimes(1);
-			expect(OfflineAudioContext).not.toHaveBeenCalled();
+			// The AudioContext must not leak on corrupted input
+			const ctx = (AudioContext as unknown as jest.Mock).mock.results[0]
+				.value;
+			expect(ctx.close).toHaveBeenCalledTimes(1);
 		});
 	});
 
@@ -388,23 +388,16 @@ describe('AudioFormatConverter', () => {
 			);
 		});
 
-		it('should probe native sample rate with AudioContext first', async () => {
+		it('should decode once with a single AudioContext', async () => {
 			const blob = new Blob(['test'], { type: 'audio/webm' });
 			await convertBlobToFormat(blob, 'mp4', 128000);
 
-			// First AudioContext call is the probe context
 			expect(AudioContext).toHaveBeenCalledTimes(1);
-			const probeCtx = (AudioContext as unknown as jest.Mock).mock
-				.results[0].value;
-			expect(probeCtx.decodeAudioData).toHaveBeenCalledTimes(1);
-			expect(probeCtx.close).toHaveBeenCalledTimes(1);
-		});
-
-		it('should create OfflineAudioContext with native sample rate', async () => {
-			const blob = new Blob(['test'], { type: 'audio/webm' });
-			await convertBlobToFormat(blob, 'flac', 192000);
-
-			expect(OfflineAudioContext).toHaveBeenCalledWith(1, 44100, 44100);
+			const ctx = (AudioContext as unknown as jest.Mock).mock.results[0]
+				.value;
+			expect(ctx.decodeAudioData).toHaveBeenCalledTimes(1);
+			expect(ctx.close).toHaveBeenCalledTimes(1);
+			expect(OfflineAudioContext).not.toHaveBeenCalled();
 		});
 
 		it('should forward onProgress callback to encodeAudioBuffer', async () => {

--- a/tests/unit/AudioFormatConverter.test.ts
+++ b/tests/unit/AudioFormatConverter.test.ts
@@ -431,6 +431,9 @@ describe('AudioFormatConverter', () => {
 			expect(mockConversionInit).toHaveBeenCalledWith(
 				expect.objectContaining({
 					audio: { codec: 'aac', bitrate: 128000 },
+					// Discarded tracks are handled by the plugin, so
+					// mediabunny's own console warnings are disabled
+					showWarnings: false,
 				}),
 			);
 			expect(mockConversionExecute).toHaveBeenCalledTimes(1);
@@ -484,6 +487,7 @@ describe('AudioFormatConverter', () => {
 			expect(mockConversionInit).toHaveBeenCalledWith(
 				expect.objectContaining({
 					audio: { codec: 'opus' },
+					showWarnings: false,
 				}),
 			);
 			expect(mockConversionExecute).toHaveBeenCalledTimes(1);

--- a/tests/unit/AudioFormatConverter.test.ts
+++ b/tests/unit/AudioFormatConverter.test.ts
@@ -40,10 +40,13 @@ jest.mock('../../src/recording/AudioEncoder', () => ({
 // Mock mediabunny Conversion pipeline
 const mockConversionExecute = jest.fn().mockResolvedValue(undefined);
 const mockConversionInit = jest.fn();
+const mockGetPrimaryAudioTrack = jest.fn();
 const mockConvertedBuffer = new ArrayBuffer(64);
 
 jest.mock('mediabunny', () => ({
-	Input: jest.fn(),
+	Input: jest.fn().mockImplementation(() => ({
+		getPrimaryAudioTrack: (): unknown => mockGetPrimaryAudioTrack(),
+	})),
 	Output: jest.fn().mockImplementation(() => ({})),
 	BlobSource: jest.fn(),
 	BufferTarget: jest.fn().mockImplementation(() => ({
@@ -146,8 +149,17 @@ describe('AudioFormatConverter', () => {
 			Promise.resolve({
 				execute: mockConversionExecute,
 				onProgress: undefined,
+				isValid: true,
+				discardedTracks: [],
 			}),
 		);
+
+		// Default input track: opus audio, the typical intermediate
+		// recording codec
+		mockGetPrimaryAudioTrack.mockResolvedValue({
+			codec: 'opus',
+			isAudioTrack: (): boolean => true,
+		});
 	});
 
 	// ---------------------------------------------------------------
@@ -461,6 +473,118 @@ describe('AudioFormatConverter', () => {
 
 			instance.onProgress!(1);
 			expect(progressFn).toHaveBeenCalledWith(100);
+		});
+
+		it('should remux without bitrate when the input codec matches the target', async () => {
+			const blob = new Blob(['test'], { type: 'audio/webm' });
+
+			// Input track is opus (default mock); ogg targets opus too
+			await convertBlobToFormat(blob, 'ogg', 128000);
+
+			expect(mockConversionInit).toHaveBeenCalledWith(
+				expect.objectContaining({
+					audio: { codec: 'opus' },
+				}),
+			);
+			expect(mockConversionExecute).toHaveBeenCalledTimes(1);
+		});
+
+		it('should fall back when the audio track is discarded', async () => {
+			const { encodeAudioBuffer } = jest.requireMock(
+				'../../src/recording/AudioEncoder',
+			);
+			// Conversion.init does not throw for codec problems: the
+			// track is discarded and the output would contain no audio
+			mockConversionInit.mockImplementationOnce(() =>
+				Promise.resolve({
+					execute: mockConversionExecute,
+					isValid: true,
+					discardedTracks: [
+						{
+							track: { isAudioTrack: (): boolean => true },
+							reason: 'no_encodable_target_codec',
+						},
+					],
+				}),
+			);
+			const warnSpy = jest
+				.spyOn(console, 'warn')
+				.mockImplementation(() => undefined);
+			const blob = new Blob(['test'], { type: 'audio/webm' });
+
+			await convertBlobToFormat(blob, 'mp4', 128000);
+
+			expect(mockConversionExecute).not.toHaveBeenCalled();
+			expect(encodeAudioBuffer).toHaveBeenCalledWith(
+				expect.anything(),
+				{ format: 'mp4', bitrate: 128000 },
+				undefined,
+			);
+			expect(warnSpy).toHaveBeenCalled();
+			warnSpy.mockRestore();
+		});
+
+		it('should ignore discarded non-audio tracks', async () => {
+			// A video track in the source container is legitimately
+			// dropped when converting to an audio-only format
+			mockConversionInit.mockImplementationOnce(() =>
+				Promise.resolve({
+					execute: mockConversionExecute,
+					isValid: true,
+					discardedTracks: [
+						{
+							track: { isAudioTrack: (): boolean => false },
+							reason: 'max_track_count_of_type_reached',
+						},
+					],
+				}),
+			);
+			const blob = new Blob(['test'], { type: 'audio/mp4' });
+
+			const result = await convertBlobToFormat(blob, 'mp3', 192000);
+
+			expect(mockConversionExecute).toHaveBeenCalledTimes(1);
+			expect(result.type).toBe('audio/mp3');
+		});
+
+		it('should fall back when the conversion is invalid', async () => {
+			const { encodeAudioBuffer } = jest.requireMock(
+				'../../src/recording/AudioEncoder',
+			);
+			mockConversionInit.mockImplementationOnce(() =>
+				Promise.resolve({
+					execute: mockConversionExecute,
+					isValid: false,
+					discardedTracks: [],
+				}),
+			);
+			const warnSpy = jest
+				.spyOn(console, 'warn')
+				.mockImplementation(() => undefined);
+			const blob = new Blob(['test'], { type: 'audio/webm' });
+
+			await convertBlobToFormat(blob, 'aac', 256000);
+
+			expect(mockConversionExecute).not.toHaveBeenCalled();
+			expect(encodeAudioBuffer).toHaveBeenCalled();
+			warnSpy.mockRestore();
+		});
+
+		it('should fall back when the input has no audio track', async () => {
+			const { encodeAudioBuffer } = jest.requireMock(
+				'../../src/recording/AudioEncoder',
+			);
+			mockGetPrimaryAudioTrack.mockResolvedValueOnce(null);
+			const warnSpy = jest
+				.spyOn(console, 'warn')
+				.mockImplementation(() => undefined);
+			const blob = new Blob(['test'], { type: 'audio/webm' });
+
+			await convertBlobToFormat(blob, 'mp4', 128000);
+
+			expect(mockConversionInit).not.toHaveBeenCalled();
+			expect(encodeAudioBuffer).toHaveBeenCalled();
+			warnSpy.mockRestore();
 		});
 
 		it('should fall back to decode and re-encode when conversion fails', async () => {

--- a/tests/unit/AudioFormatConverter.test.ts
+++ b/tests/unit/AudioFormatConverter.test.ts
@@ -478,16 +478,36 @@ describe('AudioFormatConverter', () => {
 			expect(progressFn).toHaveBeenCalledWith(100);
 		});
 
-		it('should remux without bitrate when the input codec matches the target', async () => {
+		it('should remux without bitrate when the codecs match and remux is allowed', async () => {
 			const blob = new Blob(['test'], { type: 'audio/webm' });
 
-			// Input track is opus (default mock); ogg targets opus too
-			await convertBlobToFormat(blob, 'ogg', 128000);
+			// Input track is opus (default mock); ogg targets opus too.
+			// The recording pipeline opts in: its intermediate blob is
+			// already encoded at the requested bitrate.
+			await convertBlobToFormat(blob, 'ogg', 128000, undefined, {
+				allowRemux: true,
+			});
 
 			expect(mockConversionInit).toHaveBeenCalledWith(
 				expect.objectContaining({
 					audio: { codec: 'opus' },
 					showWarnings: false,
+				}),
+			);
+			expect(mockConversionExecute).toHaveBeenCalledTimes(1);
+		});
+
+		it('should re-encode at the requested bitrate when remux is not allowed', async () => {
+			const blob = new Blob(['test'], { type: 'audio/webm' });
+
+			// Matching codecs (opus input, ogg target), but without the
+			// remux opt-in the explicitly requested bitrate must be
+			// honored: manual conversions let the user pick it
+			await convertBlobToFormat(blob, 'ogg', 64000);
+
+			expect(mockConversionInit).toHaveBeenCalledWith(
+				expect.objectContaining({
+					audio: { codec: 'opus', bitrate: 64000 },
 				}),
 			);
 			expect(mockConversionExecute).toHaveBeenCalledTimes(1);

--- a/tests/unit/AudioFormatConverter.test.ts
+++ b/tests/unit/AudioFormatConverter.test.ts
@@ -778,7 +778,7 @@ describe('AudioFormatConverter', () => {
 			expect(ctxInstance.decodeAudioData).toHaveBeenCalledTimes(2);
 		});
 
-		it('should create OfflineAudioContext with stereo channels and longest duration', async () => {
+		it('should mix mono inputs into a mono OfflineAudioContext', async () => {
 			const targets = [createMockTarget('track1')];
 			const buildTrackBlob = jest
 				.fn()
@@ -798,12 +798,59 @@ describe('AudioFormatConverter', () => {
 				buildTrackBlob,
 			);
 
-			// OfflineAudioContext(channels=2, length=sampleRate*duration, sampleRate)
+			// All decoded inputs are mono (numberOfChannels: 1), so the mix
+			// renders in mono instead of duplicating into stereo
 			expect(OfflineAudioContext).toHaveBeenCalledWith(
-				2,
+				1,
 				44100 * 1, // sampleRate * duration(1)
 				44100,
 			);
+		});
+
+		it('should keep a stereo mix when any input is stereo', async () => {
+			const targets = [
+				createMockTarget('track1'),
+				createMockTarget('track2'),
+			];
+			const buildTrackBlob = jest
+				.fn()
+				.mockResolvedValue(new Blob(['audio'], { type: 'audio/webm' }));
+
+			// Second decoded track is stereo; override only this instance
+			(AudioContext as unknown as jest.Mock).mockImplementationOnce(
+				() => ({
+					decodeAudioData: jest
+						.fn()
+						.mockResolvedValueOnce(createMockAudioBuffer())
+						.mockResolvedValueOnce(
+							createMockAudioBuffer({ numberOfChannels: 2 }),
+						),
+					createBufferSource: jest.fn().mockImplementation(() => ({
+						connect: jest.fn(),
+						start: jest.fn(),
+						buffer: null,
+					})),
+					destination: {},
+					close: jest.fn().mockResolvedValue(undefined),
+					sampleRate: 44100,
+				}),
+			);
+
+			const settings: AudioRecorderSettings = {
+				...DEFAULT_SETTINGS,
+				recordingFormat: 'mp4',
+				bitrate: 128000,
+			};
+
+			await mergeAudioTracks(
+				targets,
+				settings,
+				false,
+				jest.fn(),
+				buildTrackBlob,
+			);
+
+			expect(OfflineAudioContext).toHaveBeenCalledWith(2, 44100, 44100);
 		});
 
 		it('should forward progress callback with adjusted percentage', async () => {

--- a/tests/unit/AudioFormatConverter.test.ts
+++ b/tests/unit/AudioFormatConverter.test.ts
@@ -24,6 +24,35 @@ jest.mock('../../src/recording/AudioEncoder', () => ({
 			format,
 		);
 	}),
+	ensureEncoderRegistered: jest.fn().mockResolvedValue(undefined),
+	createOutputFormat: jest.fn().mockReturnValue({}),
+	FORMAT_CODEC_MAP: {
+		webm: 'opus',
+		ogg: 'opus',
+		mp4: 'aac',
+		m4a: 'aac',
+		aac: 'aac',
+		flac: 'flac',
+		mp3: 'mp3',
+	},
+}));
+
+// Mock mediabunny Conversion pipeline
+const mockConversionExecute = jest.fn().mockResolvedValue(undefined);
+const mockConversionInit = jest.fn();
+const mockConvertedBuffer = new ArrayBuffer(64);
+
+jest.mock('mediabunny', () => ({
+	Input: jest.fn(),
+	Output: jest.fn().mockImplementation(() => ({})),
+	BlobSource: jest.fn(),
+	BufferTarget: jest.fn().mockImplementation(() => ({
+		buffer: mockConvertedBuffer,
+	})),
+	ALL_FORMATS: [],
+	Conversion: {
+		init: (...args: unknown[]): unknown => mockConversionInit(...args),
+	},
 }));
 
 // Mock WavEncoder
@@ -110,6 +139,14 @@ describe('AudioFormatConverter', () => {
 		// Reset MediaRecorder.isTypeSupported to default
 		(MediaRecorder.isTypeSupported as jest.Mock).mockImplementation(
 			(mime: string) => mime === 'audio/webm' || mime === 'audio/ogg',
+		);
+
+		// Default: streaming conversion succeeds, fresh instance per call
+		mockConversionInit.mockImplementation(() =>
+			Promise.resolve({
+				execute: mockConversionExecute,
+				onProgress: undefined,
+			}),
 		);
 	});
 
@@ -371,7 +408,7 @@ describe('AudioFormatConverter', () => {
 	// convertBlobToFormat
 	// ---------------------------------------------------------------
 	describe('convertBlobToFormat', () => {
-		it('should decode blob and re-encode to target format', async () => {
+		it('should convert via the streaming Conversion pipeline', async () => {
 			const { encodeAudioBuffer } = jest.requireMock(
 				'../../src/recording/AudioEncoder',
 			);
@@ -379,30 +416,107 @@ describe('AudioFormatConverter', () => {
 
 			const result = await convertBlobToFormat(blob, 'mp4', 128000);
 
+			expect(mockConversionInit).toHaveBeenCalledWith(
+				expect.objectContaining({
+					audio: { codec: 'aac', bitrate: 128000 },
+				}),
+			);
+			expect(mockConversionExecute).toHaveBeenCalledTimes(1);
 			expect(result).toBeInstanceOf(Blob);
-			expect(encodeAudioBuffer).toHaveBeenCalledTimes(1);
+			expect(result.type).toBe('audio/mp4');
+			// The streaming path never materializes the full PCM
+			expect(AudioContext).not.toHaveBeenCalled();
+			expect(encodeAudioBuffer).not.toHaveBeenCalled();
+		});
+
+		it('should register the extension encoder before converting', async () => {
+			const { ensureEncoderRegistered } = jest.requireMock(
+				'../../src/recording/AudioEncoder',
+			);
+			const blob = new Blob(['test'], { type: 'audio/webm' });
+
+			await convertBlobToFormat(blob, 'mp3', 192000);
+
+			expect(ensureEncoderRegistered).toHaveBeenCalledWith('mp3');
+		});
+
+		it('should report whole-percent progress from the conversion', async () => {
+			const progressFn = jest.fn();
+			const blob = new Blob(['test'], { type: 'audio/webm' });
+
+			await convertBlobToFormat(blob, 'mp4', 128000, progressFn);
+
+			const instance = (await mockConversionInit.mock.results[0]
+				.value) as {
+				onProgress?: (progress: number) => void;
+			};
+			expect(instance.onProgress).toBeDefined();
+
+			instance.onProgress!(0.5);
+			expect(progressFn).toHaveBeenCalledWith(50);
+
+			// Same whole percent is deduplicated
+			instance.onProgress!(0.504);
+			expect(progressFn).toHaveBeenCalledTimes(1);
+
+			instance.onProgress!(1);
+			expect(progressFn).toHaveBeenCalledWith(100);
+		});
+
+		it('should fall back to decode and re-encode when conversion fails', async () => {
+			const { encodeAudioBuffer } = jest.requireMock(
+				'../../src/recording/AudioEncoder',
+			);
+			mockConversionInit.mockRejectedValueOnce(
+				new Error('unreadable container'),
+			);
+			const warnSpy = jest
+				.spyOn(console, 'warn')
+				.mockImplementation(() => undefined);
+			const blob = new Blob(['test'], { type: 'audio/webm' });
+
+			const result = await convertBlobToFormat(blob, 'mp4', 128000);
+
+			expect(result).toBeInstanceOf(Blob);
+			expect(AudioContext).toHaveBeenCalledTimes(1);
 			expect(encodeAudioBuffer).toHaveBeenCalledWith(
 				expect.objectContaining({ sampleRate: 44100 }),
 				{ format: 'mp4', bitrate: 128000 },
 				undefined,
 			);
+			expect(warnSpy).toHaveBeenCalled();
+			warnSpy.mockRestore();
 		});
 
-		it('should decode once with a single AudioContext', async () => {
+		it('should fall back when the conversion produces empty output', async () => {
+			const { encodeAudioBuffer } = jest.requireMock(
+				'../../src/recording/AudioEncoder',
+			);
+			const { BufferTarget } = jest.requireMock('mediabunny');
+			BufferTarget.mockImplementationOnce(() => ({ buffer: null }));
+			const warnSpy = jest
+				.spyOn(console, 'warn')
+				.mockImplementation(() => undefined);
 			const blob = new Blob(['test'], { type: 'audio/webm' });
-			await convertBlobToFormat(blob, 'mp4', 128000);
 
-			expect(AudioContext).toHaveBeenCalledTimes(1);
-			const ctx = (AudioContext as unknown as jest.Mock).mock.results[0]
-				.value;
-			expect(ctx.decodeAudioData).toHaveBeenCalledTimes(1);
-			expect(ctx.close).toHaveBeenCalledTimes(1);
-			expect(OfflineAudioContext).not.toHaveBeenCalled();
+			await convertBlobToFormat(blob, 'aac', 256000);
+
+			expect(encodeAudioBuffer).toHaveBeenCalledWith(
+				expect.anything(),
+				{ format: 'aac', bitrate: 256000 },
+				undefined,
+			);
+			warnSpy.mockRestore();
 		});
 
-		it('should forward onProgress callback to encodeAudioBuffer', async () => {
+		it('should forward onProgress to the fallback encoder', async () => {
+			mockConversionInit.mockRejectedValueOnce(new Error('boom'));
+			const warnSpy = jest
+				.spyOn(console, 'warn')
+				.mockImplementation(() => undefined);
 			const progressFn = jest.fn();
 			const blob = new Blob(['test'], { type: 'audio/webm' });
+
 			await convertBlobToFormat(blob, 'mp4', 128000, progressFn);
 
 			const { encodeAudioBuffer } = jest.requireMock(
@@ -413,34 +527,7 @@ describe('AudioFormatConverter', () => {
 				{ format: 'mp4', bitrate: 128000 },
 				progressFn,
 			);
-		});
-
-		it('should pass undefined when onProgress is not provided', async () => {
-			const blob = new Blob(['test'], { type: 'audio/webm' });
-			await convertBlobToFormat(blob, 'mp3', 320000);
-
-			const { encodeAudioBuffer } = jest.requireMock(
-				'../../src/recording/AudioEncoder',
-			);
-			expect(encodeAudioBuffer).toHaveBeenCalledWith(
-				expect.anything(),
-				{ format: 'mp3', bitrate: 320000 },
-				undefined,
-			);
-		});
-
-		it('should handle different target formats', async () => {
-			const { encodeAudioBuffer } = jest.requireMock(
-				'../../src/recording/AudioEncoder',
-			);
-			const blob = new Blob(['test'], { type: 'audio/webm' });
-
-			await convertBlobToFormat(blob, 'aac', 256000);
-			expect(encodeAudioBuffer).toHaveBeenCalledWith(
-				expect.anything(),
-				{ format: 'aac', bitrate: 256000 },
-				undefined,
-			);
+			warnSpy.mockRestore();
 		});
 	});
 

--- a/tests/unit/RecordingManager.test.ts
+++ b/tests/unit/RecordingManager.test.ts
@@ -401,7 +401,7 @@ describe('RecordingManager', () => {
 
 			await manager.stopRecording();
 
-			expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
+			expect(mockApp.vault.adapter.writeBinary).toHaveBeenCalledWith(
 				expect.stringMatching(/-part1\.webm\.tmp$/),
 				expect.any(ArrayBuffer),
 			);
@@ -524,7 +524,7 @@ describe('RecordingManager', () => {
 			await manager.stopRecording();
 
 			// 1 combined segment file + 1 final file (instead of 3 + 1 before buffering)
-			expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
+			expect(mockApp.vault.adapter.writeBinary).toHaveBeenCalledWith(
 				expect.stringMatching(/-part1\.webm\.tmp$/),
 				expect.any(ArrayBuffer),
 			);
@@ -1254,7 +1254,7 @@ describe('RecordingManager', () => {
 
 			await manager.stopRecording();
 
-			expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
+			expect(mockApp.vault.adapter.writeBinary).toHaveBeenCalledWith(
 				expect.stringMatching(
 					/^Meetings\/2026\/recording-Track1-.*-part1\.webm\.tmp$/,
 				),
@@ -1320,7 +1320,7 @@ describe('RecordingManager', () => {
 			expect(mockApp.vault.createFolder).toHaveBeenCalledWith(
 				'Meetings/2026/Audio',
 			);
-			expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
+			expect(mockApp.vault.adapter.writeBinary).toHaveBeenCalledWith(
 				expect.stringMatching(
 					/^Meetings\/2026\/Audio\/recording-Track1-.*-part1\.webm\.tmp$/,
 				),
@@ -1384,7 +1384,7 @@ describe('RecordingManager', () => {
 
 			await manager.stopRecording();
 
-			expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
+			expect(mockApp.vault.adapter.writeBinary).toHaveBeenCalledWith(
 				expect.stringMatching(
 					/^Recordings\/recording-Track1-.*-part1\.webm\.tmp$/,
 				),
@@ -2132,7 +2132,7 @@ describe('RecordingManager', () => {
 				splitChunkMinutes: 1,
 			});
 			// Fail only the PCM segment write that backs the part assembly
-			(mockApp.vault.createBinary as jest.Mock).mockImplementation(
+			(mockApp.vault.adapter.writeBinary as jest.Mock).mockImplementation(
 				(path: string) =>
 					path.includes('-pcm-part')
 						? Promise.reject(new Error('disk full'))
@@ -2164,7 +2164,7 @@ describe('RecordingManager', () => {
 			expect(target.partPcmBytes).toBe(0);
 
 			// Disk recovers: the preserved audio must reach the final file
-			(mockApp.vault.createBinary as jest.Mock).mockResolvedValue(
+			(mockApp.vault.adapter.writeBinary as jest.Mock).mockResolvedValue(
 				undefined,
 			);
 			await manager.stopRecording();
@@ -2389,7 +2389,7 @@ describe('RecordingManager', () => {
 			const flushGate = new Promise<void>((resolve) => {
 				releaseFlush = resolve;
 			});
-			(mockApp.vault.createBinary as jest.Mock).mockImplementation(
+			(mockApp.vault.adapter.writeBinary as jest.Mock).mockImplementation(
 				(path: string) =>
 					path.endsWith('.tmp') ? flushGate : Promise.resolve(),
 			);

--- a/tests/unit/SplitModal.test.ts
+++ b/tests/unit/SplitModal.test.ts
@@ -199,7 +199,7 @@ jest.mock('../../src/recording/AudioCapabilityDetector', () => ({
 
 // Mock the decoder: the compressed path decodes once via this function
 jest.mock('../../src/recording/AudioFormatConverter', () => ({
-	decodeAudioDataAtNativeRate: jest.fn(),
+	decodeAudioBlob: jest.fn(),
 }));
 
 // Mock the vault-wide link updater
@@ -212,7 +212,7 @@ jest.mock('../../src/utils/LinkUpdater', () => ({
 }));
 
 import { encodeAudioBuffer } from '../../src/recording/AudioEncoder';
-import { decodeAudioDataAtNativeRate } from '../../src/recording/AudioFormatConverter';
+import { decodeAudioBlob } from '../../src/recording/AudioFormatConverter';
 import { updateLinksInVault } from '../../src/utils/LinkUpdater';
 
 /** WAV header size produced by createWavHeader. */
@@ -597,7 +597,7 @@ describe('SplitModal', () => {
 
 			await internals(modal).runSplit(progressEl);
 
-			expect(decodeAudioDataAtNativeRate).not.toHaveBeenCalled();
+			expect(decodeAudioBlob).not.toHaveBeenCalled();
 			expect(mockApp.vault.createBinary).toHaveBeenCalledTimes(3);
 			const paths = (
 				mockApp.vault.createBinary as jest.Mock
@@ -975,7 +975,7 @@ describe('SplitModal', () => {
 				new ArrayBuffer(100),
 			);
 			// 150 s at 44100 Hz with 1-minute parts -> 3 parts
-			(decodeAudioDataAtNativeRate as jest.Mock).mockResolvedValue(
+			(decodeAudioBlob as jest.Mock).mockResolvedValue(
 				createMockAudioBuffer(1, 150 * 44100, 44100),
 			);
 			(global as Record<string, unknown>).AudioBuffer = class {
@@ -1001,7 +1001,7 @@ describe('SplitModal', () => {
 
 			await internals(modal).runSplit(progressEl);
 
-			expect(decodeAudioDataAtNativeRate).toHaveBeenCalledTimes(1);
+			expect(decodeAudioBlob).toHaveBeenCalledTimes(1);
 			expect(encodeAudioBuffer).toHaveBeenCalledTimes(3);
 			expect(encodeAudioBuffer).toHaveBeenCalledWith(
 				expect.objectContaining({ length: 60 * 44100 }),
@@ -1018,7 +1018,7 @@ describe('SplitModal', () => {
 		});
 
 		it('should abort when the audio is shorter than one part', async () => {
-			(decodeAudioDataAtNativeRate as jest.Mock).mockResolvedValue(
+			(decodeAudioBlob as jest.Mock).mockResolvedValue(
 				createMockAudioBuffer(1, 30 * 44100, 44100),
 			);
 			const modal = new SplitModal(mockApp, mockFile, mockSettings);
@@ -1039,7 +1039,7 @@ describe('SplitModal', () => {
 
 			await internals(modal).runSplit(progressEl);
 
-			expect(decodeAudioDataAtNativeRate).toHaveBeenCalledTimes(1);
+			expect(decodeAudioBlob).toHaveBeenCalledTimes(1);
 			expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
 				'Recordings/recording-part1.wav',
 				expect.anything(),
@@ -1069,7 +1069,7 @@ describe('SplitModal', () => {
 		});
 
 		it('should report errors from decoding', async () => {
-			(decodeAudioDataAtNativeRate as jest.Mock).mockRejectedValue(
+			(decodeAudioBlob as jest.Mock).mockRejectedValue(
 				new Error('decode failed'),
 			);
 			const modal = new SplitModal(mockApp, mockFile, mockSettings);

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -231,11 +231,9 @@ describe('AudioRecorderPlugin settings persistence', () => {
 		expect(saveData).toHaveBeenCalledTimes(1);
 	});
 
-	it('restores settings from the backup when both reads fail', async () => {
-		const { plugin, adapterRead, saveData, adapterExists } = createPlugin([
-			undefined,
-			undefined,
-		]);
+	it('uses the backup for the session and blocks saving when data.json is unreadable', async () => {
+		const { plugin, adapterRead, adapterWrite, saveData, adapterExists } =
+			createPlugin([undefined, undefined]);
 		adapterExists.mockResolvedValue(true);
 		adapterRead.mockResolvedValue(
 			JSON.stringify({ filePrefix: 'from-backup' }),
@@ -243,11 +241,17 @@ describe('AudioRecorderPlugin settings persistence', () => {
 
 		await onloadWithTimers(plugin);
 
+		// The readable backup keeps the session usable in memory
 		expect(adapterRead).toHaveBeenCalledWith(BACKUP_PATH);
 		expect(plugin.settings.filePrefix).toBe('from-backup');
 
+		// The unreadable data.json may be intact and newer than the
+		// backup (settings synced while the plugin was unloaded), so
+		// saving stays blocked instead of overwriting it with
+		// backup-derived values
 		await plugin.saveSettings();
-		expect(saveData).toHaveBeenCalledTimes(1);
+		expect(saveData).not.toHaveBeenCalled();
+		expect(adapterWrite).not.toHaveBeenCalled();
 	});
 
 	it('blocks saving when neither data.json nor the backup is readable', async () => {

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -168,7 +168,12 @@ describe('AudioRecorderPlugin settings persistence', () => {
 	});
 
 	it('restores settings from the backup when data.json is missing', async () => {
-		const { plugin, adapterRead, saveData } = createPlugin([null]);
+		const { plugin, adapterRead, adapterExists, saveData } = createPlugin([
+			null,
+		]);
+		adapterExists.mockImplementation((path: string) =>
+			Promise.resolve(path === BACKUP_PATH),
+		);
 		adapterRead.mockResolvedValue(
 			JSON.stringify({ filePrefix: 'from-backup' }),
 		);
@@ -177,9 +182,37 @@ describe('AudioRecorderPlugin settings persistence', () => {
 
 		expect(adapterRead).toHaveBeenCalledWith(BACKUP_PATH);
 		expect(plugin.settings.filePrefix).toBe('from-backup');
+		// The restore is persisted right away: data.json is recreated
+		// so the backup stops being the only copy on disk
+		expect(saveData).toHaveBeenCalledTimes(1);
+		expect(saveData).toHaveBeenCalledWith(
+			expect.objectContaining({ filePrefix: 'from-backup' }),
+		);
 
 		await plugin.saveSettings();
-		expect(saveData).toHaveBeenCalledTimes(1);
+		expect(saveData).toHaveBeenCalledTimes(2);
+	});
+
+	it('blocks saving when data.json is missing and the backup cannot be read', async () => {
+		// With data.json missing, the backup is the only remaining
+		// copy of the settings: a transient read failure must block
+		// saving instead of letting the defaults overwrite it
+		const { plugin, adapterRead, adapterWrite, adapterExists, saveData } =
+			createPlugin([null]);
+		adapterExists.mockImplementation((path: string) =>
+			Promise.resolve(path === BACKUP_PATH),
+		);
+		adapterRead.mockRejectedValue(new Error('EBUSY'));
+
+		await onloadWithTimers(plugin);
+
+		// Defaults are active in memory only
+		expect(plugin.settings.filePrefix).toBe(DEFAULT_SETTINGS.filePrefix);
+
+		await plugin.saveSettings();
+		expect(saveData).not.toHaveBeenCalled();
+		// The possibly intact backup is never overwritten with defaults
+		expect(adapterWrite).not.toHaveBeenCalled();
 	});
 
 	it('retries a failed read once and uses the second result', async () => {

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -248,6 +248,58 @@ describe('AudioRecorderPlugin settings persistence', () => {
 		expect(saveData).not.toHaveBeenCalled();
 	});
 
+	it('treats a rejected settings read as a failed read', async () => {
+		// The current Obsidian loadData() never rejects, but that is
+		// undocumented internal behavior; a rejection must degrade to
+		// the failed-read path instead of breaking onload
+		const { plugin, loadData, saveData } = createPlugin([]);
+		loadData.mockRejectedValue(new Error('read failure'));
+
+		await onloadWithTimers(plugin);
+
+		// data.json does not exist: defaults apply and saving stays
+		// enabled so the file gets created on the next change
+		expect(plugin.settings.filePrefix).toBe(DEFAULT_SETTINGS.filePrefix);
+		await plugin.saveSettings();
+		expect(saveData).toHaveBeenCalledTimes(1);
+	});
+
+	it('blocks saving when a rejected read hits an existing data.json', async () => {
+		const { plugin, loadData, saveData, adapterExists } = createPlugin([]);
+		adapterExists.mockResolvedValue(true);
+		loadData.mockRejectedValue(new Error('read failure'));
+
+		await onloadWithTimers(plugin);
+
+		await plugin.saveSettings();
+		expect(saveData).not.toHaveBeenCalled();
+	});
+
+	it('keeps the in-memory settings when a reload read fails', async () => {
+		const { plugin, loadData, saveData, adapterExists } = createPlugin([
+			{ filePrefix: 'loaded' },
+		]);
+
+		await onloadWithTimers(plugin);
+		expect(plugin.settings.filePrefix).toBe('loaded');
+
+		// External change arrives while the file is locked: every
+		// subsequent read fails
+		adapterExists.mockResolvedValue(true);
+		loadData.mockResolvedValue(undefined);
+		const changePromise = plugin.onExternalSettingsChange();
+		await jest.advanceTimersByTimeAsync(RETRY_DELAY_MS);
+		await changePromise;
+
+		// The previously loaded settings stay active instead of being
+		// replaced with defaults
+		expect(plugin.settings.filePrefix).toBe('loaded');
+
+		// Saving stays blocked until a successful reload
+		await plugin.saveSettings();
+		expect(saveData).not.toHaveBeenCalled();
+	});
+
 	it('reloads settings on external settings change', async () => {
 		const { plugin, loadData } = createPlugin([
 			{ filePrefix: 'before' },

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -40,6 +40,7 @@ jest.mock('../../src/ui/DeviceSelectionModal', () => ({
 
 // Fixture path: in production the directory comes from manifest.dir
 const PLUGIN_DIR = 'config-dir/plugins/advanced-audio-recorder';
+const DATA_PATH = `${PLUGIN_DIR}/data.json`;
 const BACKUP_PATH = `${PLUGIN_DIR}/data.json.bak`;
 const RETRY_DELAY_MS = 250;
 
@@ -58,10 +59,13 @@ interface PluginHarness {
 	saveData: jest.Mock;
 	adapterRead: jest.Mock;
 	adapterWrite: jest.Mock;
+	adapterExists: jest.Mock;
 }
 
 /**
  * Creates a plugin instance with mocked persistence functions.
+ * data.json does not exist by default; tests that model an existing
+ * but unreadable file flip adapterExists to true.
  * @param loadDataResults - Sequence of loadData results per call
  */
 function createPlugin(loadDataResults: LoadDataResult[]): PluginHarness {
@@ -78,10 +82,19 @@ function createPlugin(loadDataResults: LoadDataResult[]): PluginHarness {
 
 	const adapterRead = jest.fn().mockResolvedValue('');
 	const adapterWrite = jest.fn().mockResolvedValue(undefined);
+	const adapterExists = jest.fn().mockResolvedValue(false);
 	plugin.app.vault.adapter.read = adapterRead;
 	plugin.app.vault.adapter.write = adapterWrite;
+	plugin.app.vault.adapter.exists = adapterExists;
 
-	return { plugin, loadData, saveData, adapterRead, adapterWrite };
+	return {
+		plugin,
+		loadData,
+		saveData,
+		adapterRead,
+		adapterWrite,
+		adapterExists,
+	};
 }
 
 /**
@@ -134,11 +147,47 @@ describe('AudioRecorderPlugin settings persistence', () => {
 		expect(saveData).toHaveBeenCalledTimes(1);
 	});
 
+	it('allows saving when a missing data.json is reported as a failed read', async () => {
+		// On some filesystems reading a missing file fails with a
+		// non-ENOENT code, so loadData() returns undefined instead of
+		// null. The file's absence must still enable saving, otherwise
+		// data.json can never be created.
+		const { plugin, loadData, saveData, adapterExists } = createPlugin([
+			undefined,
+		]);
+
+		await onloadWithTimers(plugin);
+
+		expect(adapterExists).toHaveBeenCalledWith(DATA_PATH);
+		// No retry for a file that does not exist
+		expect(loadData).toHaveBeenCalledTimes(1);
+		expect(plugin.settings.filePrefix).toBe(DEFAULT_SETTINGS.filePrefix);
+
+		await plugin.saveSettings();
+		expect(saveData).toHaveBeenCalledTimes(1);
+	});
+
+	it('restores settings from the backup when data.json is missing', async () => {
+		const { plugin, adapterRead, saveData } = createPlugin([null]);
+		adapterRead.mockResolvedValue(
+			JSON.stringify({ filePrefix: 'from-backup' }),
+		);
+
+		await onloadWithTimers(plugin);
+
+		expect(adapterRead).toHaveBeenCalledWith(BACKUP_PATH);
+		expect(plugin.settings.filePrefix).toBe('from-backup');
+
+		await plugin.saveSettings();
+		expect(saveData).toHaveBeenCalledTimes(1);
+	});
+
 	it('retries a failed read once and uses the second result', async () => {
-		const { plugin, loadData, saveData } = createPlugin([
+		const { plugin, loadData, saveData, adapterExists } = createPlugin([
 			undefined,
 			{ filePrefix: 'recovered' },
 		]);
+		adapterExists.mockResolvedValue(true);
 
 		await onloadWithTimers(plugin);
 
@@ -150,10 +199,11 @@ describe('AudioRecorderPlugin settings persistence', () => {
 	});
 
 	it('restores settings from the backup when both reads fail', async () => {
-		const { plugin, adapterRead, saveData } = createPlugin([
+		const { plugin, adapterRead, saveData, adapterExists } = createPlugin([
 			undefined,
 			undefined,
 		]);
+		adapterExists.mockResolvedValue(true);
 		adapterRead.mockResolvedValue(
 			JSON.stringify({ filePrefix: 'from-backup' }),
 		);
@@ -168,11 +218,10 @@ describe('AudioRecorderPlugin settings persistence', () => {
 	});
 
 	it('blocks saving when neither data.json nor the backup is readable', async () => {
-		const { plugin, adapterRead, saveData, adapterWrite } = createPlugin([
-			undefined,
-			undefined,
-		]);
-		adapterRead.mockRejectedValue(new Error('ENOENT'));
+		const { plugin, adapterRead, saveData, adapterWrite, adapterExists } =
+			createPlugin([undefined, undefined]);
+		adapterExists.mockResolvedValue(true);
+		adapterRead.mockRejectedValue(new Error('EBUSY'));
 
 		await onloadWithTimers(plugin);
 
@@ -186,10 +235,11 @@ describe('AudioRecorderPlugin settings persistence', () => {
 	});
 
 	it('blocks saving when the backup contains invalid JSON', async () => {
-		const { plugin, adapterRead, saveData } = createPlugin([
+		const { plugin, adapterRead, saveData, adapterExists } = createPlugin([
 			undefined,
 			undefined,
 		]);
+		adapterExists.mockResolvedValue(true);
 		adapterRead.mockResolvedValue('{ truncated');
 
 		await onloadWithTimers(plugin);
@@ -214,10 +264,9 @@ describe('AudioRecorderPlugin settings persistence', () => {
 	});
 
 	it('recovers saving after a successful reload', async () => {
-		const { plugin, adapterRead, saveData, loadData } = createPlugin([
-			undefined,
-			undefined,
-		]);
+		const { plugin, adapterRead, saveData, loadData, adapterExists } =
+			createPlugin([undefined, undefined]);
+		adapterExists.mockResolvedValue(true);
 		adapterRead.mockRejectedValue(new Error('EBUSY'));
 
 		await onloadWithTimers(plugin);

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Tests for the plugin entry point: settings load/save resilience.
+ * @module tests/unit/main
+ */
+
+import { App } from 'obsidian';
+import AudioRecorderPlugin from '../../src/main';
+import { DEFAULT_SETTINGS } from '../../src/settings/Settings';
+
+jest.mock('../../src/recording/RecordingManager', () => ({
+	RecordingManager: jest.fn().mockImplementation(() => ({
+		toggleRecording: jest.fn(),
+		togglePauseResume: jest.fn(),
+		stopRecording: jest.fn(),
+		cleanup: jest.fn(),
+		updateSettings: jest.fn(),
+		getStatus: jest.fn(),
+	})),
+}));
+
+jest.mock('../../src/ui/ContextMenu', () => ({
+	ContextMenu: jest.fn().mockImplementation(() => ({
+		register: jest.fn(),
+	})),
+}));
+
+jest.mock('../../src/ui/StatusBar', () => ({
+	updateStatusBar: jest.fn(),
+	initializeStatusBar: jest.fn(),
+}));
+
+jest.mock('../../src/ui/RibbonIcon', () => ({
+	updateRibbonIcon: jest.fn(),
+	initializeRibbonIcon: jest.fn(),
+}));
+
+jest.mock('../../src/ui/DeviceSelectionModal', () => ({
+	showDeviceSelectionModal: jest.fn(),
+}));
+
+// Fixture path: in production the directory comes from manifest.dir
+const PLUGIN_DIR = 'config-dir/plugins/advanced-audio-recorder';
+const BACKUP_PATH = `${PLUGIN_DIR}/data.json.bak`;
+const RETRY_DELAY_MS = 250;
+
+const MANIFEST = {
+	id: 'advanced-audio-recorder',
+	name: 'Advanced Audio Recorder',
+	version: '1.3.3',
+	dir: PLUGIN_DIR,
+};
+
+type LoadDataResult = Record<string, unknown> | null | undefined;
+
+interface PluginHarness {
+	plugin: AudioRecorderPlugin;
+	loadData: jest.Mock;
+	saveData: jest.Mock;
+	adapterRead: jest.Mock;
+	adapterWrite: jest.Mock;
+}
+
+/**
+ * Creates a plugin instance with mocked persistence functions.
+ * @param loadDataResults - Sequence of loadData results per call
+ */
+function createPlugin(loadDataResults: LoadDataResult[]): PluginHarness {
+	const app = new App();
+	const plugin = new AudioRecorderPlugin(app as never, MANIFEST as never);
+
+	const loadData = jest.fn();
+	for (const result of loadDataResults) {
+		loadData.mockResolvedValueOnce(result);
+	}
+	const saveData = jest.fn().mockResolvedValue(undefined);
+	(plugin as unknown as Record<string, unknown>).loadData = loadData;
+	(plugin as unknown as Record<string, unknown>).saveData = saveData;
+
+	const adapterRead = jest.fn().mockResolvedValue('');
+	const adapterWrite = jest.fn().mockResolvedValue(undefined);
+	plugin.app.vault.adapter.read = adapterRead;
+	plugin.app.vault.adapter.write = adapterWrite;
+
+	return { plugin, loadData, saveData, adapterRead, adapterWrite };
+}
+
+/**
+ * Runs plugin.onload while advancing the retry timer, so loads that
+ * hit the retry path resolve under fake timers.
+ */
+async function onloadWithTimers(plugin: AudioRecorderPlugin): Promise<void> {
+	const promise = plugin.onload();
+	await jest.advanceTimersByTimeAsync(RETRY_DELAY_MS);
+	await promise;
+}
+
+describe('AudioRecorderPlugin settings persistence', () => {
+	beforeEach(() => {
+		jest.useFakeTimers();
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+		jest.clearAllMocks();
+	});
+
+	it('merges stored settings with defaults and writes a backup', async () => {
+		const { plugin, adapterWrite, loadData } = createPlugin([
+			{ filePrefix: 'meeting', sampleRate: 22050 },
+		]);
+
+		await onloadWithTimers(plugin);
+
+		expect(loadData).toHaveBeenCalledTimes(1);
+		expect(plugin.settings.filePrefix).toBe('meeting');
+		expect(plugin.settings.sampleRate).toBe(22050);
+		expect(plugin.settings.recordingFormat).toBe(
+			DEFAULT_SETTINGS.recordingFormat,
+		);
+		expect(adapterWrite).toHaveBeenCalledWith(
+			BACKUP_PATH,
+			expect.stringContaining('"filePrefix":"meeting"'),
+		);
+	});
+
+	it('uses defaults when data.json is missing and allows saving', async () => {
+		const { plugin, saveData } = createPlugin([null]);
+
+		await onloadWithTimers(plugin);
+
+		expect(plugin.settings.filePrefix).toBe(DEFAULT_SETTINGS.filePrefix);
+
+		await plugin.saveSettings();
+		expect(saveData).toHaveBeenCalledTimes(1);
+	});
+
+	it('retries a failed read once and uses the second result', async () => {
+		const { plugin, loadData, saveData } = createPlugin([
+			undefined,
+			{ filePrefix: 'recovered' },
+		]);
+
+		await onloadWithTimers(plugin);
+
+		expect(loadData).toHaveBeenCalledTimes(2);
+		expect(plugin.settings.filePrefix).toBe('recovered');
+
+		await plugin.saveSettings();
+		expect(saveData).toHaveBeenCalledTimes(1);
+	});
+
+	it('restores settings from the backup when both reads fail', async () => {
+		const { plugin, adapterRead, saveData } = createPlugin([
+			undefined,
+			undefined,
+		]);
+		adapterRead.mockResolvedValue(
+			JSON.stringify({ filePrefix: 'from-backup' }),
+		);
+
+		await onloadWithTimers(plugin);
+
+		expect(adapterRead).toHaveBeenCalledWith(BACKUP_PATH);
+		expect(plugin.settings.filePrefix).toBe('from-backup');
+
+		await plugin.saveSettings();
+		expect(saveData).toHaveBeenCalledTimes(1);
+	});
+
+	it('blocks saving when neither data.json nor the backup is readable', async () => {
+		const { plugin, adapterRead, saveData, adapterWrite } = createPlugin([
+			undefined,
+			undefined,
+		]);
+		adapterRead.mockRejectedValue(new Error('ENOENT'));
+
+		await onloadWithTimers(plugin);
+
+		// Defaults are active in memory only
+		expect(plugin.settings.filePrefix).toBe(DEFAULT_SETTINGS.filePrefix);
+
+		await plugin.saveSettings();
+		expect(saveData).not.toHaveBeenCalled();
+		// No backup written either: it would capture the defaults
+		expect(adapterWrite).not.toHaveBeenCalled();
+	});
+
+	it('blocks saving when the backup contains invalid JSON', async () => {
+		const { plugin, adapterRead, saveData } = createPlugin([
+			undefined,
+			undefined,
+		]);
+		adapterRead.mockResolvedValue('{ truncated');
+
+		await onloadWithTimers(plugin);
+
+		await plugin.saveSettings();
+		expect(saveData).not.toHaveBeenCalled();
+	});
+
+	it('reloads settings on external settings change', async () => {
+		const { plugin, loadData } = createPlugin([
+			{ filePrefix: 'before' },
+			{ filePrefix: 'after-sync' },
+		]);
+
+		await onloadWithTimers(plugin);
+		expect(plugin.settings.filePrefix).toBe('before');
+
+		await plugin.onExternalSettingsChange();
+
+		expect(loadData).toHaveBeenCalledTimes(2);
+		expect(plugin.settings.filePrefix).toBe('after-sync');
+	});
+
+	it('recovers saving after a successful reload', async () => {
+		const { plugin, adapterRead, saveData, loadData } = createPlugin([
+			undefined,
+			undefined,
+		]);
+		adapterRead.mockRejectedValue(new Error('EBUSY'));
+
+		await onloadWithTimers(plugin);
+		await plugin.saveSettings();
+		expect(saveData).not.toHaveBeenCalled();
+
+		// The file becomes readable again (lock released)
+		loadData.mockResolvedValue({ filePrefix: 'recovered' });
+		await plugin.onExternalSettingsChange();
+
+		expect(plugin.settings.filePrefix).toBe('recovered');
+		await plugin.saveSettings();
+		expect(saveData).toHaveBeenCalledTimes(1);
+	});
+});

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -285,6 +285,32 @@ describe('AudioRecorderPlugin settings persistence', () => {
 		expect(saveData).not.toHaveBeenCalled();
 	});
 
+	it('propagates in-memory settings to the recording manager while saving is blocked', async () => {
+		const { plugin, saveData, adapterExists } = createPlugin([
+			undefined,
+			undefined,
+		]);
+		adapterExists.mockResolvedValue(true);
+
+		await onloadWithTimers(plugin);
+
+		const { RecordingManager } = jest.requireMock(
+			'../../src/recording/RecordingManager',
+		);
+		const manager = (RecordingManager as jest.Mock).mock.results[0]
+			.value as { updateSettings: jest.Mock };
+
+		// The settings tab mutates the in-memory settings before
+		// calling saveSettings; with persistence blocked, the change
+		// must still reach the recording manager so the whole session
+		// sees one consistent state
+		plugin.settings.filePrefix = 'changed-in-session';
+		await plugin.saveSettings();
+
+		expect(saveData).not.toHaveBeenCalled();
+		expect(manager.updateSettings).toHaveBeenCalledWith(plugin.settings);
+	});
+
 	it('treats a rejected settings read as a failed read', async () => {
 		// The current Obsidian loadData() never rejects, but that is
 		// undocumented internal behavior; a rejection must degrade to


### PR DESCRIPTION
## Summary

Two problems addressed (analysis documented in the project knowledge base):

1. **Settings occasionally reset to defaults after a community plugin update.** Obsidian's `loadData()` returns `null` when `data.json` is missing but `undefined` when the file exists and reading/parsing fails (transient file lock during the update). The plugin collapsed both into "use defaults", and the next `saveSettings()` overwrote the intact file with those defaults.
2. **Saving compressed recordings was slow**, especially multi-track single-file output: the audio was fully decoded twice, MP3 encoding ran synchronously on the main thread via unmaintained lamejs with a progress callback per MPEG frame, and the manual decode/encode pipeline held the entire recording as PCM in memory.

## Changes

- `fix(settings)`: distinguish the three `loadData()` outcomes; retry a failed read once, then restore from a new `data.json.bak` backup; block saving while settings are not loaded correctly; implement `onExternalSettingsChange`; debounce text-field saves in the settings tab (500 ms).
- `fix(settings)`: harden backup recovery — a `data.json.bak` that exists but cannot be read blocks saving instead of being overwritten with defaults, and a successful backup restore immediately recreates the missing `data.json`.
- `fix(settings)`: when `data.json` exists but is unreadable, a readable backup keeps the session usable in memory while saving stays blocked, so a possibly newer `data.json` is never overwritten with backup-derived values; in-memory settings still propagate to the recording manager while saving is blocked.
- `perf(recording)`: decode compressed audio once instead of twice (`decodeAudioBlob`) — `decodeAudioData` resamples to the context rate by spec, so the second decode produced an identical buffer while doubling time and peak memory.
- `perf(recording)`: throttle save-progress status bar updates to whole-percent changes.
- `refactor(encoding)`: MP3 via `@mediabunny/mp3-encoder` (same pipeline as other formats, no UI freeze); lamejs removed. FLAC registration aligned with the documented `canEncodeAudio` + `registerFlacEncoder` pattern.
- `perf(recording)`: offline-format conversion through the streaming mediabunny `Conversion` pipeline (chunked transcode, honest progress) with automatic fallback to the previous decode+encode path on any failure. Codec-matching packet copy (remux) is an explicit opt-in used only by the recording pipeline; manual conversions always re-encode at the user-selected bitrate.
- `perf(recording)`: temporary `.tmp` segments written via `vault.adapter.writeBinary`, bypassing vault indexing; final files keep `createBinary`.
- `perf(recording)`: multi-track merged output renders in mono when every input is mono (any stereo input keeps stereo).

All current formats (wav, webm, ogg, mp3, mp4, m4a, aac, flac) and both multi-track output modes keep working; the PR #31 reliability invariants (pendingWrite chains, part-rotation error containment, no-rollback rule for final files) are untouched.

## Test plan

- [x] `npm test -- --no-coverage`: 26 suites, 614 tests green (new `tests/unit/main.test.ts` settings-resilience cases, streaming/fallback conversion cases, remux opt-in cases, mono/stereo mix cases)
- [x] `npm run lint`: 0 errors
- [x] `npm run build`: success; `dist/main.js` contains no lamejs
- [x] Manual in Obsidian: record in each format; 2-device multi-track in `single` and `multiple` modes; context-menu conversion (including a bitrate change on a codec-matching pair, e.g. webm to ogg) and manual split; auto-split; settings survive disable/enable and `data.json.bak` appears in the plugin folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)
