### PR TITLE
feat(audio): on-demand audio cleanup — noise removal and loudness leveling

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,12 @@ Live feedback while recording, and control over the browser's input processing �
 - **Recording stats**: the status bar shows the live elapsed time (excluding paused intervals) and the total recorded size as it grows (the sum across all tracks and parts).
 - **Mobile recording banner**: on mobile — where there is no ribbon icon — a prominent banner shows that a recording is in progress, with the elapsed time and a stop button.
 
+### Clean up audio (on demand)
+
+Right-click an audio file (or its embed) and choose **Clean up audio** to remove noise (high-pass filter + noise gate) and even out loudness, writing a processed copy and leaving the original untouched. It runs only when you ask — it never alters live recording.
+
+See the **[Audio cleanup guide](docs/audio-cleanup.md)** for a full walkthrough: each stage, recommended settings, output behavior, limitations, and troubleshooting.
+
 ## Transcription (speech-to-text)
 
 When **Enable transcription** is on in settings, recordings (and any existing audio file) can be transcribed to text. Right-click an audio file or its embed and choose **Transcribe audio**, run the **Transcribe active audio file** command, or enable **Transcribe after recording** to do it automatically.

--- a/docs/audio-cleanup.md
+++ b/docs/audio-cleanup.md
@@ -1,0 +1,121 @@
+# Audio cleanup guide
+
+The **Clean up audio** action runs offline digital signal processing (DSP) over an existing recording to remove background noise and even out loudness. It is **on-demand only** — it is invoked from the context menu, processes a file you choose, and writes a new copy. It never changes how live recording works, and it never overwrites the original.
+
+- [Overview](#overview)
+- [How to run it](#how-to-run-it)
+- [Processing stages](#processing-stages)
+  - [High-pass filter](#high-pass-filter)
+  - [Noise gate](#noise-gate)
+  - [Loudness leveling](#loudness-leveling)
+- [Output](#output)
+- [Defaults and settings](#defaults-and-settings)
+- [Recommended settings](#recommended-settings)
+- [Limitations](#limitations)
+- [Troubleshooting](#troubleshooting)
+
+## Overview
+
+The browser's built-in input processing (noise suppression, echo cancellation, automatic gain control — configured under **Settings → Audio processing & feedback**) is applied *while recording*. The **Clean up audio** action is the stronger, after-the-fact alternative: it decodes a finished file, applies the stages you select, and writes a cleaned `…-processed.wav` copy next to the source.
+
+Use it when:
+
+- A recording has constant background hiss, hum, or room rumble.
+- There is dead air / quiet gaps you want silenced.
+- Quiet and loud passages are uneven and you want a more consistent level.
+- You captured raw audio (browser filters off) and want to clean it selectively.
+
+## How to run it
+
+1. Right-click the target audio in any of these places:
+   - the **File Explorer**,
+   - an audio **embed link** in the editor (`![[recording.webm]]`),
+   - an **embedded audio player**.
+2. Choose **Clean up audio**.
+3. In the dialog, toggle the stages you want and adjust their parameters. The toggles and values start from your settings defaults but can be changed per run.
+4. (Optional) Enable **Delete source after processing** to move the original to the system trash once the cleaned copy is written.
+5. Click **Process**. A notice reports the path of the written file.
+
+At least one stage must be enabled, or the dialog asks you to enable one.
+
+## Processing stages
+
+The stages are applied in this order: **noise gate → high-pass filter → loudness leveling**. You can enable any combination.
+
+### High-pass filter
+
+Attenuates everything below a cutoff frequency, which removes low-frequency rumble: air conditioning, traffic, desk thumps, mains hum, and microphone handling noise.
+
+| Parameter | Meaning | Range | Default |
+|-----------|---------|-------|---------|
+| **Cutoff (Hz)** | Frequencies below this are progressively attenuated. | 20–300 Hz | 80 Hz |
+
+- **Speech**: 80–120 Hz is safe and removes most rumble without thinning the voice.
+- **Music / full-range**: keep it low (20–40 Hz) or disable it, so you don't lose bass.
+
+### Noise gate
+
+Silences the signal whenever its level falls below a threshold, so quiet background noise between words/phrases disappears. The gate uses **hysteresis** (it opens at the threshold but only closes once the level drops a margin below it) plus attack/release smoothing, so it does not "chatter" on and off or introduce clicks.
+
+| Parameter | Meaning | Range | Default |
+|-----------|---------|-------|---------|
+| **Threshold (dBFS)** | Audio quieter than this is gated to silence. | −80 to −20 dBFS | −50 dBFS |
+
+- A **lower** threshold (e.g. −60 dBFS) gates only very quiet noise — safer, less aggressive.
+- A **higher** threshold (e.g. −35 dBFS) removes more, but risks clipping the start/end of soft speech. Tune by ear.
+
+### Loudness leveling
+
+Runs the audio through a compressor and a makeup-gain stage to even out quiet and loud passages — useful for interviews or dictation recorded at an inconsistent distance from the mic.
+
+| Parameter | Meaning | Range | Default |
+|-----------|---------|-------|---------|
+| **Makeup gain (dB)** | Gain added after compression to restore overall level. | 0–24 dB | 6 dB |
+
+The compressor itself uses fixed, speech-friendly settings (threshold −24 dB, ratio 12:1, knee 30 dB, attack 3 ms, release 250 ms). Raise the makeup gain if the result is quieter than you want; lower it if it sounds too loud or starts to distort.
+
+## Output
+
+- The cleaned file is always written as **16-bit PCM WAV**, regardless of the source format, because the cleanup re-encodes the decoded audio losslessly. The source's channel layout (mono/stereo) and sample rate are preserved.
+- The file is saved **next to the source**, named `<source-name>-processed.wav`. If that name is taken, a numeric suffix is appended (`…-processed_1.wav`).
+- The original file is left untouched unless you enable **Delete source after processing**. If processing succeeds but deleting the source fails, the cleaned copy is still kept and a notice explains what happened.
+
+## Defaults and settings
+
+Under **Settings → Advanced Audio Recorder → Audio cleanup defaults**, set the values the dialog starts from each time:
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| **High-pass filter** | Default on/off and cutoff (Hz) for the high-pass stage. | On, 80 Hz |
+| **Noise gate** | Default on/off and threshold (dBFS) for the gate. | Off, −50 dBFS |
+| **Loudness leveling** | Default on/off and makeup gain (dB) for the compressor. | Off, 6 dB |
+
+These are only defaults — every run can override them in the dialog.
+
+## Recommended settings
+
+| Use case | High-pass | Noise gate | Leveling |
+|----------|-----------|-----------|----------|
+| Voice note / dictation | On, ~90 Hz | On, −50 dBFS | On, ~6 dB |
+| Interview (two voices) | On, ~80 Hz | On, −45 dBFS | On, ~4 dB |
+| Lecture in a noisy room | On, ~100 Hz | On, −40 dBFS | On, ~6 dB |
+| Music / instrument | Off or ~30 Hz | Off | Off |
+
+Start conservative and re-run with stronger settings if needed — the original is preserved, so you can experiment freely.
+
+## Limitations
+
+- **Output is always WAV.** Convert it afterwards with **Convert audio format** from the context menu if you need a compressed format.
+- **Size and length caps.** Cleanup decodes the whole file into memory and runs part of the work on the main thread, so a file is refused with a clear message when it is larger than 1 GB (checked before decoding) or longer than two hours. Split it first (**Split audio into parts**) and clean each part.
+- **Desktop and mobile.** Cleanup uses the Web Audio API available in the Obsidian app; it works on both, but processing a long file briefly uses significant memory and CPU.
+- **Not real-time.** This is post-processing. To shape the signal *during* recording, use the browser input toggles under **Audio processing & feedback** instead.
+
+## Troubleshooting
+
+- **"Audio file is too large to clean up here"** — the file exceeds the 1 GB size limit. Split it into parts and process each part.
+- **"Audio is too long to clean up here"** — the file exceeds the two-hour limit. Split it into parts and process each part.
+- **"The file contains no decodable audio data"** — the file is empty or its container/codec can't be decoded by the app. Check the file with **Audio file info**, or convert it first.
+- **"Audio processing failed: …"** — decoding or writing failed; the message carries the cause. Verify the file is a valid audio file and that there is free space in the vault.
+- **The voice sounds thin** — lower or disable the high-pass cutoff.
+- **Words get cut off / choppy** — lower the noise-gate threshold (e.g. from −40 to −55 dBFS) or disable the gate.
+- **Result is too quiet or too loud** — adjust the leveling makeup gain.

--- a/docs/audio-cleanup.md
+++ b/docs/audio-cleanup.md
@@ -106,13 +106,13 @@ Start conservative and re-run with stronger settings if needed — the original 
 ## Limitations
 
 - **Output is always WAV.** Convert it afterwards with **Convert audio format** from the context menu if you need a compressed format.
-- **Size and length caps.** Cleanup decodes the whole file into memory and runs part of the work on the main thread, so a file is refused with a clear message when it is larger than 1 GB (checked before decoding) or longer than two hours. Split it first (**Split audio into parts**) and clean each part. The length is only known after decoding, so a heavily compressed file that is under 1 GB but very long may fail while decoding (a generic processing error) rather than with the friendly length message — split it and clean each part.
+- **Size and length caps.** Cleanup decodes the whole file into memory and runs part of the work on the main thread, so a file is refused with a clear message when it is larger than 1 GB (checked before decoding), longer than two hours, or decodes to more samples than the working set allows (checked right after decoding). The decoded-size cap catches a heavily compressed file that is small on disk yet expands to several gigabytes once decoded. In every case, split it first (**Split audio into parts**) and clean each part.
 - **Desktop only.** The plugin is desktop-only, so cleanup runs only in the Obsidian desktop app. Processing a long file briefly uses significant memory and CPU.
 - **Not real-time.** This is post-processing. To shape the signal *during* recording, use the browser input toggles under **Audio processing & feedback** instead.
 
 ## Troubleshooting
 
-- **"Audio file is too large to clean up here"** — the file exceeds the 1 GB size limit. Split it into parts and process each part.
+- **"Audio file is too large to clean up here"** — the file exceeds the 1 GB on-disk limit, or it decodes to a buffer too large to process here. Split it into parts and process each part.
 - **"Audio is too long to clean up here"** — the file exceeds the two-hour limit. Split it into parts and process each part.
 - **"The file contains no decodable audio data"** — the file is empty or its container/codec can't be decoded by the app. Check the file with **Audio file info**, or convert it first.
 - **"Audio processing failed: …"** — decoding or writing failed; the message carries the cause. Verify the file is a valid audio file and that there is free space in the vault.

--- a/docs/audio-cleanup.md
+++ b/docs/audio-cleanup.md
@@ -76,7 +76,7 @@ The compressor itself uses fixed, speech-friendly settings (threshold −24 dB, 
 
 ## Output
 
-- The cleaned file is always written as **16-bit PCM WAV**, regardless of the source format, because the cleanup re-encodes the decoded audio losslessly. The source's channel layout (mono/stereo) and sample rate are preserved.
+- The cleaned file is always written as **16-bit PCM WAV**, regardless of the source format, because the cleanup re-encodes the decoded audio. The source's channel layout (mono/stereo) is preserved; the sample rate is the one the Obsidian audio engine decodes to, which may differ from the source.
 - The file is saved **next to the source**, named `<source-name>-processed.wav`. If that name is taken, a numeric suffix is appended (`…-processed_1.wav`).
 - The original file is left untouched unless you enable **Delete source after processing**. If processing succeeds but deleting the source fails, the cleaned copy is still kept and a notice explains what happened.
 
@@ -106,8 +106,8 @@ Start conservative and re-run with stronger settings if needed — the original 
 ## Limitations
 
 - **Output is always WAV.** Convert it afterwards with **Convert audio format** from the context menu if you need a compressed format.
-- **Size and length caps.** Cleanup decodes the whole file into memory and runs part of the work on the main thread, so a file is refused with a clear message when it is larger than 1 GB (checked before decoding) or longer than two hours. Split it first (**Split audio into parts**) and clean each part.
-- **Desktop and mobile.** Cleanup uses the Web Audio API available in the Obsidian app; it works on both, but processing a long file briefly uses significant memory and CPU.
+- **Size and length caps.** Cleanup decodes the whole file into memory and runs part of the work on the main thread, so a file is refused with a clear message when it is larger than 1 GB (checked before decoding) or longer than two hours. Split it first (**Split audio into parts**) and clean each part. The length is only known after decoding, so a heavily compressed file that is under 1 GB but very long may fail while decoding (a generic processing error) rather than with the friendly length message — split it and clean each part.
+- **Desktop only.** The plugin is desktop-only, so cleanup runs only in the Obsidian desktop app. Processing a long file briefly uses significant memory and CPU.
 - **Not real-time.** This is post-processing. To shape the signal *during* recording, use the browser input toggles under **Audio processing & feedback** instead.
 
 ## Troubleshooting

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -99,7 +99,14 @@ export default tseslint.config(
             'no-console': ['error', { allow: ['warn', 'error', 'debug'] }],
 
             // Obsidian Plugin Rules
-            'obsidianmd/ui/sentence-case': 'warn',
+            // ignoreWords keeps audio units/format acronyms the default
+            // dictionary lacks; listing them is additive (DEFAULT_ACRONYMS
+            // such as API/URL are unaffected) and preserves their exact
+            // mixed casing (dB, dBFS) instead of lowercasing them.
+            'obsidianmd/ui/sentence-case': [
+                'warn',
+                { ignoreWords: ['WAV', 'dB', 'dBFS'] },
+            ],
         },
     },
     {

--- a/src/cleanup/AudioProcessingModal.ts
+++ b/src/cleanup/AudioProcessingModal.ts
@@ -22,6 +22,9 @@ import {
 	MAX_CLEANUP_GATE_THRESHOLD_DB,
 	MIN_CLEANUP_LEVELING_MAKEUP_DB,
 	MAX_CLEANUP_LEVELING_MAKEUP_DB,
+	CLEANUP_HIGHPASS_STEP_HZ,
+	CLEANUP_GATE_STEP_DB,
+	CLEANUP_LEVELING_STEP_DB,
 	PLUGIN_LOG_PREFIX,
 } from '../constants';
 import { AudioProcessingService } from './AudioProcessingService';
@@ -68,7 +71,7 @@ export class AudioProcessingModal extends Modal {
 			{
 				min: MIN_CLEANUP_HIGHPASS_HZ,
 				max: MAX_CLEANUP_HIGHPASS_HZ,
-				step: 5,
+				step: CLEANUP_HIGHPASS_STEP_HZ,
 				value: this.config.highPass.hz,
 				onChange: (v) => (this.config.highPass.hz = v),
 			},
@@ -82,7 +85,7 @@ export class AudioProcessingModal extends Modal {
 			{
 				min: MIN_CLEANUP_GATE_THRESHOLD_DB,
 				max: MAX_CLEANUP_GATE_THRESHOLD_DB,
-				step: 1,
+				step: CLEANUP_GATE_STEP_DB,
 				value: this.config.gate.thresholdDb,
 				onChange: (v) => (this.config.gate.thresholdDb = v),
 			},
@@ -96,7 +99,7 @@ export class AudioProcessingModal extends Modal {
 			{
 				min: MIN_CLEANUP_LEVELING_MAKEUP_DB,
 				max: MAX_CLEANUP_LEVELING_MAKEUP_DB,
-				step: 1,
+				step: CLEANUP_LEVELING_STEP_DB,
 				value: this.config.leveling.makeupDb,
 				onChange: (v) => (this.config.leveling.makeupDb = v),
 			},

--- a/src/cleanup/AudioProcessingModal.ts
+++ b/src/cleanup/AudioProcessingModal.ts
@@ -6,14 +6,22 @@
  * @module cleanup/AudioProcessingModal
  */
 
-import { App, ButtonComponent, Modal, Notice, Setting, TFile } from 'obsidian';
 import {
-	MIN_INPUT_HIGHPASS_HZ,
-	MAX_INPUT_HIGHPASS_HZ,
-	MIN_INPUT_GATE_THRESHOLD_DB,
-	MAX_INPUT_GATE_THRESHOLD_DB,
-	MIN_INPUT_LEVELING_MAKEUP_DB,
-	MAX_INPUT_LEVELING_MAKEUP_DB,
+	App,
+	ButtonComponent,
+	Modal,
+	Notice,
+	Setting,
+	SliderComponent,
+	TFile,
+} from 'obsidian';
+import {
+	MIN_CLEANUP_HIGHPASS_HZ,
+	MAX_CLEANUP_HIGHPASS_HZ,
+	MIN_CLEANUP_GATE_THRESHOLD_DB,
+	MAX_CLEANUP_GATE_THRESHOLD_DB,
+	MIN_CLEANUP_LEVELING_MAKEUP_DB,
+	MAX_CLEANUP_LEVELING_MAKEUP_DB,
 	PLUGIN_LOG_PREFIX,
 } from '../constants';
 import { AudioProcessingService } from './AudioProcessingService';
@@ -58,8 +66,8 @@ export class AudioProcessingModal extends Modal {
 			this.config.highPass.enabled,
 			(v) => (this.config.highPass.enabled = v),
 			{
-				min: MIN_INPUT_HIGHPASS_HZ,
-				max: MAX_INPUT_HIGHPASS_HZ,
+				min: MIN_CLEANUP_HIGHPASS_HZ,
+				max: MAX_CLEANUP_HIGHPASS_HZ,
 				step: 5,
 				value: this.config.highPass.hz,
 				onChange: (v) => (this.config.highPass.hz = v),
@@ -72,8 +80,8 @@ export class AudioProcessingModal extends Modal {
 			this.config.gate.enabled,
 			(v) => (this.config.gate.enabled = v),
 			{
-				min: MIN_INPUT_GATE_THRESHOLD_DB,
-				max: MAX_INPUT_GATE_THRESHOLD_DB,
+				min: MIN_CLEANUP_GATE_THRESHOLD_DB,
+				max: MAX_CLEANUP_GATE_THRESHOLD_DB,
 				step: 1,
 				value: this.config.gate.thresholdDb,
 				onChange: (v) => (this.config.gate.thresholdDb = v),
@@ -86,8 +94,8 @@ export class AudioProcessingModal extends Modal {
 			this.config.leveling.enabled,
 			(v) => (this.config.leveling.enabled = v),
 			{
-				min: MIN_INPUT_LEVELING_MAKEUP_DB,
-				max: MAX_INPUT_LEVELING_MAKEUP_DB,
+				min: MIN_CLEANUP_LEVELING_MAKEUP_DB,
+				max: MAX_CLEANUP_LEVELING_MAKEUP_DB,
 				step: 1,
 				value: this.config.leveling.makeupDb,
 				onChange: (v) => (this.config.leveling.makeupDb = v),
@@ -118,7 +126,9 @@ export class AudioProcessingModal extends Modal {
 	}
 
 	/**
-	 * Adds a stage toggle with a parameter slider on the same row.
+	 * Adds a stage toggle with a parameter slider on the same row. The
+	 * slider is greyed out while the stage is off so it is clear the
+	 * parameter only takes effect once the stage is enabled.
 	 */
 	private addStageWithSlider(
 		container: HTMLElement,
@@ -134,17 +144,24 @@ export class AudioProcessingModal extends Modal {
 			onChange: (value: number) => void;
 		},
 	): void {
+		let sliderComponent!: SliderComponent;
 		new Setting(container)
 			.setName(name)
 			.setDesc(desc)
-			.addSlider((s) =>
-				s
+			.addSlider((s) => {
+				sliderComponent = s
 					.setLimits(slider.min, slider.max, slider.step)
 					.setValue(slider.value)
 					.setDynamicTooltip()
-					.onChange(slider.onChange),
-			)
-			.addToggle((toggle) => toggle.setValue(enabled).onChange(onToggle));
+					.onChange(slider.onChange);
+				s.setDisabled(!enabled);
+			})
+			.addToggle((toggle) =>
+				toggle.setValue(enabled).onChange((value) => {
+					onToggle(value);
+					sliderComponent.setDisabled(!value);
+				}),
+			);
 	}
 
 	/**

--- a/src/cleanup/AudioProcessingModal.ts
+++ b/src/cleanup/AudioProcessingModal.ts
@@ -1,0 +1,204 @@
+/**
+ * On-demand audio cleanup dialog: pick which DSP stages to apply
+ * (high-pass, noise gate, loudness leveling) and process the file into a
+ * cleaned WAV copy. Defaults come from settings; each run can override
+ * them. Opened from the context menu.
+ * @module cleanup/AudioProcessingModal
+ */
+
+import { App, ButtonComponent, Modal, Notice, Setting, TFile } from 'obsidian';
+import {
+	MIN_INPUT_HIGHPASS_HZ,
+	MAX_INPUT_HIGHPASS_HZ,
+	MIN_INPUT_GATE_THRESHOLD_DB,
+	MAX_INPUT_GATE_THRESHOLD_DB,
+	MIN_INPUT_LEVELING_MAKEUP_DB,
+	MAX_INPUT_LEVELING_MAKEUP_DB,
+	PLUGIN_LOG_PREFIX,
+} from '../constants';
+import { AudioProcessingService } from './AudioProcessingService';
+import {
+	hasActiveStage,
+	resolveAudioDspConfig,
+	type AudioDspConfig,
+} from './audioDsp';
+import type { AudioRecorderSettings } from '../settings/Settings';
+
+/**
+ * Audio-cleanup dialog for a single file.
+ */
+export class AudioProcessingModal extends Modal {
+	private readonly config: AudioDspConfig;
+	private deleteSource = false;
+	private processing = false;
+
+	constructor(
+		app: App,
+		private readonly file: TFile,
+		settings: AudioRecorderSettings,
+	) {
+		super(app);
+		this.config = resolveAudioDspConfig(settings);
+	}
+
+	onOpen(): void {
+		const { contentEl } = this;
+		contentEl.empty();
+		new Setting(contentEl).setName('Clean up audio').setHeading();
+		contentEl.createEl('p', { text: `Source: ${this.file.name}` });
+		contentEl.createEl('p', {
+			cls: 'aar-modal-config',
+			text: 'Produces a processed WAV copy next to the source.',
+		});
+
+		this.addStageWithSlider(
+			contentEl,
+			'High-pass filter',
+			'Remove low-frequency rumble below the cutoff (Hz).',
+			this.config.highPass.enabled,
+			(v) => (this.config.highPass.enabled = v),
+			{
+				min: MIN_INPUT_HIGHPASS_HZ,
+				max: MAX_INPUT_HIGHPASS_HZ,
+				step: 5,
+				value: this.config.highPass.hz,
+				onChange: (v) => (this.config.highPass.hz = v),
+			},
+		);
+		this.addStageWithSlider(
+			contentEl,
+			'Noise gate',
+			'Silence the signal below the threshold (dBFS).',
+			this.config.gate.enabled,
+			(v) => (this.config.gate.enabled = v),
+			{
+				min: MIN_INPUT_GATE_THRESHOLD_DB,
+				max: MAX_INPUT_GATE_THRESHOLD_DB,
+				step: 1,
+				value: this.config.gate.thresholdDb,
+				onChange: (v) => (this.config.gate.thresholdDb = v),
+			},
+		);
+		this.addStageWithSlider(
+			contentEl,
+			'Loudness leveling',
+			'Even out quiet and loud passages; makeup gain (dB).',
+			this.config.leveling.enabled,
+			(v) => (this.config.leveling.enabled = v),
+			{
+				min: MIN_INPUT_LEVELING_MAKEUP_DB,
+				max: MAX_INPUT_LEVELING_MAKEUP_DB,
+				step: 1,
+				value: this.config.leveling.makeupDb,
+				onChange: (v) => (this.config.leveling.makeupDb = v),
+			},
+		);
+
+		new Setting(contentEl)
+			.setName('Delete source after processing')
+			.addToggle((toggle) =>
+				toggle.setValue(this.deleteSource).onChange((v) => {
+					this.deleteSource = v;
+				}),
+			);
+
+		const status = contentEl.createDiv({ cls: 'aar-modal-status' });
+		new Setting(contentEl)
+			.addButton((button) =>
+				button
+					.setButtonText('Process')
+					.setCta()
+					.onClick(() => {
+						void this.run(status, button);
+					}),
+			)
+			.addButton((button) =>
+				button.setButtonText('Cancel').onClick(() => this.close()),
+			);
+	}
+
+	/**
+	 * Adds a stage toggle with a parameter slider on the same row.
+	 */
+	private addStageWithSlider(
+		container: HTMLElement,
+		name: string,
+		desc: string,
+		enabled: boolean,
+		onToggle: (value: boolean) => void,
+		slider: {
+			min: number;
+			max: number;
+			step: number;
+			value: number;
+			onChange: (value: number) => void;
+		},
+	): void {
+		new Setting(container)
+			.setName(name)
+			.setDesc(desc)
+			.addSlider((s) =>
+				s
+					.setLimits(slider.min, slider.max, slider.step)
+					.setValue(slider.value)
+					.setDynamicTooltip()
+					.onChange(slider.onChange),
+			)
+			.addToggle((toggle) => toggle.setValue(enabled).onChange(onToggle));
+	}
+
+	/**
+	 * Runs the processing pipeline and writes the cleaned file.
+	 */
+	private async run(
+		status: HTMLElement,
+		button: ButtonComponent,
+	): Promise<void> {
+		if (this.processing) {
+			return;
+		}
+		if (!hasActiveStage(this.config)) {
+			new Notice('Enable at least one processing stage.');
+			return;
+		}
+		this.processing = true;
+		button.setDisabled(true);
+		status.setText('Processing...');
+		// Yield once so the "Processing..." label paints before the
+		// synchronous decode/gate work briefly occupies the main thread.
+		await new Promise<void>((resolve) => window.setTimeout(resolve, 0));
+		try {
+			const service = new AudioProcessingService(this.app);
+			const outputPath = await service.process(this.file, this.config);
+			if (this.deleteSource) {
+				try {
+					await this.app.fileManager.trashFile(this.file);
+				} catch (deleteError) {
+					console.warn(
+						`${PLUGIN_LOG_PREFIX} Failed to delete source after processing:`,
+						deleteError,
+					);
+					new Notice(
+						`Processed audio saved to ${outputPath}, but the source could not be deleted.`,
+					);
+					this.close();
+					return;
+				}
+			}
+			new Notice(`Processed audio saved to ${outputPath}`);
+			this.close();
+		} catch (error) {
+			const message =
+				error instanceof Error ? error.message : String(error);
+			new Notice(`Audio processing failed: ${message}`);
+			status.setText(`Failed: ${message}`);
+		} finally {
+			this.processing = false;
+			button.setDisabled(false);
+		}
+	}
+
+	onClose(): void {
+		this.contentEl.empty();
+	}
+}

--- a/src/cleanup/AudioProcessingService.ts
+++ b/src/cleanup/AudioProcessingService.ts
@@ -10,6 +10,7 @@ import type { App, TFile } from 'obsidian';
 import {
 	MAX_AUDIO_CLEANUP_BYTES,
 	MAX_AUDIO_CLEANUP_SECONDS,
+	MAX_AUDIO_CLEANUP_DECODED_SAMPLES,
 } from '../constants';
 import { createWavHeader, WAV_HEADER_SIZE } from '../recording/WavEncoder';
 import { resolveUniquePathInDirectory } from '../recording/RecordingFileManager';
@@ -39,6 +40,17 @@ export function encodeWavInterleaved(
 ): ArrayBuffer {
 	const numChannels = Math.max(1, channels.length);
 	const numFrames = channels[0]?.length ?? 0;
+	// The interleave loop indexes every channel up to numFrames (taken
+	// from channel 0). Enforce the equal-length invariant the JSDoc
+	// promises, so a mismatched channel fails loudly instead of writing
+	// NaN (-> silent 0) samples for the missing tail.
+	for (let channel = 1; channel < channels.length; channel++) {
+		if (channels[channel].length !== numFrames) {
+			throw new Error(
+				'Cannot encode WAV: all channels must have the same length.',
+			);
+		}
+	}
 	const pcmByteLength = numFrames * numChannels * 2;
 	const header = createWavHeader(numChannels, sampleRate, pcmByteLength);
 	const out = new ArrayBuffer(WAV_HEADER_SIZE + pcmByteLength);
@@ -128,6 +140,19 @@ export class AudioProcessingService {
 					)} minutes). Split it into parts first.`,
 				);
 			}
+			// Reject by decoded working set, not just encoded size: a small
+			// compressed file can decode to a multi-gigabyte buffer that the
+			// pre-decode byte guard cannot see. Checked before the Float32
+			// channels are copied out, so an oversized file fails with a
+			// clear message rather than an out-of-memory error mid-pipeline.
+			if (
+				decoded.length * decoded.numberOfChannels >
+				MAX_AUDIO_CLEANUP_DECODED_SAMPLES
+			) {
+				throw new Error(
+					'Audio file is too large to clean up here. Split it into parts first.',
+				);
+			}
 			const channels: Float32Array[] = [];
 			for (let i = 0; i < decoded.numberOfChannels; i++) {
 				channels.push(Float32Array.from(decoded.getChannelData(i)));
@@ -204,7 +229,7 @@ export class AudioProcessingService {
 	/**
 	 * Resolves a unique `<name>-processed.wav` path next to the source.
 	 */
-	private async resolveOutputPath(file: TFile): Promise<string> {
+	private resolveOutputPath(file: TFile): Promise<string> {
 		const slash = file.path.lastIndexOf('/');
 		const directory = slash >= 0 ? file.path.slice(0, slash) : '';
 		return resolveUniquePathInDirectory(

--- a/src/cleanup/AudioProcessingService.ts
+++ b/src/cleanup/AudioProcessingService.ts
@@ -1,0 +1,202 @@
+/**
+ * On-demand audio cleanup: decode an existing audio file, apply the
+ * selected DSP stages (noise gate, high-pass filter, loudness leveling)
+ * offline, and write a processed WAV copy next to the source. Invoked
+ * from the context menu — it never runs during live recording.
+ * @module cleanup/AudioProcessingService
+ */
+
+import type { App, TFile } from 'obsidian';
+import {
+	MAX_AUDIO_CLEANUP_BYTES,
+	MAX_AUDIO_CLEANUP_SECONDS,
+} from '../constants';
+import { createWavHeader, WAV_HEADER_SIZE } from '../recording/WavEncoder';
+import { resolveUniquePathInDirectory } from '../recording/RecordingFileManager';
+import {
+	applyNoiseGateToChannel,
+	dbToGain,
+	type AudioDspConfig,
+} from './audioDsp';
+
+/** Loudness-leveling compressor curve, fixed and tuned for speech. */
+const LEVELING_COMPRESSOR_THRESHOLD_DB = -24;
+const LEVELING_COMPRESSOR_KNEE_DB = 30;
+const LEVELING_COMPRESSOR_RATIO = 12;
+const LEVELING_COMPRESSOR_ATTACK_S = 0.003;
+const LEVELING_COMPRESSOR_RELEASE_S = 0.25;
+
+/**
+ * Encodes per-channel Float32 samples (range -1..1) into an interleaved
+ * 16-bit PCM WAV file.
+ * @param channels - Per-channel sample data (all the same length)
+ * @param sampleRate - Sample rate in Hz
+ * @returns WAV-encoded bytes
+ */
+export function encodeWavInterleaved(
+	channels: Float32Array[],
+	sampleRate: number,
+): ArrayBuffer {
+	const numChannels = Math.max(1, channels.length);
+	const numFrames = channels[0]?.length ?? 0;
+	const pcmByteLength = numFrames * numChannels * 2;
+	const header = createWavHeader(numChannels, sampleRate, pcmByteLength);
+	const out = new ArrayBuffer(WAV_HEADER_SIZE + pcmByteLength);
+	new Uint8Array(out).set(new Uint8Array(header), 0);
+	const view = new DataView(out, WAV_HEADER_SIZE);
+	let offset = 0;
+	for (let frame = 0; frame < numFrames; frame++) {
+		for (let channel = 0; channel < numChannels; channel++) {
+			const sample = channels[channel][frame];
+			const clamped = Math.max(-1, Math.min(1, sample));
+			view.setInt16(offset, Math.round(clamped * 0x7fff), true);
+			offset += 2;
+		}
+	}
+	return out;
+}
+
+/**
+ * Runs the offline audio-cleanup pipeline.
+ */
+export class AudioProcessingService {
+	constructor(private readonly app: App) {}
+
+	/**
+	 * Processes an audio file and writes a cleaned WAV copy.
+	 * @param file - Source audio file
+	 * @param config - Stages to apply
+	 * @returns Vault path of the written file
+	 */
+	async process(file: TFile, config: AudioDspConfig): Promise<string> {
+		if (file.stat.size > MAX_AUDIO_CLEANUP_BYTES) {
+			throw new Error(
+				'Audio file is too large to clean up here. Split it into parts first.',
+			);
+		}
+		const data = await this.app.vault.readBinary(file);
+		const decoded = await this.decodeChannels(data);
+		const sampleRate = decoded.sampleRate;
+		let samples = decoded.data;
+
+		if (config.gate.enabled) {
+			samples = samples.map((channel) =>
+				applyNoiseGateToChannel(
+					channel,
+					sampleRate,
+					config.gate.thresholdDb,
+				),
+			);
+		}
+		if (config.highPass.enabled || config.leveling.enabled) {
+			samples = await this.renderOffline(samples, sampleRate, config);
+		}
+
+		const wav = encodeWavInterleaved(samples, sampleRate);
+		const outputPath = await this.resolveOutputPath(file);
+		await this.app.vault.createBinary(outputPath, wav);
+		return outputPath;
+	}
+
+	/**
+	 * Decodes encoded audio into per-channel Float32 sample arrays.
+	 */
+	private async decodeChannels(
+		data: ArrayBuffer,
+	): Promise<{ sampleRate: number; data: Float32Array[] }> {
+		const context = new AudioContext();
+		try {
+			const decoded = await context.decodeAudioData(data.slice(0));
+			if (decoded.duration > MAX_AUDIO_CLEANUP_SECONDS) {
+				throw new Error(
+					`Audio is too long to clean up here (limit ${String(
+						Math.round(MAX_AUDIO_CLEANUP_SECONDS / 60),
+					)} minutes). Split it into parts first.`,
+				);
+			}
+			const channels: Float32Array[] = [];
+			for (let i = 0; i < decoded.numberOfChannels; i++) {
+				channels.push(Float32Array.from(decoded.getChannelData(i)));
+			}
+			if (channels.length === 0 || channels[0].length === 0) {
+				throw new Error('The file contains no decodable audio data.');
+			}
+			return { sampleRate: decoded.sampleRate, data: channels };
+		} finally {
+			void context.close().catch(() => {
+				// Closing a context that already failed is non-fatal
+			});
+		}
+	}
+
+	/**
+	 * Renders the high-pass and leveling stages through an
+	 * OfflineAudioContext and returns the processed channels.
+	 */
+	private async renderOffline(
+		channels: Float32Array[],
+		sampleRate: number,
+		config: AudioDspConfig,
+	): Promise<Float32Array[]> {
+		const numChannels = Math.max(1, channels.length);
+		const length = channels[0]?.length ?? 0;
+		if (length === 0) {
+			return channels;
+		}
+		const offline = new OfflineAudioContext(
+			numChannels,
+			length,
+			sampleRate,
+		);
+		const buffer = offline.createBuffer(numChannels, length, sampleRate);
+		for (let i = 0; i < numChannels; i++) {
+			buffer.getChannelData(i).set(channels[i]);
+		}
+		const source = offline.createBufferSource();
+		source.buffer = buffer;
+		let node: AudioNode = source;
+
+		if (config.highPass.enabled) {
+			const filter = offline.createBiquadFilter();
+			filter.type = 'highpass';
+			filter.frequency.value = config.highPass.hz;
+			node.connect(filter);
+			node = filter;
+		}
+		if (config.leveling.enabled) {
+			const compressor = offline.createDynamicsCompressor();
+			compressor.threshold.value = LEVELING_COMPRESSOR_THRESHOLD_DB;
+			compressor.knee.value = LEVELING_COMPRESSOR_KNEE_DB;
+			compressor.ratio.value = LEVELING_COMPRESSOR_RATIO;
+			compressor.attack.value = LEVELING_COMPRESSOR_ATTACK_S;
+			compressor.release.value = LEVELING_COMPRESSOR_RELEASE_S;
+			node.connect(compressor);
+			const makeup = offline.createGain();
+			makeup.gain.value = dbToGain(config.leveling.makeupDb);
+			compressor.connect(makeup);
+			node = makeup;
+		}
+		node.connect(offline.destination);
+		source.start();
+
+		const rendered = await offline.startRendering();
+		const result: Float32Array[] = [];
+		for (let i = 0; i < rendered.numberOfChannels; i++) {
+			result.push(Float32Array.from(rendered.getChannelData(i)));
+		}
+		return result;
+	}
+
+	/**
+	 * Resolves a unique `<name>-processed.wav` path next to the source.
+	 */
+	private async resolveOutputPath(file: TFile): Promise<string> {
+		const slash = file.path.lastIndexOf('/');
+		const directory = slash >= 0 ? file.path.slice(0, slash) : '';
+		return resolveUniquePathInDirectory(
+			directory,
+			`${file.basename}-processed.wav`,
+			this.app,
+		);
+	}
+}

--- a/src/cleanup/AudioProcessingService.ts
+++ b/src/cleanup/AudioProcessingService.ts
@@ -49,7 +49,13 @@ export function encodeWavInterleaved(
 		for (let channel = 0; channel < numChannels; channel++) {
 			const sample = channels[channel][frame];
 			const clamped = Math.max(-1, Math.min(1, sample));
-			view.setInt16(offset, Math.round(clamped * 0x7fff), true);
+			// Match the project's int16 mapping (PcmStreamRecorder): use the
+			// full negative range (-32768) for negatives and 32767 for
+			// positives, rather than scaling both rails by 32767.
+			const pcm = Math.round(
+				clamped < 0 ? clamped * 0x8000 : clamped * 0x7fff,
+			);
+			view.setInt16(offset, pcm, true);
 			offset += 2;
 		}
 	}
@@ -79,6 +85,11 @@ export class AudioProcessingService {
 		const sampleRate = decoded.sampleRate;
 		let samples = decoded.data;
 
+		// The gate runs first, on the decoded signal, so the whole pipeline
+		// is a single main-thread pass before the offline render. This keeps
+		// it to one OfflineAudioContext (peak memory) at the cost of the gate
+		// detecting on un-high-passed audio; if a future change needs the
+		// high-pass to precede the gate, split the offline render in two.
 		if (config.gate.enabled) {
 			samples = samples.map((channel) =>
 				applyNoiseGateToChannel(
@@ -106,7 +117,10 @@ export class AudioProcessingService {
 	): Promise<{ sampleRate: number; data: Float32Array[] }> {
 		const context = new AudioContext();
 		try {
-			const decoded = await context.decodeAudioData(data.slice(0));
+			// decodeAudioData detaches its input buffer; that is fine here
+			// because `data` is not reused after this call, and avoiding a
+			// defensive copy halves peak memory for near-cap files.
+			const decoded = await context.decodeAudioData(data);
 			if (decoded.duration > MAX_AUDIO_CLEANUP_SECONDS) {
 				throw new Error(
 					`Audio is too long to clean up here (limit ${String(

--- a/src/cleanup/audioDsp.ts
+++ b/src/cleanup/audioDsp.ts
@@ -7,15 +7,15 @@
  */
 
 import {
-	DEFAULT_INPUT_GATE_THRESHOLD_DB,
-	DEFAULT_INPUT_HIGHPASS_HZ,
-	DEFAULT_INPUT_LEVELING_MAKEUP_DB,
-	MAX_INPUT_GATE_THRESHOLD_DB,
-	MAX_INPUT_HIGHPASS_HZ,
-	MAX_INPUT_LEVELING_MAKEUP_DB,
-	MIN_INPUT_GATE_THRESHOLD_DB,
-	MIN_INPUT_HIGHPASS_HZ,
-	MIN_INPUT_LEVELING_MAKEUP_DB,
+	DEFAULT_CLEANUP_GATE_THRESHOLD_DB,
+	DEFAULT_CLEANUP_HIGHPASS_HZ,
+	DEFAULT_CLEANUP_LEVELING_MAKEUP_DB,
+	MAX_CLEANUP_GATE_THRESHOLD_DB,
+	MAX_CLEANUP_HIGHPASS_HZ,
+	MAX_CLEANUP_LEVELING_MAKEUP_DB,
+	MIN_CLEANUP_GATE_THRESHOLD_DB,
+	MIN_CLEANUP_HIGHPASS_HZ,
+	MIN_CLEANUP_LEVELING_MAKEUP_DB,
 } from '../constants';
 import type { AudioRecorderSettings } from '../settings/Settings';
 
@@ -50,30 +50,30 @@ export function resolveAudioDspConfig(
 ): AudioDspConfig {
 	return {
 		highPass: {
-			enabled: settings.inputHighPassEnabled,
+			enabled: settings.cleanupHighPassEnabled,
 			hz: clamp(
-				settings.inputHighPassHz,
-				MIN_INPUT_HIGHPASS_HZ,
-				MAX_INPUT_HIGHPASS_HZ,
-				DEFAULT_INPUT_HIGHPASS_HZ,
+				settings.cleanupHighPassHz,
+				MIN_CLEANUP_HIGHPASS_HZ,
+				MAX_CLEANUP_HIGHPASS_HZ,
+				DEFAULT_CLEANUP_HIGHPASS_HZ,
 			),
 		},
 		gate: {
-			enabled: settings.inputNoiseGateEnabled,
+			enabled: settings.cleanupNoiseGateEnabled,
 			thresholdDb: clamp(
-				settings.inputNoiseGateThresholdDb,
-				MIN_INPUT_GATE_THRESHOLD_DB,
-				MAX_INPUT_GATE_THRESHOLD_DB,
-				DEFAULT_INPUT_GATE_THRESHOLD_DB,
+				settings.cleanupNoiseGateThresholdDb,
+				MIN_CLEANUP_GATE_THRESHOLD_DB,
+				MAX_CLEANUP_GATE_THRESHOLD_DB,
+				DEFAULT_CLEANUP_GATE_THRESHOLD_DB,
 			),
 		},
 		leveling: {
-			enabled: settings.inputLevelingEnabled,
+			enabled: settings.cleanupLevelingEnabled,
 			makeupDb: clamp(
-				settings.inputLevelingMakeupDb,
-				MIN_INPUT_LEVELING_MAKEUP_DB,
-				MAX_INPUT_LEVELING_MAKEUP_DB,
-				DEFAULT_INPUT_LEVELING_MAKEUP_DB,
+				settings.cleanupLevelingMakeupDb,
+				MIN_CLEANUP_LEVELING_MAKEUP_DB,
+				MAX_CLEANUP_LEVELING_MAKEUP_DB,
+				DEFAULT_CLEANUP_LEVELING_MAKEUP_DB,
 			),
 		},
 	};

--- a/src/cleanup/audioDsp.ts
+++ b/src/cleanup/audioDsp.ts
@@ -1,0 +1,188 @@
+/**
+ * Pure DSP helpers for on-demand audio cleanup: config resolution and
+ * clamping, dB↔gain, the noise-gate open/close decision (with
+ * hysteresis), and an offline envelope-based noise gate over decoded
+ * samples. No WebAudio or I/O — all logic here is unit tested.
+ * @module cleanup/audioDsp
+ */
+
+import {
+	DEFAULT_INPUT_GATE_THRESHOLD_DB,
+	DEFAULT_INPUT_HIGHPASS_HZ,
+	DEFAULT_INPUT_LEVELING_MAKEUP_DB,
+	MAX_INPUT_GATE_THRESHOLD_DB,
+	MAX_INPUT_HIGHPASS_HZ,
+	MAX_INPUT_LEVELING_MAKEUP_DB,
+	MIN_INPUT_GATE_THRESHOLD_DB,
+	MIN_INPUT_HIGHPASS_HZ,
+	MIN_INPUT_LEVELING_MAKEUP_DB,
+} from '../constants';
+import type { AudioRecorderSettings } from '../settings/Settings';
+
+/** Resolved, clamped audio-cleanup configuration. */
+export interface AudioDspConfig {
+	highPass: { enabled: boolean; hz: number };
+	gate: { enabled: boolean; thresholdDb: number };
+	leveling: { enabled: boolean; makeupDb: number };
+}
+
+/** Clamps a value into a range, falling back when non-finite. */
+function clamp(
+	value: number,
+	min: number,
+	max: number,
+	fallback: number,
+): number {
+	if (!Number.isFinite(value)) {
+		return fallback;
+	}
+	return Math.min(max, Math.max(min, value));
+}
+
+/**
+ * Resolves the cleanup configuration from settings, clamping every
+ * numeric field into its supported range. Used as the default config the
+ * processing dialog starts from.
+ * @param settings - Plugin settings
+ */
+export function resolveAudioDspConfig(
+	settings: AudioRecorderSettings,
+): AudioDspConfig {
+	return {
+		highPass: {
+			enabled: settings.inputHighPassEnabled,
+			hz: clamp(
+				settings.inputHighPassHz,
+				MIN_INPUT_HIGHPASS_HZ,
+				MAX_INPUT_HIGHPASS_HZ,
+				DEFAULT_INPUT_HIGHPASS_HZ,
+			),
+		},
+		gate: {
+			enabled: settings.inputNoiseGateEnabled,
+			thresholdDb: clamp(
+				settings.inputNoiseGateThresholdDb,
+				MIN_INPUT_GATE_THRESHOLD_DB,
+				MAX_INPUT_GATE_THRESHOLD_DB,
+				DEFAULT_INPUT_GATE_THRESHOLD_DB,
+			),
+		},
+		leveling: {
+			enabled: settings.inputLevelingEnabled,
+			makeupDb: clamp(
+				settings.inputLevelingMakeupDb,
+				MIN_INPUT_LEVELING_MAKEUP_DB,
+				MAX_INPUT_LEVELING_MAKEUP_DB,
+				DEFAULT_INPUT_LEVELING_MAKEUP_DB,
+			),
+		},
+	};
+}
+
+/**
+ * True when at least one stage is enabled (processing would change the
+ * audio).
+ * @param config - Resolved config
+ */
+export function hasActiveStage(config: AudioDspConfig): boolean {
+	return (
+		config.highPass.enabled ||
+		config.gate.enabled ||
+		config.leveling.enabled
+	);
+}
+
+/**
+ * Converts a dB value to a linear gain multiplier.
+ * @param db - Level in decibels
+ */
+export function dbToGain(db: number): number {
+	return Math.pow(10, db / 20);
+}
+
+/**
+ * Noise-gate open/close decision with hysteresis: opens at the threshold
+ * and only closes once the level falls a hysteresis margin below it, so
+ * the gate does not chatter around the threshold.
+ * @param rmsDb - Current level in dBFS
+ * @param thresholdDb - Open threshold in dBFS
+ * @param hysteresisDb - Margin below the threshold for closing
+ * @param currentlyOpen - Whether the gate is currently open
+ */
+export function gateShouldOpen(
+	rmsDb: number,
+	thresholdDb: number,
+	hysteresisDb: number,
+	currentlyOpen: boolean,
+): boolean {
+	if (rmsDb >= thresholdDb) {
+		return true;
+	}
+	if (rmsDb <= thresholdDb - hysteresisDb) {
+		return false;
+	}
+	return currentlyOpen;
+}
+
+/** Window size, in seconds, used to track the gate envelope. */
+const GATE_WINDOW_SECONDS = 0.02;
+
+/** Hysteresis, in dB, for the offline gate. */
+const GATE_HYSTERESIS_DB = 6;
+
+/** Gate open ramp time constant in milliseconds (fast, to avoid clipping onsets). */
+const GATE_ATTACK_MS = 5;
+
+/** Gate close ramp time constant in milliseconds (slower, to avoid clicks). */
+const GATE_RELEASE_MS = 80;
+
+/**
+ * Applies an envelope-based noise gate to one channel of samples,
+ * returning a new array. The level is tracked per short window; the gain
+ * ramps toward open/closed with attack/release smoothing so gating never
+ * introduces clicks.
+ * @param samples - Channel samples in the range -1..1
+ * @param sampleRate - Sample rate in Hz
+ * @param thresholdDb - Gate threshold in dBFS
+ * @param attackMs - Open ramp time constant in milliseconds
+ * @param releaseMs - Close ramp time constant in milliseconds
+ * @returns New gated channel samples
+ */
+export function applyNoiseGateToChannel(
+	samples: Float32Array,
+	sampleRate: number,
+	thresholdDb: number,
+	attackMs = GATE_ATTACK_MS,
+	releaseMs = GATE_RELEASE_MS,
+): Float32Array {
+	const out = new Float32Array(samples.length);
+	if (samples.length === 0 || sampleRate <= 0) {
+		return out;
+	}
+	const windowSize = Math.max(
+		1,
+		Math.floor(sampleRate * GATE_WINDOW_SECONDS),
+	);
+	const attackCoef = Math.exp(-1 / (sampleRate * (attackMs / 1000)));
+	const releaseCoef = Math.exp(-1 / (sampleRate * (releaseMs / 1000)));
+	let open = true;
+	let gain = 1;
+
+	for (let start = 0; start < samples.length; start += windowSize) {
+		const end = Math.min(samples.length, start + windowSize);
+		let sumSquares = 0;
+		for (let i = start; i < end; i++) {
+			sumSquares += samples[i] * samples[i];
+		}
+		const rms = Math.sqrt(sumSquares / (end - start));
+		const rmsDb = rms > 0 ? 20 * Math.log10(rms) : -Infinity;
+		open = gateShouldOpen(rmsDb, thresholdDb, GATE_HYSTERESIS_DB, open);
+		const target = open ? 1 : 0;
+		for (let i = start; i < end; i++) {
+			const coef = target > gain ? attackCoef : releaseCoef;
+			gain = target + (gain - target) * coef;
+			out[i] = samples[i] * gain;
+		}
+	}
+	return out;
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -438,3 +438,49 @@ export const LOCAL_WHISPER_MODELS_DOC_URL =
  * so the bar never jumps backwards when post-processing starts.
  */
 export const TRANSCRIBE_CHUNK_PROGRESS_CEILING = 0.95;
+
+// ── Input DSP processing ────────────────────────────────────────────
+
+/** Default high-pass filter cutoff in Hz (removes low rumble). */
+export const DEFAULT_INPUT_HIGHPASS_HZ = 80;
+
+/** Minimum configurable high-pass cutoff in Hz. */
+export const MIN_INPUT_HIGHPASS_HZ = 20;
+
+/** Maximum configurable high-pass cutoff in Hz. */
+export const MAX_INPUT_HIGHPASS_HZ = 300;
+
+/** Default noise-gate threshold in dBFS. */
+export const DEFAULT_INPUT_GATE_THRESHOLD_DB = -50;
+
+/** Minimum configurable noise-gate threshold in dBFS. */
+export const MIN_INPUT_GATE_THRESHOLD_DB = -80;
+
+/** Maximum configurable noise-gate threshold in dBFS. */
+export const MAX_INPUT_GATE_THRESHOLD_DB = -20;
+
+/** Default makeup gain in dB applied after leveling compression. */
+export const DEFAULT_INPUT_LEVELING_MAKEUP_DB = 6;
+
+/** Minimum configurable leveling makeup gain in dB. */
+export const MIN_INPUT_LEVELING_MAKEUP_DB = 0;
+
+/** Maximum configurable leveling makeup gain in dB. */
+export const MAX_INPUT_LEVELING_MAKEUP_DB = 24;
+
+/**
+ * Upper bound, in bytes, on the encoded size of a file the on-demand
+ * audio cleanup will read and decode. Checked before decoding so a
+ * pathologically large file is rejected up front instead of allocating
+ * the whole decoded buffer (and a larger Float32 working copy) in the
+ * renderer. Mirrors the player's WAVEFORM_MAX_DECODE_BYTES ceiling.
+ */
+export const MAX_AUDIO_CLEANUP_BYTES = 1024 * 1024 * 1024;
+
+/**
+ * Upper bound, in seconds, on the duration of a file the on-demand audio
+ * cleanup will process. The noise gate and WAV encoding run as a single
+ * synchronous pass on the main thread, so a very long file would freeze
+ * the UI; above this the action asks the user to split the file first.
+ */
+export const MAX_AUDIO_CLEANUP_SECONDS = 2 * 60 * 60;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -469,6 +469,18 @@ export const MIN_CLEANUP_LEVELING_MAKEUP_DB = 0;
 export const MAX_CLEANUP_LEVELING_MAKEUP_DB = 24;
 
 /**
+ * Slider step (Hz) for the high-pass cutoff, shared by the cleanup
+ * dialog and the settings tab so the two surfaces cannot drift apart.
+ */
+export const CLEANUP_HIGHPASS_STEP_HZ = 5;
+
+/** Slider step (dBFS) for the noise-gate threshold in the cleanup UI. */
+export const CLEANUP_GATE_STEP_DB = 1;
+
+/** Slider step (dB) for the leveling makeup gain in the cleanup UI. */
+export const CLEANUP_LEVELING_STEP_DB = 1;
+
+/**
  * Upper bound, in bytes, on the encoded size of a file the on-demand
  * audio cleanup will read and decode. Checked before decoding so a
  * pathologically large file is rejected up front instead of allocating
@@ -485,3 +497,19 @@ export const MAX_AUDIO_CLEANUP_BYTES = WAVEFORM_MAX_DECODE_BYTES;
  * the UI; above this the action asks the user to split the file first.
  */
 export const MAX_AUDIO_CLEANUP_SECONDS = 2 * 60 * 60;
+
+/**
+ * Upper bound on the total decoded sample count (frames × channels) the
+ * on-demand cleanup will process. Where {@link MAX_AUDIO_CLEANUP_BYTES}
+ * bounds the on-disk size, this bounds the decoded working set: the
+ * pipeline holds several full Float32 copies of the signal at once (the
+ * gated input, the OfflineAudioContext buffer, and the rendered output),
+ * so peak memory scales with this count rather than with the encoded
+ * size. A heavily compressed file can be small on disk yet decode to a
+ * multi-gigabyte buffer the byte guard alone would not catch; at 4 bytes
+ * per sample and roughly three concurrent copies this caps the peak
+ * working set near 1.5 GB. Checked right after decoding, before the
+ * Float32 channels are materialized, so an oversized file is refused with
+ * a clear message instead of failing with an out-of-memory error.
+ */
+export const MAX_AUDIO_CLEANUP_DECODED_SAMPLES = 128 * 1024 * 1024;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -439,43 +439,44 @@ export const LOCAL_WHISPER_MODELS_DOC_URL =
  */
 export const TRANSCRIBE_CHUNK_PROGRESS_CEILING = 0.95;
 
-// ── Input DSP processing ────────────────────────────────────────────
+// Audio cleanup (on-demand DSP)
 
 /** Default high-pass filter cutoff in Hz (removes low rumble). */
-export const DEFAULT_INPUT_HIGHPASS_HZ = 80;
+export const DEFAULT_CLEANUP_HIGHPASS_HZ = 80;
 
 /** Minimum configurable high-pass cutoff in Hz. */
-export const MIN_INPUT_HIGHPASS_HZ = 20;
+export const MIN_CLEANUP_HIGHPASS_HZ = 20;
 
 /** Maximum configurable high-pass cutoff in Hz. */
-export const MAX_INPUT_HIGHPASS_HZ = 300;
+export const MAX_CLEANUP_HIGHPASS_HZ = 300;
 
 /** Default noise-gate threshold in dBFS. */
-export const DEFAULT_INPUT_GATE_THRESHOLD_DB = -50;
+export const DEFAULT_CLEANUP_GATE_THRESHOLD_DB = -50;
 
 /** Minimum configurable noise-gate threshold in dBFS. */
-export const MIN_INPUT_GATE_THRESHOLD_DB = -80;
+export const MIN_CLEANUP_GATE_THRESHOLD_DB = -80;
 
 /** Maximum configurable noise-gate threshold in dBFS. */
-export const MAX_INPUT_GATE_THRESHOLD_DB = -20;
+export const MAX_CLEANUP_GATE_THRESHOLD_DB = -20;
 
 /** Default makeup gain in dB applied after leveling compression. */
-export const DEFAULT_INPUT_LEVELING_MAKEUP_DB = 6;
+export const DEFAULT_CLEANUP_LEVELING_MAKEUP_DB = 6;
 
 /** Minimum configurable leveling makeup gain in dB. */
-export const MIN_INPUT_LEVELING_MAKEUP_DB = 0;
+export const MIN_CLEANUP_LEVELING_MAKEUP_DB = 0;
 
 /** Maximum configurable leveling makeup gain in dB. */
-export const MAX_INPUT_LEVELING_MAKEUP_DB = 24;
+export const MAX_CLEANUP_LEVELING_MAKEUP_DB = 24;
 
 /**
  * Upper bound, in bytes, on the encoded size of a file the on-demand
  * audio cleanup will read and decode. Checked before decoding so a
  * pathologically large file is rejected up front instead of allocating
  * the whole decoded buffer (and a larger Float32 working copy) in the
- * renderer. Mirrors the player's WAVEFORM_MAX_DECODE_BYTES ceiling.
+ * renderer. Bound to the player's decode ceiling so the two stay in
+ * lockstep.
  */
-export const MAX_AUDIO_CLEANUP_BYTES = 1024 * 1024 * 1024;
+export const MAX_AUDIO_CLEANUP_BYTES = WAVEFORM_MAX_DECODE_BYTES;
 
 /**
  * Upper bound, in seconds, on the duration of a file the on-demand audio

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -28,6 +28,9 @@ import {
 	DEFAULT_LLM_ANTHROPIC_MODEL,
 	DEFAULT_LLM_OLLAMA_BASE_URL,
 	DEFAULT_LLM_MAX_TOKENS,
+	DEFAULT_INPUT_HIGHPASS_HZ,
+	DEFAULT_INPUT_GATE_THRESHOLD_DB,
+	DEFAULT_INPUT_LEVELING_MAKEUP_DB,
 } from '../constants';
 import { getDefaultDeviceId } from '../utils/DeviceUtils';
 import type {
@@ -209,6 +212,18 @@ export interface AudioRecorderSettings {
 	showRecordingStats: boolean;
 	/** Show a prominent recording banner on mobile */
 	mobileRecordingBanner: boolean;
+	/** Default: enable the high-pass (low-rumble removal) stage */
+	inputHighPassEnabled: boolean;
+	/** High-pass filter cutoff in Hz */
+	inputHighPassHz: number;
+	/** Enable the noise gate */
+	inputNoiseGateEnabled: boolean;
+	/** Noise-gate threshold in dBFS */
+	inputNoiseGateThresholdDb: number;
+	/** Enable loudness leveling (compression) */
+	inputLevelingEnabled: boolean;
+	/** Makeup gain in dB applied after leveling */
+	inputLevelingMakeupDb: number;
 }
 
 /** Transcription engine identifier, derived from {@link TRANSCRIPTION_PROVIDER_IDS}. */
@@ -379,6 +394,12 @@ export const DEFAULT_SETTINGS: AudioRecorderSettings = {
 	showInputLevelMeter: true,
 	showRecordingStats: true,
 	mobileRecordingBanner: true,
+	inputHighPassEnabled: true,
+	inputHighPassHz: DEFAULT_INPUT_HIGHPASS_HZ,
+	inputNoiseGateEnabled: false,
+	inputNoiseGateThresholdDb: DEFAULT_INPUT_GATE_THRESHOLD_DB,
+	inputLevelingEnabled: false,
+	inputLevelingMakeupDb: DEFAULT_INPUT_LEVELING_MAKEUP_DB,
 };
 
 /**

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -28,9 +28,9 @@ import {
 	DEFAULT_LLM_ANTHROPIC_MODEL,
 	DEFAULT_LLM_OLLAMA_BASE_URL,
 	DEFAULT_LLM_MAX_TOKENS,
-	DEFAULT_INPUT_HIGHPASS_HZ,
-	DEFAULT_INPUT_GATE_THRESHOLD_DB,
-	DEFAULT_INPUT_LEVELING_MAKEUP_DB,
+	DEFAULT_CLEANUP_HIGHPASS_HZ,
+	DEFAULT_CLEANUP_GATE_THRESHOLD_DB,
+	DEFAULT_CLEANUP_LEVELING_MAKEUP_DB,
 } from '../constants';
 import { getDefaultDeviceId } from '../utils/DeviceUtils';
 import type {
@@ -213,17 +213,17 @@ export interface AudioRecorderSettings {
 	/** Show a prominent recording banner on mobile */
 	mobileRecordingBanner: boolean;
 	/** Default: enable the high-pass (low-rumble removal) stage */
-	inputHighPassEnabled: boolean;
+	cleanupHighPassEnabled: boolean;
 	/** High-pass filter cutoff in Hz */
-	inputHighPassHz: number;
+	cleanupHighPassHz: number;
 	/** Enable the noise gate */
-	inputNoiseGateEnabled: boolean;
+	cleanupNoiseGateEnabled: boolean;
 	/** Noise-gate threshold in dBFS */
-	inputNoiseGateThresholdDb: number;
+	cleanupNoiseGateThresholdDb: number;
 	/** Enable loudness leveling (compression) */
-	inputLevelingEnabled: boolean;
+	cleanupLevelingEnabled: boolean;
 	/** Makeup gain in dB applied after leveling */
-	inputLevelingMakeupDb: number;
+	cleanupLevelingMakeupDb: number;
 }
 
 /** Transcription engine identifier, derived from {@link TRANSCRIPTION_PROVIDER_IDS}. */
@@ -394,12 +394,12 @@ export const DEFAULT_SETTINGS: AudioRecorderSettings = {
 	showInputLevelMeter: true,
 	showRecordingStats: true,
 	mobileRecordingBanner: true,
-	inputHighPassEnabled: true,
-	inputHighPassHz: DEFAULT_INPUT_HIGHPASS_HZ,
-	inputNoiseGateEnabled: false,
-	inputNoiseGateThresholdDb: DEFAULT_INPUT_GATE_THRESHOLD_DB,
-	inputLevelingEnabled: false,
-	inputLevelingMakeupDb: DEFAULT_INPUT_LEVELING_MAKEUP_DB,
+	cleanupHighPassEnabled: true,
+	cleanupHighPassHz: DEFAULT_CLEANUP_HIGHPASS_HZ,
+	cleanupNoiseGateEnabled: false,
+	cleanupNoiseGateThresholdDb: DEFAULT_CLEANUP_GATE_THRESHOLD_DB,
+	cleanupLevelingEnabled: false,
+	cleanupLevelingMakeupDb: DEFAULT_CLEANUP_LEVELING_MAKEUP_DB,
 };
 
 /**

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -39,6 +39,9 @@ import {
 	MAX_CLEANUP_GATE_THRESHOLD_DB,
 	MIN_CLEANUP_LEVELING_MAKEUP_DB,
 	MAX_CLEANUP_LEVELING_MAKEUP_DB,
+	CLEANUP_HIGHPASS_STEP_HZ,
+	CLEANUP_GATE_STEP_DB,
+	CLEANUP_LEVELING_STEP_DB,
 } from '../constants';
 import { SystemDiagnostics } from '../diagnostics/SystemDiagnostics';
 import { SystemInfoModal } from '../diagnostics/SystemInfoModal';
@@ -764,7 +767,7 @@ export class AudioRecorderSettingTab extends PluginSettingTab {
 					.setLimits(
 						MIN_CLEANUP_HIGHPASS_HZ,
 						MAX_CLEANUP_HIGHPASS_HZ,
-						5,
+						CLEANUP_HIGHPASS_STEP_HZ,
 					)
 					.setValue(s.cleanupHighPassHz)
 					.setDynamicTooltip()
@@ -792,7 +795,7 @@ export class AudioRecorderSettingTab extends PluginSettingTab {
 					.setLimits(
 						MIN_CLEANUP_GATE_THRESHOLD_DB,
 						MAX_CLEANUP_GATE_THRESHOLD_DB,
-						1,
+						CLEANUP_GATE_STEP_DB,
 					)
 					.setValue(s.cleanupNoiseGateThresholdDb)
 					.setDynamicTooltip()
@@ -820,7 +823,7 @@ export class AudioRecorderSettingTab extends PluginSettingTab {
 					.setLimits(
 						MIN_CLEANUP_LEVELING_MAKEUP_DB,
 						MAX_CLEANUP_LEVELING_MAKEUP_DB,
-						1,
+						CLEANUP_LEVELING_STEP_DB,
 					)
 					.setValue(s.cleanupLevelingMakeupDb)
 					.setDynamicTooltip()

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -33,6 +33,12 @@ import {
 	MIN_SPLIT_CHUNK_MINUTES,
 	MAX_SPLIT_CHUNK_MINUTES,
 	SPLIT_PART_SUFFIX_PATTERN,
+	MIN_INPUT_HIGHPASS_HZ,
+	MAX_INPUT_HIGHPASS_HZ,
+	MIN_INPUT_GATE_THRESHOLD_DB,
+	MAX_INPUT_GATE_THRESHOLD_DB,
+	MIN_INPUT_LEVELING_MAKEUP_DB,
+	MAX_INPUT_LEVELING_MAKEUP_DB,
 } from '../constants';
 import { SystemDiagnostics } from '../diagnostics/SystemDiagnostics';
 import { SystemInfoModal } from '../diagnostics/SystemInfoModal';
@@ -728,6 +734,96 @@ export class AudioRecorderSettingTab extends PluginSettingTab {
 			.addToggle((toggle) =>
 				toggle.setValue(s.mobileRecordingBanner).onChange(async (v) => {
 					s.mobileRecordingBanner = v;
+					await this.plugin.saveSettings();
+				}),
+			);
+
+		this.renderInputDspSettings(containerEl);
+	}
+
+	/**
+	 * Renders the default settings for the on-demand "Clean up audio"
+	 * dialog (high-pass, noise gate, loudness leveling). These prefill the
+	 * dialog opened from the context menu; each run can override them.
+	 * @param containerEl - The settings container element
+	 */
+	private renderInputDspSettings(containerEl: HTMLElement): void {
+		const s = this.plugin.settings;
+		new Setting(containerEl)
+			.setName('Audio cleanup defaults')
+			.setDesc(
+				'Defaults for the cleanup action in the file/embed context menu. Cleanup runs on demand and writes a processed copy; it does not change live recording.',
+			)
+			.setHeading();
+
+		new Setting(containerEl)
+			.setName('High-pass filter')
+			.setDesc('Remove low-frequency rumble below the cutoff by default.')
+			.addSlider((slider) =>
+				slider
+					.setLimits(MIN_INPUT_HIGHPASS_HZ, MAX_INPUT_HIGHPASS_HZ, 5)
+					.setValue(s.inputHighPassHz)
+					.setDynamicTooltip()
+					.onChange(async (v) => {
+						s.inputHighPassHz = v;
+						await this.plugin.saveSettings();
+					}),
+			)
+			.addToggle((toggle) =>
+				toggle.setValue(s.inputHighPassEnabled).onChange(async (v) => {
+					s.inputHighPassEnabled = v;
+					await this.plugin.saveSettings();
+				}),
+			);
+
+		new Setting(containerEl)
+			.setName('Noise gate')
+			.setDesc(
+				'Silence the signal below the threshold (dBFS) by default.',
+			)
+			.addSlider((slider) =>
+				slider
+					.setLimits(
+						MIN_INPUT_GATE_THRESHOLD_DB,
+						MAX_INPUT_GATE_THRESHOLD_DB,
+						1,
+					)
+					.setValue(s.inputNoiseGateThresholdDb)
+					.setDynamicTooltip()
+					.onChange(async (v) => {
+						s.inputNoiseGateThresholdDb = v;
+						await this.plugin.saveSettings();
+					}),
+			)
+			.addToggle((toggle) =>
+				toggle.setValue(s.inputNoiseGateEnabled).onChange(async (v) => {
+					s.inputNoiseGateEnabled = v;
+					await this.plugin.saveSettings();
+				}),
+			);
+
+		new Setting(containerEl)
+			.setName('Loudness leveling')
+			.setDesc(
+				'Even out quiet and loud passages (compressor); makeup gain (dB).',
+			)
+			.addSlider((slider) =>
+				slider
+					.setLimits(
+						MIN_INPUT_LEVELING_MAKEUP_DB,
+						MAX_INPUT_LEVELING_MAKEUP_DB,
+						1,
+					)
+					.setValue(s.inputLevelingMakeupDb)
+					.setDynamicTooltip()
+					.onChange(async (v) => {
+						s.inputLevelingMakeupDb = v;
+						await this.plugin.saveSettings();
+					}),
+			)
+			.addToggle((toggle) =>
+				toggle.setValue(s.inputLevelingEnabled).onChange(async (v) => {
+					s.inputLevelingEnabled = v;
 					await this.plugin.saveSettings();
 				}),
 			);

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -33,12 +33,12 @@ import {
 	MIN_SPLIT_CHUNK_MINUTES,
 	MAX_SPLIT_CHUNK_MINUTES,
 	SPLIT_PART_SUFFIX_PATTERN,
-	MIN_INPUT_HIGHPASS_HZ,
-	MAX_INPUT_HIGHPASS_HZ,
-	MIN_INPUT_GATE_THRESHOLD_DB,
-	MAX_INPUT_GATE_THRESHOLD_DB,
-	MIN_INPUT_LEVELING_MAKEUP_DB,
-	MAX_INPUT_LEVELING_MAKEUP_DB,
+	MIN_CLEANUP_HIGHPASS_HZ,
+	MAX_CLEANUP_HIGHPASS_HZ,
+	MIN_CLEANUP_GATE_THRESHOLD_DB,
+	MAX_CLEANUP_GATE_THRESHOLD_DB,
+	MIN_CLEANUP_LEVELING_MAKEUP_DB,
+	MAX_CLEANUP_LEVELING_MAKEUP_DB,
 } from '../constants';
 import { SystemDiagnostics } from '../diagnostics/SystemDiagnostics';
 import { SystemInfoModal } from '../diagnostics/SystemInfoModal';
@@ -738,7 +738,7 @@ export class AudioRecorderSettingTab extends PluginSettingTab {
 				}),
 			);
 
-		this.renderInputDspSettings(containerEl);
+		this.renderAudioCleanupSettings(containerEl);
 	}
 
 	/**
@@ -747,7 +747,7 @@ export class AudioRecorderSettingTab extends PluginSettingTab {
 	 * dialog opened from the context menu; each run can override them.
 	 * @param containerEl - The settings container element
 	 */
-	private renderInputDspSettings(containerEl: HTMLElement): void {
+	private renderAudioCleanupSettings(containerEl: HTMLElement): void {
 		const s = this.plugin.settings;
 		new Setting(containerEl)
 			.setName('Audio cleanup defaults')
@@ -761,19 +761,25 @@ export class AudioRecorderSettingTab extends PluginSettingTab {
 			.setDesc('Remove low-frequency rumble below the cutoff by default.')
 			.addSlider((slider) =>
 				slider
-					.setLimits(MIN_INPUT_HIGHPASS_HZ, MAX_INPUT_HIGHPASS_HZ, 5)
-					.setValue(s.inputHighPassHz)
+					.setLimits(
+						MIN_CLEANUP_HIGHPASS_HZ,
+						MAX_CLEANUP_HIGHPASS_HZ,
+						5,
+					)
+					.setValue(s.cleanupHighPassHz)
 					.setDynamicTooltip()
 					.onChange(async (v) => {
-						s.inputHighPassHz = v;
+						s.cleanupHighPassHz = v;
 						await this.plugin.saveSettings();
 					}),
 			)
 			.addToggle((toggle) =>
-				toggle.setValue(s.inputHighPassEnabled).onChange(async (v) => {
-					s.inputHighPassEnabled = v;
-					await this.plugin.saveSettings();
-				}),
+				toggle
+					.setValue(s.cleanupHighPassEnabled)
+					.onChange(async (v) => {
+						s.cleanupHighPassEnabled = v;
+						await this.plugin.saveSettings();
+					}),
 			);
 
 		new Setting(containerEl)
@@ -784,22 +790,24 @@ export class AudioRecorderSettingTab extends PluginSettingTab {
 			.addSlider((slider) =>
 				slider
 					.setLimits(
-						MIN_INPUT_GATE_THRESHOLD_DB,
-						MAX_INPUT_GATE_THRESHOLD_DB,
+						MIN_CLEANUP_GATE_THRESHOLD_DB,
+						MAX_CLEANUP_GATE_THRESHOLD_DB,
 						1,
 					)
-					.setValue(s.inputNoiseGateThresholdDb)
+					.setValue(s.cleanupNoiseGateThresholdDb)
 					.setDynamicTooltip()
 					.onChange(async (v) => {
-						s.inputNoiseGateThresholdDb = v;
+						s.cleanupNoiseGateThresholdDb = v;
 						await this.plugin.saveSettings();
 					}),
 			)
 			.addToggle((toggle) =>
-				toggle.setValue(s.inputNoiseGateEnabled).onChange(async (v) => {
-					s.inputNoiseGateEnabled = v;
-					await this.plugin.saveSettings();
-				}),
+				toggle
+					.setValue(s.cleanupNoiseGateEnabled)
+					.onChange(async (v) => {
+						s.cleanupNoiseGateEnabled = v;
+						await this.plugin.saveSettings();
+					}),
 			);
 
 		new Setting(containerEl)
@@ -810,22 +818,24 @@ export class AudioRecorderSettingTab extends PluginSettingTab {
 			.addSlider((slider) =>
 				slider
 					.setLimits(
-						MIN_INPUT_LEVELING_MAKEUP_DB,
-						MAX_INPUT_LEVELING_MAKEUP_DB,
+						MIN_CLEANUP_LEVELING_MAKEUP_DB,
+						MAX_CLEANUP_LEVELING_MAKEUP_DB,
 						1,
 					)
-					.setValue(s.inputLevelingMakeupDb)
+					.setValue(s.cleanupLevelingMakeupDb)
 					.setDynamicTooltip()
 					.onChange(async (v) => {
-						s.inputLevelingMakeupDb = v;
+						s.cleanupLevelingMakeupDb = v;
 						await this.plugin.saveSettings();
 					}),
 			)
 			.addToggle((toggle) =>
-				toggle.setValue(s.inputLevelingEnabled).onChange(async (v) => {
-					s.inputLevelingEnabled = v;
-					await this.plugin.saveSettings();
-				}),
+				toggle
+					.setValue(s.cleanupLevelingEnabled)
+					.onChange(async (v) => {
+						s.cleanupLevelingEnabled = v;
+						await this.plugin.saveSettings();
+					}),
 			);
 	}
 

--- a/src/ui/ContextMenu.ts
+++ b/src/ui/ContextMenu.ts
@@ -52,7 +52,7 @@ export class ContextMenu {
 	/** Tracks menus that already have the "Transcribe audio" item to prevent duplicates. */
 	private readonly menusWithTranscribeItem = new WeakSet<Menu>();
 	/** Tracks menus that already have the "Clean up audio" item to prevent duplicates. */
-	private readonly menusWithProcessItem = new WeakSet<Menu>();
+	private readonly menusWithCleanupItem = new WeakSet<Menu>();
 
 	/**
 	 * Creates a new ContextMenu instance.
@@ -248,7 +248,7 @@ export class ContextMenu {
 						this.addAudioFileInfoMenuItem(menu, file);
 						this.addConvertMenuItem(menu, file);
 						this.addSplitMenuItem(menu, file);
-						this.addProcessMenuItem(menu, file);
+						this.addCleanupMenuItem(menu, file);
 						this.addTranscribeMenuItem(menu, file);
 						this.addDeleteRecordingMenuItem(menu, file);
 					}
@@ -307,7 +307,7 @@ export class ContextMenu {
 		this.addAudioFileInfoMenuItem(menu, file);
 		this.addConvertMenuItem(menu, file);
 		this.addSplitMenuItem(menu, file);
-		this.addProcessMenuItem(menu, file);
+		this.addCleanupMenuItem(menu, file);
 		this.addTranscribeMenuItem(menu, file);
 		this.addDeleteRecordingAndLinkMenuItem(
 			menu,
@@ -324,11 +324,11 @@ export class ContextMenu {
 	 * @param menu - The menu to add the item to.
 	 * @param file - The audio file.
 	 */
-	private addProcessMenuItem(menu: Menu, file: TFile): void {
-		if (this.menusWithProcessItem.has(menu)) {
+	private addCleanupMenuItem(menu: Menu, file: TFile): void {
+		if (this.menusWithCleanupItem.has(menu)) {
 			return;
 		}
-		this.menusWithProcessItem.add(menu);
+		this.menusWithCleanupItem.add(menu);
 
 		menu.addItem((item: MenuItem) => {
 			item.setTitle('Clean up audio')

--- a/src/ui/ContextMenu.ts
+++ b/src/ui/ContextMenu.ts
@@ -24,6 +24,7 @@ import { ConversionModal } from './ConversionModal';
 import { SplitModal } from './SplitModal';
 import { TranscriptionModal } from './TranscriptionModal';
 import type { TranscriptionModalOptions } from './TranscriptionModal';
+import { AudioProcessingModal } from '../cleanup/AudioProcessingModal';
 import type { AudioRecorderSettings } from '../settings/Settings';
 
 /** CodeMirror view attached to Editor (internal Obsidian API). */
@@ -50,6 +51,8 @@ export class ContextMenu {
 	private readonly menusWithSplitItem = new WeakSet<Menu>();
 	/** Tracks menus that already have the "Transcribe audio" item to prevent duplicates. */
 	private readonly menusWithTranscribeItem = new WeakSet<Menu>();
+	/** Tracks menus that already have the "Clean up audio" item to prevent duplicates. */
+	private readonly menusWithProcessItem = new WeakSet<Menu>();
 
 	/**
 	 * Creates a new ContextMenu instance.
@@ -245,6 +248,7 @@ export class ContextMenu {
 						this.addAudioFileInfoMenuItem(menu, file);
 						this.addConvertMenuItem(menu, file);
 						this.addSplitMenuItem(menu, file);
+						this.addProcessMenuItem(menu, file);
 						this.addTranscribeMenuItem(menu, file);
 						this.addDeleteRecordingMenuItem(menu, file);
 					}
@@ -303,6 +307,7 @@ export class ContextMenu {
 		this.addAudioFileInfoMenuItem(menu, file);
 		this.addConvertMenuItem(menu, file);
 		this.addSplitMenuItem(menu, file);
+		this.addProcessMenuItem(menu, file);
 		this.addTranscribeMenuItem(menu, file);
 		this.addDeleteRecordingAndLinkMenuItem(
 			menu,
@@ -311,6 +316,32 @@ export class ContextMenu {
 			cursor.line,
 			linkMatch,
 		);
+	}
+
+	/**
+	 * Adds a "Clean up audio" item that opens the on-demand DSP dialog
+	 * (noise gate, high-pass, loudness leveling).
+	 * @param menu - The menu to add the item to.
+	 * @param file - The audio file.
+	 */
+	private addProcessMenuItem(menu: Menu, file: TFile): void {
+		if (this.menusWithProcessItem.has(menu)) {
+			return;
+		}
+		this.menusWithProcessItem.add(menu);
+
+		menu.addItem((item: MenuItem) => {
+			item.setTitle('Clean up audio')
+				.setIcon('wand-2')
+				.setSection(AAR_MENU_SECTION)
+				.onClick(() => {
+					new AudioProcessingModal(
+						this.app,
+						file,
+						this.getSettings(),
+					).open();
+				});
+		});
 	}
 
 	/**

--- a/src/ui/TranscriptionModal.ts
+++ b/src/ui/TranscriptionModal.ts
@@ -127,14 +127,14 @@ export class TranscriptionModal extends Modal {
 		contentEl.empty();
 		new Setting(contentEl).setName('Transcribe audio').setHeading();
 		contentEl.createEl('p', {
-			cls: 'aar-transcribe-config',
+			cls: 'aar-modal-config',
 			text: `Source: ${this.file.name}`,
 		});
 
 		this.configEl = contentEl.createDiv({ cls: 'aar-transcribe-options' });
 		this.renderConfig();
 
-		this.statusEl = contentEl.createDiv({ cls: 'aar-transcribe-status' });
+		this.statusEl = contentEl.createDiv({ cls: 'aar-modal-status' });
 		this.statusEl.setText('Ready.');
 		const progress = contentEl.createDiv({
 			cls: 'aar-transcribe-progress',

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -618,12 +618,18 @@ input.aar-input-invalid {
     box-shadow: inset 2px 0 0 var(--color-accent);
 }
 
-/* Transcription modal */
-.aar-transcribe-config {
+/* Modal text shared by the transcription and audio-cleanup dialogs */
+.aar-modal-config {
     color: var(--text-muted);
     font-size: 0.9em;
 }
 
+.aar-modal-status {
+    margin: 8px 0 4px;
+    font-size: 0.9em;
+}
+
+/* Transcription modal */
 .aar-transcribe-options {
     margin: 8px 0;
 }
@@ -631,11 +637,6 @@ input.aar-input-invalid {
 .aar-transcribe-options-disabled {
     opacity: 0.5;
     pointer-events: none;
-}
-
-.aar-transcribe-status {
-    margin: 8px 0 4px;
-    font-size: 0.9em;
 }
 
 .aar-transcribe-progress {

--- a/tests/unit/AudioProcessingService.test.ts
+++ b/tests/unit/AudioProcessingService.test.ts
@@ -252,8 +252,8 @@ describe('encodeWavInterleaved', () => {
 		expect(view.getInt16(2, true)).toBe(0);
 		// Frame 1: left=0 -> 0, right=0.5 -> ~16384
 		expect(view.getInt16(6, true)).toBeCloseTo(16384, -1);
-		// Clipping: -1 -> -32767
-		expect(view.getInt16(8, true)).toBe(-32767);
+		// Full negative range: -1 -> -32768
+		expect(view.getInt16(8, true)).toBe(-32768);
 	});
 
 	it('produces a header-only file for empty channels', () => {

--- a/tests/unit/AudioProcessingService.test.ts
+++ b/tests/unit/AudioProcessingService.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Integration ("e2e as far as jsdom allows") tests for the on-demand
+ * audio-cleanup pipeline. WebAudio (AudioContext / OfflineAudioContext)
+ * and the vault are mocked so the full AudioProcessingService.process
+ * path runs: read -> decode -> gate -> offline render -> WAV encode ->
+ * write. Also covers the WAV encoder round-trip and the guards.
+ *
+ * @jest-environment jsdom
+ */
+
+import type { App, TFile } from 'obsidian';
+import {
+	AudioProcessingService,
+	encodeWavInterleaved,
+} from 'src/cleanup/AudioProcessingService';
+import type { AudioDspConfig } from 'src/cleanup/audioDsp';
+import {
+	MAX_AUDIO_CLEANUP_BYTES,
+	MAX_AUDIO_CLEANUP_SECONDS,
+} from 'src/constants';
+
+/** A writable fake AudioBuffer. */
+function fakeBuffer(channels: Float32Array[], sampleRate: number): unknown {
+	return {
+		numberOfChannels: channels.length,
+		length: channels[0]?.length ?? 0,
+		sampleRate,
+		duration: (channels[0]?.length ?? 0) / sampleRate,
+		getChannelData: (i: number): Float32Array => channels[i],
+	};
+}
+
+/** Chainable fake WebAudio node. */
+function fakeNode(): Record<string, unknown> {
+	return {
+		type: '',
+		buffer: null,
+		frequency: { value: 0 },
+		threshold: { value: 0 },
+		knee: { value: 0 },
+		ratio: { value: 0 },
+		attack: { value: 0 },
+		release: { value: 0 },
+		gain: { value: 1 },
+		connect: jest.fn(),
+		start: jest.fn(),
+	};
+}
+
+const decodeAudioData = jest.fn();
+
+beforeAll(() => {
+	class FakeAudioContext {
+		decodeAudioData = decodeAudioData;
+		close = jest.fn().mockResolvedValue(undefined);
+	}
+	class FakeOfflineAudioContext {
+		private rendered: unknown = null;
+		readonly destination = {};
+		constructor(
+			public numberOfChannels: number,
+			public length: number,
+			public sampleRate: number,
+		) {}
+		createBuffer(numChannels: number, length: number): unknown {
+			const channels = Array.from(
+				{ length: numChannels },
+				() => new Float32Array(length),
+			);
+			this.rendered = fakeBuffer(channels, this.sampleRate);
+			return this.rendered;
+		}
+		createBufferSource(): Record<string, unknown> {
+			return fakeNode();
+		}
+		createBiquadFilter(): Record<string, unknown> {
+			return fakeNode();
+		}
+		createDynamicsCompressor(): Record<string, unknown> {
+			return fakeNode();
+		}
+		createGain(): Record<string, unknown> {
+			return fakeNode();
+		}
+		startRendering(): Promise<unknown> {
+			// Echo whatever was written into the created buffer
+			return Promise.resolve(this.rendered);
+		}
+	}
+	(globalThis as unknown as { AudioContext: unknown }).AudioContext =
+		FakeAudioContext;
+	(
+		globalThis as unknown as { OfflineAudioContext: unknown }
+	).OfflineAudioContext = FakeOfflineAudioContext;
+});
+
+/** Builds a fake App with an in-memory vault. */
+function makeApp(): { app: App; written: Map<string, ArrayBuffer> } {
+	const written = new Map<string, ArrayBuffer>();
+	const adapter = {
+		exists: (path: string): Promise<boolean> =>
+			Promise.resolve(written.has(path)),
+	};
+	const vault = {
+		adapter,
+		readBinary: (): Promise<ArrayBuffer> =>
+			Promise.resolve(new ArrayBuffer(16)),
+		createBinary: (path: string, data: ArrayBuffer): Promise<void> => {
+			written.set(path, data);
+			return Promise.resolve();
+		},
+	};
+	return { app: { vault } as unknown as App, written };
+}
+
+function fakeFile(path: string, size = 1024): TFile {
+	const basename = path.slice(
+		path.lastIndexOf('/') + 1,
+		path.lastIndexOf('.'),
+	);
+	return { path, basename, stat: { size } } as unknown as TFile;
+}
+
+const ALL_STAGES: AudioDspConfig = {
+	highPass: { enabled: true, hz: 80 },
+	gate: { enabled: true, thresholdDb: -50 },
+	leveling: { enabled: true, makeupDb: 6 },
+};
+
+/** Parses the channel count / sample rate / frame count from a WAV blob. */
+function readWavHeader(buffer: ArrayBuffer): {
+	channels: number;
+	sampleRate: number;
+	dataBytes: number;
+} {
+	const view = new DataView(buffer);
+	return {
+		channels: view.getUint16(22, true),
+		sampleRate: view.getUint32(24, true),
+		dataBytes: view.getUint32(40, true),
+	};
+}
+
+describe('AudioProcessingService.process (e2e pipeline)', () => {
+	beforeEach(() => {
+		decodeAudioData.mockReset();
+	});
+
+	it('decodes, processes, and writes a stereo WAV next to the source', async () => {
+		const sampleRate = 16000;
+		const left = new Float32Array(sampleRate).fill(0.4);
+		const right = new Float32Array(sampleRate).fill(-0.4);
+		decodeAudioData.mockResolvedValue(
+			fakeBuffer([left, right], sampleRate),
+		);
+
+		const { app, written } = makeApp();
+		const service = new AudioProcessingService(app);
+		const outputPath = await service.process(
+			fakeFile('voice/rec.mp3'),
+			ALL_STAGES,
+		);
+
+		expect(outputPath).toBe('voice/rec-processed.wav');
+		expect(written.has(outputPath)).toBe(true);
+		const header = readWavHeader(written.get(outputPath) as ArrayBuffer);
+		expect(header.channels).toBe(2);
+		expect(header.sampleRate).toBe(sampleRate);
+		expect(header.dataBytes).toBe(sampleRate * 2 * 2); // frames * ch * 2 bytes
+	});
+
+	it('processes a gate-only run without invoking the offline graph', async () => {
+		const sampleRate = 16000;
+		decodeAudioData.mockResolvedValue(
+			fakeBuffer([new Float32Array(sampleRate).fill(0.2)], sampleRate),
+		);
+		const { app, written } = makeApp();
+		const service = new AudioProcessingService(app);
+		const path = await service.process(fakeFile('voice/rec.wav'), {
+			highPass: { enabled: false, hz: 80 },
+			gate: { enabled: true, thresholdDb: -50 },
+			leveling: { enabled: false, makeupDb: 0 },
+		});
+		expect(path).toBe('voice/rec-processed.wav');
+		expect(readWavHeader(written.get(path) as ArrayBuffer).channels).toBe(
+			1,
+		);
+	});
+
+	it('rejects files larger than the byte limit before decoding', async () => {
+		const { app } = makeApp();
+		await expect(
+			new AudioProcessingService(app).process(
+				fakeFile('huge.wav', MAX_AUDIO_CLEANUP_BYTES + 1),
+				ALL_STAGES,
+			),
+		).rejects.toThrow(/too large/i);
+		expect(decodeAudioData).not.toHaveBeenCalled();
+	});
+
+	it('rejects files longer than the cleanup limit', async () => {
+		const sampleRate = 16000;
+		const tooLong = new Float32Array(
+			sampleRate * (MAX_AUDIO_CLEANUP_SECONDS + 60),
+		);
+		decodeAudioData.mockResolvedValue(fakeBuffer([tooLong], sampleRate));
+		const { app } = makeApp();
+		await expect(
+			new AudioProcessingService(app).process(
+				fakeFile('long.wav'),
+				ALL_STAGES,
+			),
+		).rejects.toThrow(/too long/i);
+	});
+
+	it('rejects files with no decodable audio', async () => {
+		decodeAudioData.mockResolvedValue(fakeBuffer([], 16000));
+		const { app } = makeApp();
+		await expect(
+			new AudioProcessingService(app).process(
+				fakeFile('empty.wav'),
+				ALL_STAGES,
+			),
+		).rejects.toThrow(/no decodable audio/i);
+	});
+
+	it('propagates a decode failure (unsupported container)', async () => {
+		decodeAudioData.mockRejectedValue(new Error('Unable to decode audio'));
+		const { app } = makeApp();
+		await expect(
+			new AudioProcessingService(app).process(
+				fakeFile('bad.mp3'),
+				ALL_STAGES,
+			),
+		).rejects.toThrow(/decode/i);
+	});
+});
+
+describe('encodeWavInterleaved', () => {
+	it('writes a header and interleaves channels, round-tripping samples', () => {
+		const left = new Float32Array([1, 0, -1]);
+		const right = new Float32Array([0, 0.5, -0.5]);
+		const wav = encodeWavInterleaved([left, right], 48000);
+		const header = readWavHeader(wav);
+		expect(header.channels).toBe(2);
+		expect(header.sampleRate).toBe(48000);
+		expect(header.dataBytes).toBe(3 * 2 * 2);
+
+		const view = new DataView(wav, 44);
+		// Frame 0: left=1 -> 32767, right=0 -> 0
+		expect(view.getInt16(0, true)).toBe(32767);
+		expect(view.getInt16(2, true)).toBe(0);
+		// Frame 1: left=0 -> 0, right=0.5 -> ~16384
+		expect(view.getInt16(6, true)).toBeCloseTo(16384, -1);
+		// Clipping: -1 -> -32767
+		expect(view.getInt16(8, true)).toBe(-32767);
+	});
+
+	it('produces a header-only file for empty channels', () => {
+		const wav = encodeWavInterleaved([], 16000);
+		expect(readWavHeader(wav).dataBytes).toBe(0);
+	});
+});

--- a/tests/unit/AudioProcessingService.test.ts
+++ b/tests/unit/AudioProcessingService.test.ts
@@ -17,6 +17,7 @@ import type { AudioDspConfig } from 'src/cleanup/audioDsp';
 import {
 	MAX_AUDIO_CLEANUP_BYTES,
 	MAX_AUDIO_CLEANUP_SECONDS,
+	MAX_AUDIO_CLEANUP_DECODED_SAMPLES,
 } from 'src/constants';
 
 /** A writable fake AudioBuffer. */
@@ -213,6 +214,29 @@ describe('AudioProcessingService.process (e2e pipeline)', () => {
 		).rejects.toThrow(/too long/i);
 	});
 
+	it('rejects files whose decoded working set exceeds the sample cap', async () => {
+		// A short, highly compressed file can pass the byte and duration
+		// guards yet decode to a buffer too large to hold several copies of.
+		// length × channels exceeds the cap while the duration stays under
+		// the limit, so the decoded-sample guard is what rejects it.
+		const sampleRate = 48000;
+		const oversized = {
+			numberOfChannels: 2,
+			length: MAX_AUDIO_CLEANUP_DECODED_SAMPLES,
+			sampleRate,
+			duration: MAX_AUDIO_CLEANUP_DECODED_SAMPLES / sampleRate,
+			getChannelData: (): Float32Array => new Float32Array(1),
+		};
+		decodeAudioData.mockResolvedValue(oversized);
+		const { app } = makeApp();
+		await expect(
+			new AudioProcessingService(app).process(
+				fakeFile('dense.opus'),
+				ALL_STAGES,
+			),
+		).rejects.toThrow(/too large/i);
+	});
+
 	it('rejects files with no decodable audio', async () => {
 		decodeAudioData.mockResolvedValue(fakeBuffer([], 16000));
 		const { app } = makeApp();
@@ -259,5 +283,13 @@ describe('encodeWavInterleaved', () => {
 	it('produces a header-only file for empty channels', () => {
 		const wav = encodeWavInterleaved([], 16000);
 		expect(readWavHeader(wav).dataBytes).toBe(0);
+	});
+
+	it('throws when channels have mismatched lengths', () => {
+		const left = new Float32Array([1, 0, -1]);
+		const right = new Float32Array([0, 0.5]);
+		expect(() => encodeWavInterleaved([left, right], 48000)).toThrow(
+			/same length/i,
+		);
 	});
 });

--- a/tests/unit/ContextMenu.test.ts
+++ b/tests/unit/ContextMenu.test.ts
@@ -55,6 +55,12 @@ jest.mock('../../src/ui/SplitModal', () => ({
 	})),
 }));
 
+jest.mock('../../src/cleanup/AudioProcessingModal', () => ({
+	AudioProcessingModal: jest.fn().mockImplementation(() => ({
+		open: jest.fn(),
+	})),
+}));
+
 // Mock AudioEncoder to avoid mediabunny TextDecoder requirement
 jest.mock('../../src/recording/AudioEncoder', () => ({
 	encodeAudioBuffer: jest.fn(),
@@ -185,11 +191,11 @@ describe('ContextMenu', () => {
 
 			fileMenuCallback(mockMenu, mockFile);
 
-			expect(mockMenu.addItem).toHaveBeenCalledTimes(4);
+			expect(mockMenu.addItem).toHaveBeenCalledTimes(5);
 
 			// Verify the delete item configuration (4th item: Audio info, Convert, Split, Delete)
 			const addItemCallback = (mockMenu.addItem as jest.Mock).mock
-				.calls[3][0];
+				.calls[4][0];
 			const mockItem = {
 				setTitle: jest.fn().mockReturnThis(),
 				setIcon: jest.fn().mockReturnThis(),
@@ -210,7 +216,7 @@ describe('ContextMenu', () => {
 
 			fileMenuCallback(mockMenu, mockFile);
 
-			expect(mockMenu.addItem).toHaveBeenCalledTimes(4);
+			expect(mockMenu.addItem).toHaveBeenCalledTimes(5);
 
 			// Verify the audio info item configuration (1st item)
 			const addItemCallback = (mockMenu.addItem as jest.Mock).mock
@@ -325,7 +331,7 @@ describe('ContextMenu', () => {
 
 			fileMenuCallback(mockMenu, mockFile);
 
-			expect(mockMenu.addItem).toHaveBeenCalledTimes(4);
+			expect(mockMenu.addItem).toHaveBeenCalledTimes(5);
 
 			// Verify the split item configuration (3rd item: info, convert, split, delete)
 			const addItemCallback = (mockMenu.addItem as jest.Mock).mock
@@ -375,6 +381,39 @@ describe('ContextMenu', () => {
 			);
 		});
 
+		it('adds a "Clean up audio" item and opens AudioProcessingModal', () => {
+			const { AudioProcessingModal } = jest.requireMock(
+				'../../src/cleanup/AudioProcessingModal',
+			);
+			const mockMenu = new Menu();
+			const mockFile = new TFile();
+			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
+
+			fileMenuCallback(mockMenu, mockFile);
+
+			// Order: info(0), convert(1), split(2), clean up(3), delete(4)
+			const addItemCallback = (mockMenu.addItem as jest.Mock).mock
+				.calls[3][0];
+			const mockItem = {
+				setTitle: jest.fn().mockReturnThis(),
+				setIcon: jest.fn().mockReturnThis(),
+				setSection: jest.fn().mockReturnThis(),
+				onClick: jest.fn(),
+			};
+			addItemCallback(mockItem);
+
+			expect(mockItem.setTitle).toHaveBeenCalledWith('Clean up audio');
+			expect(mockItem.setSection).toHaveBeenCalledWith('aar');
+
+			const clickHandler = mockItem.onClick.mock.calls[0][0];
+			clickHandler();
+			expect(AudioProcessingModal).toHaveBeenCalledWith(
+				mockApp,
+				mockFile,
+				expect.any(Object),
+			);
+		});
+
 		it('should not duplicate "Split audio into parts" when called twice on the same menu', () => {
 			const mockMenu = new Menu();
 			const mockFile = new TFile();
@@ -420,7 +459,7 @@ describe('ContextMenu', () => {
 			fileMenuCallback(mockMenu, mockFile);
 
 			const addItemCallback = (mockMenu.addItem as jest.Mock).mock
-				.calls[3][0];
+				.calls[4][0];
 			const mockItem = {
 				setTitle: jest.fn().mockReturnThis(),
 				setIcon: jest.fn().mockReturnThis(),
@@ -451,7 +490,7 @@ describe('ContextMenu', () => {
 			fileMenuCallback(mockMenu, mockFile);
 
 			const addItemCallback = (mockMenu.addItem as jest.Mock).mock
-				.calls[3][0];
+				.calls[4][0];
 			const mockItem = {
 				setTitle: jest.fn().mockReturnThis(),
 				setIcon: jest.fn().mockReturnThis(),
@@ -565,9 +604,9 @@ describe('ContextMenu', () => {
 
 			editorMenuCallback(mockMenu, mockEditor, {});
 
-			expect(mockMenu.addItem).toHaveBeenCalledTimes(4);
+			expect(mockMenu.addItem).toHaveBeenCalledTimes(5);
 			const addItemCallback = (mockMenu.addItem as jest.Mock).mock
-				.calls[3][0]; // Delete recording & link is the fourth item (info, convert, split, delete&link)
+				.calls[4][0]; // Delete recording & link is the fourth item (info, convert, split, delete&link)
 			const mockItem = {
 				setTitle: jest.fn().mockReturnThis(),
 				setIcon: jest.fn().mockReturnThis(),
@@ -601,7 +640,7 @@ describe('ContextMenu', () => {
 			editorMenuCallback(mockMenu, mockEditor, {});
 
 			const addItemCallback = (mockMenu.addItem as jest.Mock).mock
-				.calls[3][0];
+				.calls[4][0];
 			const mockItem = {
 				setTitle: jest.fn().mockReturnThis(),
 				setIcon: jest.fn().mockReturnThis(),
@@ -653,7 +692,7 @@ describe('ContextMenu', () => {
 			editorMenuCallback(mockMenu, mockEditor, {});
 
 			const addItemCallback = (mockMenu.addItem as jest.Mock).mock
-				.calls[3][0];
+				.calls[4][0];
 			const mockItem = {
 				setTitle: jest.fn().mockReturnThis(),
 				setIcon: jest.fn().mockReturnThis(),

--- a/tests/unit/Settings.test.ts
+++ b/tests/unit/Settings.test.ts
@@ -268,12 +268,12 @@ describe('Settings', () => {
 				showInputLevelMeter: false,
 				showRecordingStats: false,
 				mobileRecordingBanner: false,
-				inputHighPassEnabled: false,
-				inputHighPassHz: 100,
-				inputNoiseGateEnabled: true,
-				inputNoiseGateThresholdDb: -45,
-				inputLevelingEnabled: true,
-				inputLevelingMakeupDb: 9,
+				cleanupHighPassEnabled: false,
+				cleanupHighPassHz: 100,
+				cleanupNoiseGateEnabled: true,
+				cleanupNoiseGateThresholdDb: -45,
+				cleanupLevelingEnabled: true,
+				cleanupLevelingMakeupDb: 9,
 			};
 
 			const result = mergeSettings(fullSettings);

--- a/tests/unit/Settings.test.ts
+++ b/tests/unit/Settings.test.ts
@@ -268,6 +268,12 @@ describe('Settings', () => {
 				showInputLevelMeter: false,
 				showRecordingStats: false,
 				mobileRecordingBanner: false,
+				inputHighPassEnabled: false,
+				inputHighPassHz: 100,
+				inputNoiseGateEnabled: true,
+				inputNoiseGateThresholdDb: -45,
+				inputLevelingEnabled: true,
+				inputLevelingMakeupDb: 9,
 			};
 
 			const result = mergeSettings(fullSettings);

--- a/tests/unit/audioDsp.test.ts
+++ b/tests/unit/audioDsp.test.ts
@@ -12,10 +12,10 @@ import {
 } from 'src/cleanup/audioDsp';
 import { mergeSettings } from 'src/settings/Settings';
 import {
-	DEFAULT_INPUT_HIGHPASS_HZ,
-	MAX_INPUT_GATE_THRESHOLD_DB,
-	MAX_INPUT_HIGHPASS_HZ,
-	MIN_INPUT_LEVELING_MAKEUP_DB,
+	DEFAULT_CLEANUP_HIGHPASS_HZ,
+	MAX_CLEANUP_GATE_THRESHOLD_DB,
+	MAX_CLEANUP_HIGHPASS_HZ,
+	MIN_CLEANUP_LEVELING_MAKEUP_DB,
 } from 'src/constants';
 
 describe('gateShouldOpen', () => {
@@ -62,12 +62,12 @@ describe('resolveAudioDspConfig', () => {
 	it('passes through valid values', () => {
 		const config = resolveAudioDspConfig(
 			mergeSettings({
-				inputHighPassEnabled: true,
-				inputHighPassHz: 120,
-				inputNoiseGateEnabled: true,
-				inputNoiseGateThresholdDb: -45,
-				inputLevelingEnabled: true,
-				inputLevelingMakeupDb: 9,
+				cleanupHighPassEnabled: true,
+				cleanupHighPassHz: 120,
+				cleanupNoiseGateEnabled: true,
+				cleanupNoiseGateThresholdDb: -45,
+				cleanupLevelingEnabled: true,
+				cleanupLevelingMakeupDb: 9,
 			}),
 		);
 		expect(config.highPass).toEqual({ enabled: true, hz: 120 });
@@ -78,21 +78,21 @@ describe('resolveAudioDspConfig', () => {
 	it('clamps out-of-range values', () => {
 		const config = resolveAudioDspConfig(
 			mergeSettings({
-				inputHighPassHz: 10_000,
-				inputNoiseGateThresholdDb: 0,
-				inputLevelingMakeupDb: -100,
+				cleanupHighPassHz: 10_000,
+				cleanupNoiseGateThresholdDb: 0,
+				cleanupLevelingMakeupDb: -100,
 			}),
 		);
-		expect(config.highPass.hz).toBe(MAX_INPUT_HIGHPASS_HZ);
-		expect(config.gate.thresholdDb).toBe(MAX_INPUT_GATE_THRESHOLD_DB);
-		expect(config.leveling.makeupDb).toBe(MIN_INPUT_LEVELING_MAKEUP_DB);
+		expect(config.highPass.hz).toBe(MAX_CLEANUP_HIGHPASS_HZ);
+		expect(config.gate.thresholdDb).toBe(MAX_CLEANUP_GATE_THRESHOLD_DB);
+		expect(config.leveling.makeupDb).toBe(MIN_CLEANUP_LEVELING_MAKEUP_DB);
 	});
 
 	it('falls back to defaults for non-finite values', () => {
 		const settings = mergeSettings({});
-		settings.inputHighPassHz = Number.NaN;
+		settings.cleanupHighPassHz = Number.NaN;
 		expect(resolveAudioDspConfig(settings).highPass.hz).toBe(
-			DEFAULT_INPUT_HIGHPASS_HZ,
+			DEFAULT_CLEANUP_HIGHPASS_HZ,
 		);
 	});
 });

--- a/tests/unit/audioDsp.test.ts
+++ b/tests/unit/audioDsp.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for the pure input-DSP helpers: gate decision (with hysteresis),
+ * dB-to-gain, config resolution/clamping, and active-stage detection.
+ */
+
+import {
+	applyNoiseGateToChannel,
+	dbToGain,
+	gateShouldOpen,
+	hasActiveStage,
+	resolveAudioDspConfig,
+} from 'src/cleanup/audioDsp';
+import { mergeSettings } from 'src/settings/Settings';
+import {
+	DEFAULT_INPUT_HIGHPASS_HZ,
+	MAX_INPUT_GATE_THRESHOLD_DB,
+	MAX_INPUT_HIGHPASS_HZ,
+	MIN_INPUT_LEVELING_MAKEUP_DB,
+} from 'src/constants';
+
+describe('gateShouldOpen', () => {
+	it('opens at or above the threshold', () => {
+		expect(gateShouldOpen(-40, -50, 6, false)).toBe(true);
+		expect(gateShouldOpen(-50, -50, 6, false)).toBe(true);
+	});
+
+	it('closes only below the hysteresis margin', () => {
+		// Between (threshold - hysteresis) and threshold: keep state
+		expect(gateShouldOpen(-54, -50, 6, true)).toBe(true);
+		expect(gateShouldOpen(-54, -50, 6, false)).toBe(false);
+		// Below the margin: always closed
+		expect(gateShouldOpen(-57, -50, 6, true)).toBe(false);
+	});
+});
+
+describe('dbToGain', () => {
+	it('maps 0 dB to 1 and +6 dB to ~2', () => {
+		expect(dbToGain(0)).toBeCloseTo(1);
+		expect(dbToGain(6)).toBeCloseTo(1.995, 2);
+		expect(dbToGain(-6)).toBeCloseTo(0.501, 2);
+	});
+});
+
+describe('hasActiveStage', () => {
+	it('is false only when every stage is disabled', () => {
+		const off = {
+			highPass: { enabled: false, hz: 80 },
+			gate: { enabled: false, thresholdDb: -50 },
+			leveling: { enabled: false, makeupDb: 6 },
+		};
+		expect(hasActiveStage(off)).toBe(false);
+		expect(
+			hasActiveStage({
+				...off,
+				gate: { enabled: true, thresholdDb: -50 },
+			}),
+		).toBe(true);
+	});
+});
+
+describe('resolveAudioDspConfig', () => {
+	it('passes through valid values', () => {
+		const config = resolveAudioDspConfig(
+			mergeSettings({
+				inputHighPassEnabled: true,
+				inputHighPassHz: 120,
+				inputNoiseGateEnabled: true,
+				inputNoiseGateThresholdDb: -45,
+				inputLevelingEnabled: true,
+				inputLevelingMakeupDb: 9,
+			}),
+		);
+		expect(config.highPass).toEqual({ enabled: true, hz: 120 });
+		expect(config.gate).toEqual({ enabled: true, thresholdDb: -45 });
+		expect(config.leveling).toEqual({ enabled: true, makeupDb: 9 });
+	});
+
+	it('clamps out-of-range values', () => {
+		const config = resolveAudioDspConfig(
+			mergeSettings({
+				inputHighPassHz: 10_000,
+				inputNoiseGateThresholdDb: 0,
+				inputLevelingMakeupDb: -100,
+			}),
+		);
+		expect(config.highPass.hz).toBe(MAX_INPUT_HIGHPASS_HZ);
+		expect(config.gate.thresholdDb).toBe(MAX_INPUT_GATE_THRESHOLD_DB);
+		expect(config.leveling.makeupDb).toBe(MIN_INPUT_LEVELING_MAKEUP_DB);
+	});
+
+	it('falls back to defaults for non-finite values', () => {
+		const settings = mergeSettings({});
+		settings.inputHighPassHz = Number.NaN;
+		expect(resolveAudioDspConfig(settings).highPass.hz).toBe(
+			DEFAULT_INPUT_HIGHPASS_HZ,
+		);
+	});
+});
+
+describe('applyNoiseGateToChannel', () => {
+	it('passes loud audio and attenuates quiet audio', () => {
+		const sampleRate = 16000;
+		const samples = new Float32Array(sampleRate); // 1 second
+		// First half loud (0.5 ~ -6 dBFS), second half near-silent (~-80 dBFS)
+		for (let i = 0; i < samples.length; i++) {
+			const loud = i < samples.length / 2;
+			samples[i] = (loud ? 0.5 : 0.0001) * (i % 2 === 0 ? 1 : -1);
+		}
+		const gated = applyNoiseGateToChannel(samples, sampleRate, -40);
+
+		// Mid-point of the loud region is essentially unchanged
+		const loudIndex = Math.floor(samples.length / 4);
+		expect(Math.abs(gated[loudIndex])).toBeGreaterThan(0.45);
+		// End of the silent region is gated to near zero
+		const lastSample = gated[gated.length - 1];
+		expect(Math.abs(lastSample)).toBeLessThan(0.00005);
+	});
+
+	it('returns an empty array for empty input', () => {
+		expect(
+			applyNoiseGateToChannel(new Float32Array(0), 16000, -40),
+		).toEqual(new Float32Array(0));
+	});
+});


### PR DESCRIPTION
## Summary

Adds **on-demand audio cleanup** — noise removal (high-pass + noise gate) and **loudness leveling** (compression + makeup gain) — invoked from the **context menu**, not applied during live recording. Right-click an audio file or its embed → **Clean up audio** → pick stages → it writes a processed `…-processed.wav` copy next to the source, leaving the original untouched.

> Per the request, this is **on-demand only** and does not change the recording pipeline. Based on `claude/recording-feedback` (PR #36).

## What it does

The **Clean up audio** dialog (defaults come from settings; each run can override) applies any combination of:

- **High-pass filter** — removes low-frequency rumble below a configurable cutoff (Hz). `BiquadFilterNode` via `OfflineAudioContext`.
- **Noise gate** — silences the signal below a configurable threshold (dBFS), with **hysteresis** and attack/release smoothing so gating never clicks. Implemented as a pure, offline envelope gate over the decoded samples.
- **Loudness leveling** — a `DynamicsCompressorNode` evens out quiet/loud passages, with a configurable **makeup gain** (dB).

Optional **delete source after processing**. Enable at least one stage to run.

## Architecture

- `AudioProcessingService`: `readBinary → decodeAudioData → (pure noise gate) → OfflineAudioContext (high-pass → compressor → makeup) → interleaved 16-bit WAV → createBinary`. Fully offline; no live-recording impact.
- `audioDsp` (pure, unit tested): config resolve/clamp, `dbToGain`, `gateShouldOpen` (hysteresis), and `applyNoiseGateToChannel` (envelope gate).
- `AudioProcessingModal` + a **Clean up audio** context-menu item (file menu, editor menu, and embedded-player menu).
- Settings hold the cleanup **defaults** that prefill the dialog (no live master toggle).
- The live input-processing chain from the previous revision was removed and `RecordingManager` reverted to its original stream handling.

## Testing

- `npx tsc -noEmit` clean; `npx eslint .` no errors; production esbuild builds.
- **882 tests pass** (gate hysteresis, dB↔gain, config clamping, active-stage detection, offline noise-gate behavior; ContextMenu item indices/counts updated for the new item).
- README updated.

https://claude.ai/code/session_01AxMFHTVcPkhr2gseXk2DP8