### PR TITLE
feat(recording): input-processing toggles and live recording feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,15 @@ The waveform is drawn for supported audio files up to a large safety size. Peaks
 
 > **Desktop and mobile**: the enhanced player works wherever Obsidian renders audio embeds. Waveform extraction relies on the Web Audio API available in the app.
 
+## Recording feedback & input processing
+
+Live feedback while recording, and control over the browser's input processing — all configurable under **Settings > Advanced Audio Recorder > Audio processing & feedback**.
+
+- **Noise suppression**, **echo cancellation**, and **automatic gain control** toggles are applied to the microphone stream (and to the diagnostics test recording).
+- **Input level meter**: a live VU meter in the status bar shows that the microphone is actually picking up sound.
+- **Recording stats**: the status bar shows the live elapsed time (excluding paused intervals) and the recorded file size as it grows.
+- **Mobile recording banner**: on mobile — where there is no ribbon icon — a prominent banner shows that a recording is in progress, with the elapsed time and a stop button.
+
 ## Transcription (speech-to-text)
 
 When **Enable transcription** is on in settings, recordings (and any existing audio file) can be transcribed to text. Right-click an audio file or its embed and choose **Transcribe audio**, run the **Transcribe active audio file** command, or enable **Transcribe after recording** to do it automatically.

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Live feedback while recording, and control over the browser's input processing �
 
 - **Noise suppression**, **echo cancellation**, and **automatic gain control** toggles are applied to the microphone stream (and to the diagnostics test recording).
 - **Input level meter**: a live VU meter in the status bar shows that the microphone is actually picking up sound.
-- **Recording stats**: the status bar shows the live elapsed time (excluding paused intervals) and the recorded file size as it grows.
+- **Recording stats**: the status bar shows the live elapsed time (excluding paused intervals) and the total recorded size as it grows (the sum across all tracks and parts).
 - **Mobile recording banner**: on mobile — where there is no ribbon icon — a prominent banner shows that a recording is in progress, with the elapsed time and a stop button.
 
 ## Transcription (speech-to-text)

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@
  * @module main
  */
 
-import { Notice, Plugin, TFile } from 'obsidian';
+import { Notice, Platform, Plugin, TFile } from 'obsidian';
 import { RecordingStatus } from './types';
 import type {
 	SaveProgress,
@@ -31,9 +31,11 @@ import {
 } from './recording/EncodingWorkerClient';
 import {
 	updateStatusBar,
+	updateRecordingLiveStats,
 	initializeStatusBar,
 	renderTranscriptionStatusBar,
 } from './ui/StatusBar';
+import { RecordingBanner } from './ui/RecordingBanner';
 import { updateRibbonIcon, initializeRibbonIcon } from './ui/RibbonIcon';
 import { showDeviceSelectionModal } from './ui/DeviceSelectionModal';
 import { ContextMenu } from './ui/ContextMenu';
@@ -56,6 +58,9 @@ const SETTINGS_BACKUP_FILE = 'data.json.bak';
 
 /** Accessible label for the status-bar action that reopens a minimized transcription. */
 const RESTORE_TRANSCRIPTION_LABEL = 'Restore transcription window';
+
+/** Refresh interval, in ms, for the live recording stats and meter. */
+const LIVE_STATS_INTERVAL_MS = 200;
 
 /**
  * Result of reading the stored settings from disk.
@@ -99,6 +104,7 @@ export default class AudioRecorderPlugin extends Plugin {
 	private statusBarItem: HTMLElement | null = null;
 	private ribbonIconEl: HTMLElement | null = null;
 	private contextMenu!: ContextMenu;
+	private recordingBanner!: RecordingBanner;
 	private playerRegistrar!: EnhancedPlayerRegistrar;
 	private journal!: SessionJournal;
 	private encodingWorker: EncodingWorkerClient | null = null;
@@ -151,17 +157,14 @@ export default class AudioRecorderPlugin extends Plugin {
 		// at stop) and the player registrar (which reads/edits them), so
 		// their cache and serialized write chain stay unified.
 		const markerStore = new MarkerStore(this.app);
+		this.recordingBanner = new RecordingBanner(() => {
+			void this.recordingManager.stopRecording();
+		});
 		this.recordingManager = new RecordingManager(
 			this.app,
 			this.settings,
 			(status: RecordingStatus, saveProgress?: SaveProgress) => {
-				this.recordingStatus = status;
-				this.recordingSaveProgress =
-					status === RecordingStatus.Saving
-						? saveProgress
-						: undefined;
-				this.renderStatusBar();
-				updateRibbonIcon(this.ribbonIconEl, status);
+				this.handleStatusChange(status, saveProgress);
 			},
 			this.journal,
 			(result: RecordingSaveResult) => {
@@ -271,6 +274,7 @@ export default class AudioRecorderPlugin extends Plugin {
 	 */
 	onunload(): void {
 		this.recordingManager.cleanup();
+		this.recordingBanner.hide();
 		this.playerRegistrar.dispose();
 		setEncodingWorkerClient(null);
 		this.encodingWorker?.terminate();
@@ -735,6 +739,10 @@ export default class AudioRecorderPlugin extends Plugin {
 			this.recordingStatus,
 			this.recordingSaveProgress,
 			controls,
+			{
+				showStats: this.settings.showRecordingStats,
+				showMeter: this.settings.showInputLevelMeter,
+			},
 		);
 	}
 
@@ -785,10 +793,72 @@ export default class AudioRecorderPlugin extends Plugin {
 	}
 
 	/**
-	 * Sets up the status bar item.
+	 * Sets up the status bar item and the live-stats refresh interval.
 	 */
 	private setupStatusBar(): void {
 		this.statusBarItem = this.addStatusBarItem();
 		initializeStatusBar(this.statusBarItem);
+		// Refresh the live recording indicators a few times a second so the
+		// timer and meter stay smooth without re-rendering the status bar.
+		this.registerInterval(
+			window.setInterval(() => {
+				this.pumpLiveStats();
+			}, LIVE_STATS_INTERVAL_MS),
+		);
+	}
+
+	/**
+	 * Renders the status bar and the mobile banner for a status change.
+	 * @param status - New recording status
+	 * @param saveProgress - Optional save progress for the saving state
+	 */
+	private handleStatusChange(
+		status: RecordingStatus,
+		saveProgress?: SaveProgress,
+	): void {
+		this.recordingStatus = status;
+		this.recordingSaveProgress =
+			status === RecordingStatus.Saving ? saveProgress : undefined;
+		// Route through renderStatusBar so minimized transcription progress
+		// keeps its precedence when recording returns to idle.
+		this.renderStatusBar();
+		updateRibbonIcon(this.ribbonIconEl, status);
+
+		const active =
+			status === RecordingStatus.Recording ||
+			status === RecordingStatus.Paused;
+		if (
+			active &&
+			Platform.isMobile &&
+			this.settings.mobileRecordingBanner
+		) {
+			this.recordingBanner.show(status === RecordingStatus.Paused);
+		} else {
+			this.recordingBanner.hide();
+		}
+	}
+
+	/**
+	 * Pushes live elapsed time, recorded size, and input level to the
+	 * status bar and mobile banner while a recording is active.
+	 */
+	private pumpLiveStats(): void {
+		const status = this.recordingManager.getStatus();
+		if (
+			status !== RecordingStatus.Recording &&
+			status !== RecordingStatus.Paused
+		) {
+			return;
+		}
+		const elapsedMs = this.recordingManager.getElapsedMs();
+		updateRecordingLiveStats(this.statusBarItem, {
+			elapsedMs,
+			bytes: this.recordingManager.getRecordedBytes(),
+			level: this.recordingManager.getInputLevel(),
+		});
+		this.recordingBanner.update(
+			elapsedMs,
+			status === RecordingStatus.Paused,
+		);
 	}
 }

--- a/src/recording/AudioStreamHandler.ts
+++ b/src/recording/AudioStreamHandler.ts
@@ -33,16 +33,41 @@ const MAX_RETRIES = 2;
 const RETRY_DELAY_MS = 500;
 
 /**
+ * Browser audio-processing constraints applied to the input stream.
+ */
+export interface AudioProcessingConstraints {
+	noiseSuppression: boolean;
+	echoCancellation: boolean;
+	autoGainControl: boolean;
+}
+
+/**
+ * Reads the audio-processing constraints from settings.
+ * @param settings - Plugin settings
+ */
+export function getProcessingConstraints(
+	settings: AudioRecorderSettings,
+): AudioProcessingConstraints {
+	return {
+		noiseSuppression: settings.inputNoiseSuppression,
+		echoCancellation: settings.inputEchoCancellation,
+		autoGainControl: settings.inputAutoGainControl,
+	};
+}
+
+/**
  * Gets a MediaStream for the specified audio device.
  * Implements retry logic for temporary access errors.
  * @param deviceId - Optional device ID to use
  * @param sampleRate - Audio sample rate
+ * @param processing - Optional audio-processing constraints
  * @returns Promise resolving to MediaStream
  * @throws AudioStreamError if device access fails after all retries
  */
 export async function getAudioStream(
 	deviceId?: string,
 	sampleRate?: number,
+	processing?: AudioProcessingConstraints,
 ): Promise<MediaStream> {
 	let lastError: Error | null = null;
 
@@ -52,6 +77,13 @@ export async function getAudioStream(
 				audio: {
 					deviceId: deviceId ? { exact: deviceId } : undefined,
 					sampleRate: sampleRate,
+					...(processing
+						? {
+								noiseSuppression: processing.noiseSuppression,
+								echoCancellation: processing.echoCancellation,
+								autoGainControl: processing.autoGainControl,
+							}
+						: {}),
 				},
 			});
 		} catch (error) {
@@ -90,16 +122,18 @@ export async function getAudioStream(
 export async function getAudioStreams(
 	settings: AudioRecorderSettings,
 ): Promise<{ streams: MediaStream[]; trackOrder: TrackAudioSource[] }> {
+	const processing = getProcessingConstraints(settings);
 	if (settings.enableMultiTrack) {
 		const trackOrder = getOrderedTrackSources(settings);
 		const streamPromises = trackOrder.map((source) =>
-			getAudioStream(source.deviceId, settings.sampleRate),
+			getAudioStream(source.deviceId, settings.sampleRate, processing),
 		);
 		return { streams: await Promise.all(streamPromises), trackOrder };
 	}
 	const stream = await getAudioStream(
 		settings.audioDeviceId,
 		settings.sampleRate,
+		processing,
 	);
 	return { streams: [stream], trackOrder: [] };
 }

--- a/src/recording/InputLevelMonitor.ts
+++ b/src/recording/InputLevelMonitor.ts
@@ -1,0 +1,107 @@
+/**
+ * Live input-level metering. Taps a MediaStream through a Web Audio
+ * AnalyserNode and exposes a 0..1 level for a VU meter. The RMS and
+ * perceptual-scaling math is pure and unit tested; the class wraps it
+ * with the audio-graph plumbing and resource cleanup.
+ * @module recording/InputLevelMonitor
+ */
+
+import { PLUGIN_LOG_PREFIX } from '../constants';
+
+/** Lowest level, in dBFS, mapped to the bottom of the meter. */
+const METER_FLOOR_DB = -60;
+
+/**
+ * Root-mean-square amplitude of time-domain samples (range 0..~1).
+ * @param samples - Time-domain samples in the range -1..1
+ */
+export function computeRms(samples: Float32Array): number {
+	if (samples.length === 0) {
+		return 0;
+	}
+	let sumSquares = 0;
+	for (let i = 0; i < samples.length; i++) {
+		sumSquares += samples[i] * samples[i];
+	}
+	return Math.sqrt(sumSquares / samples.length);
+}
+
+/**
+ * Maps an RMS amplitude to a 0..1 meter fraction on a dB scale, so quiet
+ * speech is visible and the meter behaves perceptually. Silence maps to
+ * 0; full scale maps to 1.
+ * @param rms - RMS amplitude (0..1)
+ */
+export function rmsToMeterFraction(rms: number): number {
+	if (rms <= 0) {
+		return 0;
+	}
+	const db = 20 * Math.log10(rms);
+	const fraction = (db - METER_FLOOR_DB) / -METER_FLOOR_DB;
+	return Math.min(1, Math.max(0, fraction));
+}
+
+/**
+ * Wraps a MediaStream in an analyser to read the live input level.
+ */
+export class InputLevelMonitor {
+	private context: AudioContext | null = null;
+	private analyser: AnalyserNode | null = null;
+	private source: MediaStreamAudioSourceNode | null = null;
+	private buffer: Float32Array<ArrayBuffer> | null = null;
+
+	/**
+	 * Starts metering the given stream. Safe to call once per monitor.
+	 * @param stream - Input MediaStream to meter
+	 */
+	start(stream: MediaStream): void {
+		try {
+			this.context = new AudioContext();
+			this.source = this.context.createMediaStreamSource(stream);
+			this.analyser = this.context.createAnalyser();
+			this.analyser.fftSize = 1024;
+			// Analyser only — never connect to the destination, or the
+			// input would be played back as a feedback loop.
+			this.source.connect(this.analyser);
+			this.buffer = new Float32Array(this.analyser.fftSize);
+		} catch (error) {
+			console.warn(
+				`${PLUGIN_LOG_PREFIX} Could not start input level monitor:`,
+				error,
+			);
+			this.stop();
+		}
+	}
+
+	/**
+	 * Returns the current input level as a 0..1 meter fraction, or 0 when
+	 * the monitor is not running.
+	 */
+	getLevel(): number {
+		if (!this.analyser || !this.buffer) {
+			return 0;
+		}
+		this.analyser.getFloatTimeDomainData(this.buffer);
+		return rmsToMeterFraction(computeRms(this.buffer));
+	}
+
+	/**
+	 * Stops metering and releases the audio graph.
+	 */
+	stop(): void {
+		try {
+			this.source?.disconnect();
+		} catch {
+			// Already disconnected
+		}
+		if (this.context) {
+			void this.context.close().catch(() => {
+				// Closing a context that already failed is non-fatal
+			});
+		}
+		this.context = null;
+		this.analyser = null;
+		this.source = null;
+		this.buffer = null;
+	}
+}

--- a/src/recording/InputLevelMonitor.ts
+++ b/src/recording/InputLevelMonitor.ts
@@ -57,6 +57,13 @@ export class InputLevelMonitor {
 	start(stream: MediaStream): void {
 		try {
 			this.context = new AudioContext();
+			// A context may start suspended until a user gesture; resume so
+			// the analyser receives data instead of reading silence.
+			if (this.context.state === 'suspended') {
+				void this.context.resume().catch(() => {
+					// Non-fatal: the meter simply stays at zero
+				});
+			}
 			this.source = this.context.createMediaStreamSource(stream);
 			this.analyser = this.context.createAnalyser();
 			this.analyser.fftSize = 1024;

--- a/src/recording/PartRotationController.ts
+++ b/src/recording/PartRotationController.ts
@@ -143,6 +143,21 @@ export class PartRotationController {
 	}
 
 	/**
+	 * Returns the active (unpaused) milliseconds elapsed since the session
+	 * began. The live span since the last anchor is added only while
+	 * recording, so a value read during a pause excludes the paused time.
+	 * This is the single source of truth for pause-aware elapsed time.
+	 * @param status - Current recording status
+	 */
+	getSessionActiveMs(status: RecordingStatus): number {
+		const liveMs =
+			status === RecordingStatus.Recording
+				? Date.now() - this.activeAnchor
+				: 0;
+		return this.sessionActiveMs + liveMs;
+	}
+
+	/**
 	 * Re-anchors active-time accounting when the recording resumes
 	 * (and when capture actually starts).
 	 */

--- a/src/recording/RecordingManager.ts
+++ b/src/recording/RecordingManager.ts
@@ -89,10 +89,6 @@ export class RecordingManager {
 	private totalChunks: number = 0;
 	/** Total bytes of audio data observed this session (live size). */
 	private recordedBytes: number = 0;
-	/** Accumulated paused time in ms, for pause-aware elapsed time. */
-	private pausedAccumMs: number = 0;
-	/** Timestamp when the current pause began, or null when not paused. */
-	private pauseStartedAt: number | null = null;
 	/** Live input-level meter for the primary stream, when enabled. */
 	private levelMonitor: InputLevelMonitor | null = null;
 	private isMobileRecording: boolean = false;
@@ -226,7 +222,8 @@ export class RecordingManager {
 
 	/**
 	 * Returns the elapsed active recording time in milliseconds, excluding
-	 * paused intervals. Zero when idle.
+	 * paused intervals. Zero when idle. Delegates to the rotation
+	 * controller, which already owns the pause-aware active-time clock.
 	 */
 	getElapsedMs(): number {
 		if (
@@ -235,15 +232,7 @@ export class RecordingManager {
 		) {
 			return 0;
 		}
-		const pausedNow =
-			this.pauseStartedAt !== null ? Date.now() - this.pauseStartedAt : 0;
-		return Math.max(
-			0,
-			Date.now() -
-				this.recordingStartTime -
-				this.pausedAccumMs -
-				pausedNow,
-		);
+		return this.rotation.getSessionActiveMs(this.status);
 	}
 
 	/**
@@ -522,8 +511,6 @@ export class RecordingManager {
 			this.markerBuffer = [];
 			this.persistedMarkerPaths.clear();
 			this.recordedBytes = 0;
-			this.pausedAccumMs = 0;
-			this.pauseStartedAt = null;
 			this.startLevelMonitor();
 
 			if (this.isWavPcmRecording) {
@@ -896,8 +883,6 @@ export class RecordingManager {
 			this.recordingTimestamp = null;
 			this.totalChunks = 0;
 			this.recordedBytes = 0;
-			this.pausedAccumMs = 0;
-			this.pauseStartedAt = null;
 			this.isWavPcmRecording = false;
 			this.insertionContext = null;
 			this.sessionSplitEnabled = false;
@@ -973,7 +958,6 @@ export class RecordingManager {
 			}
 			// Freeze active-time accounting used by auto-split rotation
 			this.rotation.markPaused();
-			this.pauseStartedAt = Date.now();
 			this.setStatus(RecordingStatus.Paused);
 			new Notice('Recording paused');
 		} else if (this.status === RecordingStatus.Paused) {
@@ -989,10 +973,6 @@ export class RecordingManager {
 				});
 			}
 			this.rotation.markResumed();
-			if (this.pauseStartedAt !== null) {
-				this.pausedAccumMs += Date.now() - this.pauseStartedAt;
-				this.pauseStartedAt = null;
-			}
 			this.setStatus(RecordingStatus.Recording);
 			new Notice('Recording resumed');
 		} else {

--- a/src/recording/RecordingManager.ts
+++ b/src/recording/RecordingManager.ts
@@ -56,6 +56,7 @@ import {
 	validateRecordingCapability,
 } from './AudioCapabilityDetector';
 import { PcmStreamRecorder } from './PcmStreamRecorder';
+import { InputLevelMonitor } from './InputLevelMonitor';
 import { resolveRecorderFormat } from './AudioFormatConverter';
 import { TrackWriteQueue } from './TrackWriteQueue';
 import { RecordingFinalizer } from './RecordingFinalizer';
@@ -86,6 +87,14 @@ export class RecordingManager {
 	private recordingStartTime: number = 0;
 	private recordingTimestamp: string | null = null;
 	private totalChunks: number = 0;
+	/** Total bytes of audio data observed this session (live size). */
+	private recordedBytes: number = 0;
+	/** Accumulated paused time in ms, for pause-aware elapsed time. */
+	private pausedAccumMs: number = 0;
+	/** Timestamp when the current pause began, or null when not paused. */
+	private pauseStartedAt: number | null = null;
+	/** Live input-level meter for the primary stream, when enabled. */
+	private levelMonitor: InputLevelMonitor | null = null;
 	private isMobileRecording: boolean = false;
 	private isWavPcmRecording: boolean = false;
 	private activeRecorderFormat: string = FORMAT_WEBM;
@@ -197,6 +206,43 @@ export class RecordingManager {
 			(this.status === RecordingStatus.Recording ||
 				this.status === RecordingStatus.Paused) &&
 			this.settings.playerEnableMarkers
+		);
+	}
+
+	/**
+	 * Returns the current input level (0..1) for a VU meter, or 0 when no
+	 * monitor is running.
+	 */
+	getInputLevel(): number {
+		return this.levelMonitor?.getLevel() ?? 0;
+	}
+
+	/**
+	 * Returns the total bytes of audio data observed this session.
+	 */
+	getRecordedBytes(): number {
+		return this.recordedBytes;
+	}
+
+	/**
+	 * Returns the elapsed active recording time in milliseconds, excluding
+	 * paused intervals. Zero when idle.
+	 */
+	getElapsedMs(): number {
+		if (
+			this.status !== RecordingStatus.Recording &&
+			this.status !== RecordingStatus.Paused
+		) {
+			return 0;
+		}
+		const pausedNow =
+			this.pauseStartedAt !== null ? Date.now() - this.pauseStartedAt : 0;
+		return Math.max(
+			0,
+			Date.now() -
+				this.recordingStartTime -
+				this.pausedAccumMs -
+				pausedNow,
 		);
 	}
 
@@ -367,6 +413,28 @@ export class RecordingManager {
 	}
 
 	/**
+	 * Starts the input-level monitor on the primary stream when the meter
+	 * is enabled. A failure to start is non-fatal (the meter just stays
+	 * at zero).
+	 */
+	private startLevelMonitor(): void {
+		this.stopLevelMonitor();
+		if (!this.settings.showInputLevelMeter || this.streams.length === 0) {
+			return;
+		}
+		this.levelMonitor = new InputLevelMonitor();
+		this.levelMonitor.start(this.streams[0]);
+	}
+
+	/**
+	 * Stops and releases the input-level monitor.
+	 */
+	private stopLevelMonitor(): void {
+		this.levelMonitor?.stop();
+		this.levelMonitor = null;
+	}
+
+	/**
 	 * Updates settings reference.
 	 * @param settings - New settings
 	 */
@@ -453,6 +521,10 @@ export class RecordingManager {
 			this.totalChunks = 0;
 			this.markerBuffer = [];
 			this.persistedMarkerPaths.clear();
+			this.recordedBytes = 0;
+			this.pausedAccumMs = 0;
+			this.pauseStartedAt = null;
+			this.startLevelMonitor();
 
 			if (this.isWavPcmRecording) {
 				await this.initPcmRecording();
@@ -814,6 +886,7 @@ export class RecordingManager {
 				error,
 			);
 		} finally {
+			this.stopLevelMonitor();
 			stopAllStreams(this.streams);
 			this.streams = [];
 			this.recorders = [];
@@ -822,6 +895,9 @@ export class RecordingManager {
 			this.trackOrder = [];
 			this.recordingTimestamp = null;
 			this.totalChunks = 0;
+			this.recordedBytes = 0;
+			this.pausedAccumMs = 0;
+			this.pauseStartedAt = null;
 			this.isWavPcmRecording = false;
 			this.insertionContext = null;
 			this.sessionSplitEnabled = false;
@@ -897,6 +973,7 @@ export class RecordingManager {
 			}
 			// Freeze active-time accounting used by auto-split rotation
 			this.rotation.markPaused();
+			this.pauseStartedAt = Date.now();
 			this.setStatus(RecordingStatus.Paused);
 			new Notice('Recording paused');
 		} else if (this.status === RecordingStatus.Paused) {
@@ -912,6 +989,10 @@ export class RecordingManager {
 				});
 			}
 			this.rotation.markResumed();
+			if (this.pauseStartedAt !== null) {
+				this.pausedAccumMs += Date.now() - this.pauseStartedAt;
+				this.pauseStartedAt = null;
+			}
 			this.setStatus(RecordingStatus.Recording);
 			new Notice('Recording resumed');
 		} else {
@@ -934,6 +1015,7 @@ export class RecordingManager {
 		// on the released streams after unload
 		this.rotation.requestStop();
 		this.sessionSplitEnabled = false;
+		this.stopLevelMonitor();
 		for (const recorder of this.pcmRecorders) {
 			recorder.stop().catch((error: unknown) => {
 				console.error(
@@ -985,6 +1067,7 @@ export class RecordingManager {
 			return;
 		}
 		this.totalChunks += 1;
+		this.recordedBytes += data.size;
 		const flushThreshold = this.isMobileRecording
 			? MOBILE_BUFFER_LIMIT_BYTES
 			: DESKTOP_FLUSH_THRESHOLD_BYTES;
@@ -1012,6 +1095,7 @@ export class RecordingManager {
 			return;
 		}
 		this.totalChunks += 1;
+		this.recordedBytes += data.byteLength;
 
 		await this.writeQueue.enqueue(target, async () => {
 			target.pcmBuffers.push(data);

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -197,6 +197,18 @@ export interface AudioRecorderSettings {
 	llmModel: string;
 	/** Maximum output tokens for LLM post-processing */
 	llmMaxTokens: number;
+	/** Apply browser noise suppression to the input */
+	inputNoiseSuppression: boolean;
+	/** Apply browser echo cancellation to the input */
+	inputEchoCancellation: boolean;
+	/** Apply browser automatic gain control to the input */
+	inputAutoGainControl: boolean;
+	/** Show a live input-level meter while recording */
+	showInputLevelMeter: boolean;
+	/** Show live elapsed time and file size while recording */
+	showRecordingStats: boolean;
+	/** Show a prominent recording banner on mobile */
+	mobileRecordingBanner: boolean;
 }
 
 /** Transcription engine identifier, derived from {@link TRANSCRIPTION_PROVIDER_IDS}. */
@@ -361,6 +373,12 @@ export const DEFAULT_SETTINGS: AudioRecorderSettings = {
 	llmApiKey: '',
 	llmModel: DEFAULT_LLM_OPENAI_MODEL,
 	llmMaxTokens: DEFAULT_LLM_MAX_TOKENS,
+	inputNoiseSuppression: true,
+	inputEchoCancellation: true,
+	inputAutoGainControl: true,
+	showInputLevelMeter: true,
+	showRecordingStats: true,
+	mobileRecordingBanner: true,
 };
 
 /**

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -27,6 +27,7 @@ import {
 	getEncoderDescription,
 	isOfflineEncodingSupported,
 } from '../recording/AudioEncoder';
+import { getProcessingConstraints } from '../recording/AudioStreamHandler';
 import {
 	DEFAULT_SPLIT_PART_SUFFIX,
 	MIN_SPLIT_CHUNK_MINUTES,
@@ -790,11 +791,7 @@ export class AudioRecorderSettingTab extends PluginSettingTab {
 						? { exact: this.plugin.settings.audioDeviceId }
 						: undefined,
 					sampleRate: this.plugin.settings.sampleRate,
-					noiseSuppression:
-						this.plugin.settings.inputNoiseSuppression,
-					echoCancellation:
-						this.plugin.settings.inputEchoCancellation,
-					autoGainControl: this.plugin.settings.inputAutoGainControl,
+					...getProcessingConstraints(this.plugin.settings),
 				},
 			});
 

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -191,6 +191,9 @@ export class AudioRecorderSettingTab extends PluginSettingTab {
 				});
 			});
 
+		// Audio processing & feedback
+		this.renderInputProcessingSettings(containerEl);
+
 		// Output format
 		new Setting(containerEl).setName('Output format').setHeading();
 
@@ -654,6 +657,82 @@ export class AudioRecorderSettingTab extends PluginSettingTab {
 	}
 
 	/**
+	 * Renders the audio input-processing constraints and the live
+	 * recording-feedback options.
+	 * @param containerEl - The settings container element
+	 */
+	private renderInputProcessingSettings(containerEl: HTMLElement): void {
+		const s = this.plugin.settings;
+		new Setting(containerEl)
+			.setName('Audio processing & feedback')
+			.setHeading();
+
+		new Setting(containerEl)
+			.setName('Noise suppression')
+			.setDesc('Apply the browser noise-suppression filter to the input.')
+			.addToggle((toggle) =>
+				toggle.setValue(s.inputNoiseSuppression).onChange(async (v) => {
+					s.inputNoiseSuppression = v;
+					await this.plugin.saveSettings();
+				}),
+			);
+
+		new Setting(containerEl)
+			.setName('Echo cancellation')
+			.setDesc('Apply the browser echo-cancellation filter to the input.')
+			.addToggle((toggle) =>
+				toggle.setValue(s.inputEchoCancellation).onChange(async (v) => {
+					s.inputEchoCancellation = v;
+					await this.plugin.saveSettings();
+				}),
+			);
+
+		new Setting(containerEl)
+			.setName('Automatic gain control')
+			.setDesc('Let the browser normalize the input level automatically.')
+			.addToggle((toggle) =>
+				toggle.setValue(s.inputAutoGainControl).onChange(async (v) => {
+					s.inputAutoGainControl = v;
+					await this.plugin.saveSettings();
+				}),
+			);
+
+		new Setting(containerEl)
+			.setName('Input level meter')
+			.setDesc('Show a live input-level meter while recording.')
+			.addToggle((toggle) =>
+				toggle.setValue(s.showInputLevelMeter).onChange(async (v) => {
+					s.showInputLevelMeter = v;
+					await this.plugin.saveSettings();
+				}),
+			);
+
+		new Setting(containerEl)
+			.setName('Recording stats')
+			.setDesc(
+				'Show the live elapsed time and recorded file size while recording.',
+			)
+			.addToggle((toggle) =>
+				toggle.setValue(s.showRecordingStats).onChange(async (v) => {
+					s.showRecordingStats = v;
+					await this.plugin.saveSettings();
+				}),
+			);
+
+		new Setting(containerEl)
+			.setName('Mobile recording banner')
+			.setDesc(
+				'Show a prominent recording banner on mobile, where there is no ribbon indicator.',
+			)
+			.addToggle((toggle) =>
+				toggle.setValue(s.mobileRecordingBanner).onChange(async (v) => {
+					s.mobileRecordingBanner = v;
+					await this.plugin.saveSettings();
+				}),
+			);
+	}
+
+	/**
 	 * Populates dropdown with audio devices.
 	 * @param dropdown - The dropdown component
 	 */
@@ -711,6 +790,11 @@ export class AudioRecorderSettingTab extends PluginSettingTab {
 						? { exact: this.plugin.settings.audioDeviceId }
 						: undefined,
 					sampleRate: this.plugin.settings.sampleRate,
+					noiseSuppression:
+						this.plugin.settings.inputNoiseSuppression,
+					echoCancellation:
+						this.plugin.settings.inputEchoCancellation,
+					autoGainControl: this.plugin.settings.inputAutoGainControl,
 				},
 			});
 

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -192,9 +192,6 @@ export class AudioRecorderSettingTab extends PluginSettingTab {
 				});
 			});
 
-		// Audio processing & feedback
-		this.renderInputProcessingSettings(containerEl);
-
 		// Output format
 		new Setting(containerEl).setName('Output format').setHeading();
 
@@ -555,6 +552,9 @@ export class AudioRecorderSettingTab extends PluginSettingTab {
 				this.saveTextSettingDebounced();
 			},
 		});
+
+		// Audio processing & feedback
+		this.renderInputProcessingSettings(containerEl);
 
 		// Diagnostics
 		new Setting(containerEl).setName('Diagnostics').setHeading();

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -711,7 +711,7 @@ export class AudioRecorderSettingTab extends PluginSettingTab {
 		new Setting(containerEl)
 			.setName('Recording stats')
 			.setDesc(
-				'Show the live elapsed time and recorded file size while recording.',
+				'Show the live elapsed time and total recorded size while recording.',
 			)
 			.addToggle((toggle) =>
 				toggle.setValue(s.showRecordingStats).onChange(async (v) => {

--- a/src/ui/RecordingBanner.ts
+++ b/src/ui/RecordingBanner.ts
@@ -1,0 +1,72 @@
+/**
+ * Prominent on-screen recording banner, primarily for mobile where there
+ * is no ribbon icon to show that a recording is in progress. Displays a
+ * pulsing indicator, the elapsed time, and a stop button.
+ * @module ui/RecordingBanner
+ */
+
+import { setIcon } from 'obsidian';
+import { formatTimecode } from '../utils/TimeUtils';
+
+/**
+ * A floating recording banner appended to the document body.
+ */
+export class RecordingBanner {
+	private el: HTMLElement | null = null;
+	private timeEl: HTMLElement | null = null;
+
+	/**
+	 * @param onStop - Invoked when the banner's stop button is tapped
+	 */
+	constructor(private readonly onStop: () => void) {}
+
+	/**
+	 * Shows the banner (creating it on first call) and reflects the paused
+	 * state.
+	 * @param paused - Whether the recording is paused
+	 */
+	show(paused: boolean): void {
+		if (!this.el) {
+			this.el = activeDocument.body.createDiv({
+				cls: 'aar-recording-banner',
+			});
+			this.el.createSpan({ cls: 'aar-recording-banner-dot' });
+			this.timeEl = this.el.createSpan({
+				cls: 'aar-recording-banner-time',
+				text: '0:00',
+			});
+			const stop = this.el.createSpan({
+				cls: 'aar-recording-banner-stop',
+			});
+			stop.setAttribute('aria-label', 'Stop recording');
+			stop.setAttribute('role', 'button');
+			setIcon(stop, 'square');
+			stop.addEventListener('click', (event) => {
+				event.stopPropagation();
+				this.onStop();
+			});
+		}
+		this.el.toggleClass('is-paused', paused);
+	}
+
+	/**
+	 * Updates the elapsed-time label.
+	 * @param elapsedMs - Elapsed active recording time in milliseconds
+	 * @param paused - Whether the recording is paused
+	 */
+	update(elapsedMs: number, paused: boolean): void {
+		if (this.timeEl) {
+			const time = formatTimecode(elapsedMs / 1000);
+			this.timeEl.textContent = paused ? `Paused ${time}` : time;
+		}
+	}
+
+	/**
+	 * Removes the banner from the DOM.
+	 */
+	hide(): void {
+		this.el?.remove();
+		this.el = null;
+		this.timeEl = null;
+	}
+}

--- a/src/ui/RecordingBanner.ts
+++ b/src/ui/RecordingBanner.ts
@@ -40,10 +40,19 @@ export class RecordingBanner {
 			});
 			stop.setAttribute('aria-label', 'Stop recording');
 			stop.setAttribute('role', 'button');
+			stop.setAttribute('tabindex', '0');
 			setIcon(stop, 'square');
 			stop.addEventListener('click', (event) => {
 				event.stopPropagation();
 				this.onStop();
+			});
+			// A role="button" element must also activate on Enter/Space
+			stop.addEventListener('keydown', (event) => {
+				if (event.key === 'Enter' || event.key === ' ') {
+					event.preventDefault();
+					event.stopPropagation();
+					this.onStop();
+				}
 			});
 		}
 		this.el.toggleClass('is-paused', paused);

--- a/src/ui/StatusBar.ts
+++ b/src/ui/StatusBar.ts
@@ -6,6 +6,26 @@
 import { setIcon } from 'obsidian';
 import { RecordingStatus } from '../types';
 import type { SaveProgress, RecordingControls } from '../types';
+import { formatTimecode } from '../utils/TimeUtils';
+import { formatByteSize } from '../utils/formatBytes';
+
+/** Which live indicators to render in the recording state. */
+export interface RecordingLiveOptions {
+	/** Show elapsed time and recorded size. */
+	showStats: boolean;
+	/** Show the input-level meter. */
+	showMeter: boolean;
+}
+
+/** Live values pushed to the recording status bar on a timer. */
+export interface RecordingLiveStats {
+	/** Elapsed active recording time in milliseconds. */
+	elapsedMs: number;
+	/** Recorded bytes so far. */
+	bytes: number;
+	/** Input level as a 0..1 fraction. */
+	level: number;
+}
 
 /**
  * Options for an interactive background progress indicator.
@@ -30,6 +50,7 @@ export function updateStatusBar(
 	status: RecordingStatus,
 	saveProgress?: SaveProgress,
 	controls?: RecordingControls,
+	liveOptions?: RecordingLiveOptions,
 ): void {
 	if (!statusBarItem) {
 		return;
@@ -37,10 +58,20 @@ export function updateStatusBar(
 
 	switch (status) {
 		case RecordingStatus.Recording:
-			renderRecordingState(statusBarItem, 'Recording...', controls);
+			renderRecordingState(
+				statusBarItem,
+				'Recording...',
+				controls,
+				liveOptions,
+			);
 			break;
 		case RecordingStatus.Paused:
-			renderRecordingState(statusBarItem, 'Recording paused', controls);
+			renderRecordingState(
+				statusBarItem,
+				'Recording paused',
+				controls,
+				liveOptions,
+			);
 			break;
 		case RecordingStatus.Saving:
 			renderSavingState(statusBarItem, saveProgress);
@@ -62,6 +93,7 @@ function renderRecordingState(
 	el: HTMLElement,
 	label: string,
 	controls?: RecordingControls,
+	liveOptions?: RecordingLiveOptions,
 ): void {
 	el.empty();
 	el.classList.add('is-recording');
@@ -96,6 +128,47 @@ function renderRecordingState(
 			'Stop recording',
 			controls.onStop,
 		);
+	}
+
+	if (liveOptions?.showStats || liveOptions?.showMeter) {
+		const live = container.createSpan({ cls: 'aar-recording-live' });
+		if (liveOptions.showStats) {
+			live.createSpan({ cls: 'aar-recording-time', text: '0:00' });
+			live.createSpan({ cls: 'aar-recording-size', text: '0 B' });
+		}
+		if (liveOptions.showMeter) {
+			const meter = live.createSpan({ cls: 'aar-input-meter' });
+			meter.createSpan({ cls: 'aar-input-meter-fill' });
+		}
+	}
+}
+
+/**
+ * Updates the live recording indicators (elapsed time, recorded size,
+ * input level) in place, without re-rendering the status bar. No-op when
+ * the recording state is not currently shown.
+ * @param statusBarItem - The status bar element
+ * @param stats - Live values to display
+ */
+export function updateRecordingLiveStats(
+	statusBarItem: HTMLElement | null,
+	stats: RecordingLiveStats,
+): void {
+	const live = statusBarItem?.querySelector('.aar-recording-live');
+	if (!live) {
+		return;
+	}
+	const time = live.querySelector('.aar-recording-time');
+	if (time) {
+		time.textContent = formatTimecode(stats.elapsedMs / 1000);
+	}
+	const size = live.querySelector('.aar-recording-size');
+	if (size) {
+		size.textContent = formatByteSize(stats.bytes);
+	}
+	const fill = live.querySelector<HTMLElement>('.aar-input-meter-fill');
+	if (fill) {
+		fill.style.width = `${String(Math.round(stats.level * 100))}%`;
 	}
 }
 

--- a/src/ui/StatusBar.ts
+++ b/src/ui/StatusBar.ts
@@ -168,7 +168,9 @@ export function updateRecordingLiveStats(
 	}
 	const fill = live.querySelector<HTMLElement>('.aar-input-meter-fill');
 	if (fill) {
-		fill.style.width = `${String(Math.round(stats.level * 100))}%`;
+		fill.setCssProps({
+			'--aar-meter-fill': `${String(Math.round(stats.level * 100))}%`,
+		});
 	}
 }
 

--- a/src/utils/AudioFileAnalyzer.ts
+++ b/src/utils/AudioFileAnalyzer.ts
@@ -4,6 +4,7 @@
  */
 
 import { App, Notice, TFile } from 'obsidian';
+import { formatByteSize } from './formatBytes';
 
 /**
  * Represents detailed information about an audio file.
@@ -80,7 +81,11 @@ export async function getAudioFileInfo(
 
 		return {
 			fileName: file.name,
-			fileSize: formatBytes(fileSizeInBytes),
+			fileSize: formatByteSize(fileSizeInBytes, {
+				decimals: 2,
+				trimZeros: true,
+				bytesLabel: 'Bytes',
+			}),
 			duration: formatDuration(durationInSeconds),
 			containerFormat: getMimeTypeFromExtension(extension),
 			audioCodec: inferCodecFromExtension(extension),
@@ -93,24 +98,6 @@ export async function getAudioFileInfo(
 		new Notice('An error occurred while analyzing the audio file.');
 		return null;
 	}
-}
-
-/**
- * Formats a byte size into a human-readable string.
- * @param bytes - The size in bytes.
- * @param decimals - Number of decimal places.
- * @returns Formatted size string.
- */
-function formatBytes(bytes: number, decimals = 2): string {
-	if (!+bytes) return '0 Bytes';
-
-	const k = 1024;
-	const dm = decimals < 0 ? 0 : decimals;
-	const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
-
-	const i = Math.floor(Math.log(bytes) / Math.log(k));
-
-	return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`;
 }
 
 /**

--- a/src/utils/formatBytes.ts
+++ b/src/utils/formatBytes.ts
@@ -1,27 +1,63 @@
 /**
- * Small formatting helper for human-readable byte sizes.
+ * Small formatting helper for human-readable byte sizes. Shared by the
+ * live recording stat (compact "1.4 MB") and the file-info modal
+ * (precise "1.5 MB" / "500 Bytes"); the presentation differs via options
+ * while the unit-selection math stays in one place.
  * @module utils/formatBytes
  */
 
-/** Unit suffixes for {@link formatByteSize}. */
-const BYTE_UNITS = ['B', 'KB', 'MB', 'GB', 'TB'];
+/** Unit suffixes above bytes, in ascending order. */
+const LARGE_UNITS = ['KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+
+/** Highest supported exponent (bytes is exponent 0). */
+const MAX_EXPONENT = LARGE_UNITS.length;
+
+/** Default decimal places for units above bytes. */
+const DEFAULT_DECIMALS = 1;
+
+/** Options controlling how {@link formatByteSize} renders a size. */
+export interface ByteSizeOptions {
+	/** Decimal places for units above bytes (default 1). */
+	decimals?: number;
+	/** Strip trailing zeros from the decimal part (default false). */
+	trimZeros?: boolean;
+	/** Label for the bytes unit (default "B"). */
+	bytesLabel?: string;
+}
 
 /**
  * Formats a byte count as a human-readable string (e.g. "1.4 MB").
- * Negative or non-finite inputs render as "0 B".
+ * Negative or non-finite inputs render as "0 <bytesLabel>".
  * @param bytes - Byte count
+ * @param options - Presentation options
  * @returns Formatted size string
  */
-export function formatByteSize(bytes: number): string {
+export function formatByteSize(
+	bytes: number,
+	options: ByteSizeOptions = {},
+): string {
+	const {
+		decimals = DEFAULT_DECIMALS,
+		trimZeros = false,
+		bytesLabel = 'B',
+	} = options;
 	if (!Number.isFinite(bytes) || bytes <= 0) {
-		return '0 B';
+		return `0 ${bytesLabel}`;
 	}
 	const exponent = Math.min(
-		BYTE_UNITS.length - 1,
+		MAX_EXPONENT,
 		Math.floor(Math.log(bytes) / Math.log(1024)),
 	);
+	const unit = exponent === 0 ? bytesLabel : LARGE_UNITS[exponent - 1];
 	const value = bytes / Math.pow(1024, exponent);
-	// Whole numbers for bytes; one decimal for larger units
-	const formatted = exponent === 0 ? String(value) : value.toFixed(1);
-	return `${formatted} ${BYTE_UNITS[exponent]}`;
+	let formatted: string;
+	if (exponent === 0) {
+		// Whole numbers for bytes
+		formatted = String(value);
+	} else if (trimZeros) {
+		formatted = String(parseFloat(value.toFixed(decimals)));
+	} else {
+		formatted = value.toFixed(decimals);
+	}
+	return `${formatted} ${unit}`;
 }

--- a/src/utils/formatBytes.ts
+++ b/src/utils/formatBytes.ts
@@ -1,0 +1,27 @@
+/**
+ * Small formatting helper for human-readable byte sizes.
+ * @module utils/formatBytes
+ */
+
+/** Unit suffixes for {@link formatByteSize}. */
+const BYTE_UNITS = ['B', 'KB', 'MB', 'GB', 'TB'];
+
+/**
+ * Formats a byte count as a human-readable string (e.g. "1.4 MB").
+ * Negative or non-finite inputs render as "0 B".
+ * @param bytes - Byte count
+ * @returns Formatted size string
+ */
+export function formatByteSize(bytes: number): string {
+	if (!Number.isFinite(bytes) || bytes <= 0) {
+		return '0 B';
+	}
+	const exponent = Math.min(
+		BYTE_UNITS.length - 1,
+		Math.floor(Math.log(bytes) / Math.log(1024)),
+	);
+	const value = bytes / Math.pow(1024, exponent);
+	// Whole numbers for bytes; one decimal for larger units
+	const formatted = exponent === 0 ? String(value) : value.toFixed(1);
+	return `${formatted} ${BYTE_UNITS[exponent]}`;
+}

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -155,7 +155,7 @@ If your plugin does not need CSS, delete this file.
 .aar-input-meter-fill {
     display: block;
     height: 100%;
-    width: 0%;
+    width: var(--aar-meter-fill, 0%);
     background-color: var(--color-green);
     transition: width 0.1s linear;
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -126,6 +126,83 @@ If your plugin does not need CSS, delete this file.
     margin-bottom: 4px;
 }
 
+/* Live recording stats and input meter */
+.aar-recording-live {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    margin-left: 6px;
+    font-variant-numeric: tabular-nums;
+}
+
+.aar-recording-time {
+    color: var(--text-normal);
+}
+
+.aar-recording-size {
+    color: var(--text-muted);
+}
+
+.aar-input-meter {
+    display: inline-block;
+    width: 42px;
+    height: 6px;
+    border-radius: 3px;
+    background-color: var(--background-modifier-border);
+    overflow: hidden;
+}
+
+.aar-input-meter-fill {
+    display: block;
+    height: 100%;
+    width: 0%;
+    background-color: var(--color-green);
+    transition: width 0.1s linear;
+}
+
+/* Mobile recording banner */
+.aar-recording-banner {
+    position: fixed;
+    top: calc(env(safe-area-inset-top, 0px) + 8px);
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: var(--layer-notice, 100);
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 6px 14px;
+    border-radius: 20px;
+    background-color: var(--background-secondary);
+    border: 1px solid var(--background-modifier-border);
+    box-shadow: var(--shadow-s);
+    font-variant-numeric: tabular-nums;
+}
+
+.aar-recording-banner-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background-color: var(--color-red);
+    animation: pulse-recording 1.5s ease-in-out infinite;
+}
+
+.aar-recording-banner.is-paused .aar-recording-banner-dot {
+    animation: none;
+    background-color: var(--text-muted);
+}
+
+.aar-recording-banner-stop {
+    display: inline-flex;
+    align-items: center;
+    cursor: pointer;
+    color: var(--color-red);
+}
+
+.aar-recording-banner-stop svg {
+    width: 16px;
+    height: 16px;
+}
+
 /* Save progress */
 .aar-status-progress-content {
     width: 100%;

--- a/tests/mocks/obsidian.ts
+++ b/tests/mocks/obsidian.ts
@@ -35,6 +35,10 @@ export class Plugin {
 		return document.createElement('div');
 	}
 
+	registerInterval(id: number): number {
+		return id;
+	}
+
 	async loadData(): Promise<unknown> {
 		return {};
 	}

--- a/tests/unit/PartRotationController.test.ts
+++ b/tests/unit/PartRotationController.test.ts
@@ -496,4 +496,55 @@ describe('PartRotationController', () => {
 			expect(position.offsetSeconds).toBeLessThan(1);
 		});
 	});
+
+	describe('getSessionActiveMs', () => {
+		it('is zero immediately after the session starts', () => {
+			expect(
+				controller.getSessionActiveMs(RecordingStatus.Recording),
+			).toBe(0);
+		});
+
+		it('counts active wall-clock time while recording', () => {
+			jest.advanceTimersByTime(5000);
+
+			expect(
+				controller.getSessionActiveMs(RecordingStatus.Recording),
+			).toBe(5000);
+		});
+
+		it('freezes during a pause and excludes the paused span', () => {
+			jest.advanceTimersByTime(3000);
+			controller.markPaused();
+			jest.advanceTimersByTime(4000);
+
+			// Frozen at the active time accumulated before the pause
+			expect(controller.getSessionActiveMs(RecordingStatus.Paused)).toBe(
+				3000,
+			);
+		});
+
+		it('resumes counting after a pause, never counting paused time', () => {
+			jest.advanceTimersByTime(3000);
+			controller.markPaused();
+			jest.advanceTimersByTime(4000);
+			controller.markResumed();
+			jest.advanceTimersByTime(2000);
+
+			expect(
+				controller.getSessionActiveMs(RecordingStatus.Recording),
+			).toBe(5000);
+		});
+
+		it('keeps accumulating across an auto-split rotation', async () => {
+			jest.advanceTimersByTime(15 * MS_PER_MINUTE);
+			controller.maybeRotate();
+			await controller.waitForPendingRotation();
+			jest.advanceTimersByTime(2000);
+
+			// Whole-session active time spans both parts
+			expect(
+				controller.getSessionActiveMs(RecordingStatus.Recording),
+			).toBe(15 * MS_PER_MINUTE + 2000);
+		});
+	});
 });

--- a/tests/unit/Settings.test.ts
+++ b/tests/unit/Settings.test.ts
@@ -262,6 +262,12 @@ describe('Settings', () => {
 				llmApiKey: 'ak-test',
 				llmModel: 'claude-opus-4-8',
 				llmMaxTokens: 2048,
+				inputNoiseSuppression: false,
+				inputEchoCancellation: false,
+				inputAutoGainControl: false,
+				showInputLevelMeter: false,
+				showRecordingStats: false,
+				mobileRecordingBanner: false,
 			};
 
 			const result = mergeSettings(fullSettings);

--- a/tests/unit/recordingFeedback.test.ts
+++ b/tests/unit/recordingFeedback.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Tests for the pure recording-feedback helpers: byte formatting and the
+ * input-level RMS / meter math.
+ */
+
+import { formatByteSize } from 'src/utils/formatBytes';
+import {
+	computeRms,
+	rmsToMeterFraction,
+} from 'src/recording/InputLevelMonitor';
+
+describe('formatByteSize', () => {
+	it('formats bytes, KB, MB, and GB', () => {
+		expect(formatByteSize(512)).toBe('512 B');
+		expect(formatByteSize(1024)).toBe('1.0 KB');
+		expect(formatByteSize(1.5 * 1024 * 1024)).toBe('1.5 MB');
+		expect(formatByteSize(2 * 1024 * 1024 * 1024)).toBe('2.0 GB');
+	});
+
+	it('renders non-positive or invalid input as 0 B', () => {
+		expect(formatByteSize(0)).toBe('0 B');
+		expect(formatByteSize(-5)).toBe('0 B');
+		expect(formatByteSize(Number.NaN)).toBe('0 B');
+	});
+});
+
+describe('computeRms', () => {
+	it('is zero for silence and empty input', () => {
+		expect(computeRms(new Float32Array(0))).toBe(0);
+		expect(computeRms(new Float32Array([0, 0, 0]))).toBe(0);
+	});
+
+	it('computes the root mean square amplitude', () => {
+		// Constant 0.5 -> RMS 0.5
+		expect(
+			computeRms(new Float32Array([0.5, -0.5, 0.5, -0.5])),
+		).toBeCloseTo(0.5);
+		// Full-scale square wave -> RMS 1
+		expect(computeRms(new Float32Array([1, -1, 1, -1]))).toBeCloseTo(1);
+	});
+});
+
+describe('rmsToMeterFraction', () => {
+	it('maps silence to 0 and full scale to 1', () => {
+		expect(rmsToMeterFraction(0)).toBe(0);
+		expect(rmsToMeterFraction(1)).toBeCloseTo(1);
+	});
+
+	it('maps the dB floor to 0 and is monotonic', () => {
+		// -60 dBFS is the floor
+		expect(rmsToMeterFraction(0.001)).toBeCloseTo(0);
+		const quiet = rmsToMeterFraction(0.01); // -40 dBFS
+		const loud = rmsToMeterFraction(0.1); // -20 dBFS
+		expect(quiet).toBeGreaterThan(0);
+		expect(loud).toBeGreaterThan(quiet);
+		expect(loud).toBeLessThan(1);
+	});
+});

--- a/tests/unit/recordingFeedback.test.ts
+++ b/tests/unit/recordingFeedback.test.ts
@@ -22,6 +22,16 @@ describe('formatByteSize', () => {
 		expect(formatByteSize(-5)).toBe('0 B');
 		expect(formatByteSize(Number.NaN)).toBe('0 B');
 	});
+
+	it('honors presentation options (decimals, trimZeros, bytesLabel)', () => {
+		expect(formatByteSize(1.25 * 1024 * 1024, { decimals: 2 })).toBe(
+			'1.25 MB',
+		);
+		expect(
+			formatByteSize(1.5 * 1024 * 1024, { decimals: 2, trimZeros: true }),
+		).toBe('1.5 MB');
+		expect(formatByteSize(500, { bytesLabel: 'Bytes' })).toBe('500 Bytes');
+	});
 });
 
 describe('computeRms', () => {


### PR DESCRIPTION
## Summary

Implements the remaining community **"quality & feedback during recording"** requests, on top of the transcription branch (#35). Everything is configurable under **Settings → Audio processing & feedback**.

> Based on `claude/audio-transcription` (PR #35) so the diff shows only this feature. Retarget down the stack as the earlier PRs merge.

## What's added

- **Input-processing toggles** — **noise suppression**, **echo cancellation**, and **automatic gain control** are threaded through `getUserMedia` constraints in `AudioStreamHandler` (and applied to the diagnostics test recording too). Closes the long-standing "let me turn off noise suppression / voice isolation" request and matches Field Recorder.
- **Live input-level meter (VU)** in the status bar — an `InputLevelMonitor` taps the stream through a Web Audio `AnalyserNode`; the **RMS + perceptual dB-scaling math is pure and unit tested**. Confirms the mic is actually capturing before you finish.
- **Live recording stats** — elapsed **active** time (pause-aware) and recorded **file size**, refreshed on a 200 ms timer via a dedicated `updateRecordingLiveStats` that updates in place (no status-bar re-render).
- **Mobile recording banner** — a prominent, stoppable on-screen indicator for mobile, where there's no ribbon icon (direct forum request).

## Implementation

- `RecordingManager` now tracks recorded bytes and pause-aware elapsed time, owns the level monitor (started on the primary stream when enabled, torn down on stop/cleanup), and exposes `getInputLevel()` / `getRecordedBytes()` / `getElapsedMs()`.
- The plugin runs one `registerInterval` that pumps live values to the status bar and banner only while recording/paused.
- New settings: input noise suppression / echo cancellation / AGC, input level meter, recording stats, mobile banner — each a simple toggle with progressive, sensible defaults (all on).

## Testing

- `npx tsc -noEmit` clean; `npx eslint .` no errors; production esbuild builds.
- **873 tests pass** (new: `formatByteSize`, `computeRms`, `rmsToMeterFraction`).
- README updated.

https://claude.ai/code/session_01AxMFHTVcPkhr2gseXk2DP8

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxMFHTVcPkhr2gseXk2DP8)_