### PR TITLE
[codex] fix player upgrade after recording

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -588,6 +588,11 @@ export default class AudioRecorderPlugin extends Plugin {
 	 * @param result - The saved audio paths and the note the links landed in
 	 */
 	private handleRecordingSaved(result: RecordingSaveResult): void {
+		this.playerRegistrar.primeSavedRecordingsForEnhancement(
+			result.audioPaths,
+			result.notePath,
+		);
+
 		if (
 			!this.settings.transcriptionEnabled ||
 			!this.settings.transcribeOnSave ||

--- a/src/player/EnhancedPlayerRegistrar.ts
+++ b/src/player/EnhancedPlayerRegistrar.ts
@@ -96,6 +96,13 @@ export class EnhancedPlayerRegistrar {
 	private readonly pendingRerenderPaths = new Set<string>();
 	/** Retry count per scoped path while metadata catches up. */
 	private readonly pendingRerenderRetries = new Map<string, number>();
+	/** Notes to rebuild directly once a saved recording probes as audio. */
+	private readonly pendingDirectRerenderNotePaths = new Map<
+		string,
+		Set<string>
+	>();
+	/** Notes that should receive a direct rebuild after the current probe. */
+	private readonly pendingProbeNotePaths = new Map<string, Set<string>>();
 	/** Whether every leaf must re-render (master toggle flip). */
 	private pendingRerenderAll = false;
 	/** Debounced flush that coalesces a burst of re-render requests. */
@@ -190,6 +197,8 @@ export class EnhancedPlayerRegistrar {
 		this.probing.clear();
 		this.pendingRerenderPaths.clear();
 		this.pendingRerenderRetries.clear();
+		this.pendingDirectRerenderNotePaths.clear();
+		this.pendingProbeNotePaths.clear();
 		this.markerStore.clearCache();
 		void this.decoder.close().catch(() => {
 			// Closing a context that never opened or already failed is
@@ -231,6 +240,31 @@ export class EnhancedPlayerRegistrar {
 		}
 		this.lastResolved = resolved;
 		this.registry.applySettings(resolved);
+	}
+
+	/**
+	 * Primes freshly saved recordings for enhancement after the recording
+	 * pipeline inserts their embeds into a note. This avoids depending on
+	 * Obsidian first creating a native embed and starting the lazy probe: once
+	 * the file is proven audio-only, the note that received the embed is
+	 * rebuilt directly.
+	 * @param audioPaths - Vault paths written by the recording finalizer
+	 * @param notePath - Note that received the embed links, if any
+	 */
+	primeSavedRecordingsForEnhancement(
+		audioPaths: string[],
+		notePath: string | null,
+	): void {
+		if (!this.getSettings().enhancedPlayerEnabled || !notePath) {
+			return;
+		}
+		for (const audioPath of audioPaths) {
+			const file = this.app.vault.getAbstractFileByPath(audioPath);
+			if (!(file instanceof TFile) || !isAudioFile(file)) {
+				continue;
+			}
+			void this.probeAndUpgrade(file, notePath);
+		}
 	}
 
 	/**
@@ -334,8 +368,26 @@ export class EnhancedPlayerRegistrar {
 	 * open views so the embed is rebuilt as the enhanced player.
 	 * @param file - Media file to probe
 	 */
-	private async probeAndUpgrade(file: TFile): Promise<void> {
-		if (this.mediaKindCache.has(file.path) || this.probing.has(file.path)) {
+	private async probeAndUpgrade(
+		file: TFile,
+		notePath?: string,
+	): Promise<void> {
+		if (notePath) {
+			this.addPendingProbeNotePath(file.path, notePath);
+		}
+		const knownKind = this.mediaKindCache.get(file.path);
+		if (knownKind) {
+			if (
+				shouldEnhance(
+					this.getSettings().enhancedPlayerEnabled,
+					knownKind,
+				)
+			) {
+				this.requestRerenderForFile(file.path, notePath);
+			}
+			return;
+		}
+		if (this.probing.has(file.path)) {
 			return;
 		}
 		this.probing.add(file.path);
@@ -345,13 +397,33 @@ export class EnhancedPlayerRegistrar {
 			);
 			this.mediaKindCache.set(file.path, kind);
 			if (shouldEnhance(this.getSettings().enhancedPlayerEnabled, kind)) {
-				// Only the notes that actually embed this file need rebuilding,
-				// so a large note that does not embed it is never re-rendered
-				this.requestRerenderForFile(file.path);
+				const notePaths = this.pendingProbeNotePaths.get(file.path);
+				if (notePaths && notePaths.size > 0) {
+					for (const pendingNotePath of notePaths) {
+						this.requestRerenderForFile(file.path, pendingNotePath);
+					}
+				} else {
+					// Only the notes that actually embed this file need rebuilding,
+					// so a large note that does not embed it is never re-rendered
+					this.requestRerenderForFile(file.path);
+				}
 			}
 		} finally {
+			this.pendingProbeNotePaths.delete(file.path);
 			this.probing.delete(file.path);
 		}
+	}
+
+	/**
+	 * Remembers that a saved recording should rebuild a known note after its
+	 * media probe completes.
+	 * @param path - Vault path of the recording
+	 * @param notePath - Note that received the embed link
+	 */
+	private addPendingProbeNotePath(path: string, notePath: string): void {
+		const notePaths = this.pendingProbeNotePaths.get(path) ?? new Set();
+		notePaths.add(notePath);
+		this.pendingProbeNotePaths.set(path, notePaths);
 	}
 
 	/**
@@ -395,8 +467,14 @@ export class EnhancedPlayerRegistrar {
 	 * probe upgrade never re-renders unrelated (possibly large) notes.
 	 * @param path - Vault path of the upgraded file
 	 */
-	private requestRerenderForFile(path: string): void {
+	private requestRerenderForFile(path: string, notePath?: string): void {
 		this.pendingRerenderPaths.add(path);
+		if (notePath) {
+			const notePaths =
+				this.pendingDirectRerenderNotePaths.get(path) ?? new Set();
+			notePaths.add(notePath);
+			this.pendingDirectRerenderNotePaths.set(path, notePaths);
+		}
 		if (!this.pendingRerenderRetries.has(path)) {
 			this.pendingRerenderRetries.set(path, 0);
 		}
@@ -422,20 +500,54 @@ export class EnhancedPlayerRegistrar {
 			}
 			for (const path of paths) {
 				this.pendingRerenderRetries.delete(path);
+				this.pendingDirectRerenderNotePaths.delete(path);
 			}
 			return;
 		}
 		const unmatchedPaths = new Set(paths);
+		const matchedRerenderPaths = new Set<string>();
 		for (const leaf of leaves) {
-			const matchedPaths = this.leafEmbeddedPaths(leaf, paths);
+			const matchedPaths = new Set([
+				...this.leafDirectRerenderPaths(leaf, paths),
+				...this.leafEmbeddedPaths(leaf, paths),
+			]);
 			if (matchedPaths.size > 0) {
 				this.rerenderLeaf(leaf);
 				for (const path of matchedPaths) {
 					unmatchedPaths.delete(path);
+					matchedRerenderPaths.add(path);
 				}
 			}
 		}
+		for (const path of matchedRerenderPaths) {
+			this.pendingRerenderRetries.delete(path);
+			this.pendingDirectRerenderNotePaths.delete(path);
+		}
 		this.rescheduleUnmatchedRerenders(unmatchedPaths);
+	}
+
+	/**
+	 * Returns probed file paths that should rebuild this exact note because
+	 * the recording pipeline just inserted their embeds there.
+	 * @param leaf - Workspace leaf to test
+	 * @param paths - Candidate embedded file paths
+	 */
+	private leafDirectRerenderPaths(
+		leaf: WorkspaceLeaf,
+		paths: Set<string>,
+	): Set<string> {
+		const matchedPaths = new Set<string>();
+		const view = leaf.view;
+		if (!(view instanceof MarkdownView) || !view.file) {
+			return matchedPaths;
+		}
+		for (const path of paths) {
+			const notePaths = this.pendingDirectRerenderNotePaths.get(path);
+			if (notePaths?.has(view.file.path)) {
+				matchedPaths.add(path);
+			}
+		}
+		return matchedPaths;
 	}
 
 	/**
@@ -479,6 +591,7 @@ export class EnhancedPlayerRegistrar {
 			const retryCount = this.pendingRerenderRetries.get(path) ?? 0;
 			if (retryCount >= SCOPED_RERENDER_RETRY_LIMIT) {
 				this.pendingRerenderRetries.delete(path);
+				this.pendingDirectRerenderNotePaths.delete(path);
 				continue;
 			}
 			this.pendingRerenderRetries.set(path, retryCount + 1);

--- a/src/player/EnhancedPlayerRegistrar.ts
+++ b/src/player/EnhancedPlayerRegistrar.ts
@@ -69,6 +69,12 @@ const ENHANCED_FLAG = 'aarEnhanced';
 const RERENDER_DEBOUNCE_MS = 50;
 
 /**
+ * Number of extra scoped re-render attempts for a freshly inserted embed
+ * whose metadata cache entry may lag behind the editor update.
+ */
+const SCOPED_RERENDER_RETRY_LIMIT = 5;
+
+/**
  * Registers and owns the enhanced player integration.
  */
 export class EnhancedPlayerRegistrar {
@@ -88,6 +94,8 @@ export class EnhancedPlayerRegistrar {
 	private lastResolved: ResolvedPlayerSettings | null = null;
 	/** Paths pending a scoped re-render (probe upgrades of specific files). */
 	private readonly pendingRerenderPaths = new Set<string>();
+	/** Retry count per scoped path while metadata catches up. */
+	private readonly pendingRerenderRetries = new Map<string, number>();
 	/** Whether every leaf must re-render (master toggle flip). */
 	private pendingRerenderAll = false;
 	/** Debounced flush that coalesces a burst of re-render requests. */
@@ -180,6 +188,8 @@ export class EnhancedPlayerRegistrar {
 		this.peakCache.clear();
 		this.mediaKindCache.clear();
 		this.probing.clear();
+		this.pendingRerenderPaths.clear();
+		this.pendingRerenderRetries.clear();
 		this.markerStore.clearCache();
 		void this.decoder.close().catch(() => {
 			// Closing a context that never opened or already failed is
@@ -387,6 +397,9 @@ export class EnhancedPlayerRegistrar {
 	 */
 	private requestRerenderForFile(path: string): void {
 		this.pendingRerenderPaths.add(path);
+		if (!this.pendingRerenderRetries.has(path)) {
+			this.pendingRerenderRetries.set(path, 0);
+		}
 		this.scheduleRerender();
 	}
 
@@ -403,31 +416,46 @@ export class EnhancedPlayerRegistrar {
 			return;
 		}
 		const leaves = this.app.workspace.getLeavesOfType('markdown');
-		for (const leaf of leaves) {
-			if (all || this.leafEmbedsAnyPath(leaf, paths)) {
+		if (all) {
+			for (const leaf of leaves) {
 				this.rerenderLeaf(leaf);
 			}
+			for (const path of paths) {
+				this.pendingRerenderRetries.delete(path);
+			}
+			return;
 		}
+		const unmatchedPaths = new Set(paths);
+		for (const leaf of leaves) {
+			const matchedPaths = this.leafEmbeddedPaths(leaf, paths);
+			if (matchedPaths.size > 0) {
+				this.rerenderLeaf(leaf);
+				for (const path of matchedPaths) {
+					unmatchedPaths.delete(path);
+				}
+			}
+		}
+		this.rescheduleUnmatchedRerenders(unmatchedPaths);
 	}
 
 	/**
-	 * Whether a leaf's note embeds any of the given file paths, resolved
-	 * through the metadata cache. A note with no matching embed is left
-	 * untouched.
+	 * Returns the given file paths embedded by a leaf's note, resolved through
+	 * the metadata cache. A note with no matching embed is left untouched.
 	 * @param leaf - Workspace leaf to test
 	 * @param paths - Candidate embedded file paths
 	 */
-	private leafEmbedsAnyPath(
+	private leafEmbeddedPaths(
 		leaf: WorkspaceLeaf,
 		paths: Set<string>,
-	): boolean {
+	): Set<string> {
+		const matchedPaths = new Set<string>();
 		const view = leaf.view;
 		if (!(view instanceof MarkdownView) || !view.file) {
-			return false;
+			return matchedPaths;
 		}
 		const embeds = this.app.metadataCache.getFileCache(view.file)?.embeds;
 		if (!embeds) {
-			return false;
+			return matchedPaths;
 		}
 		for (const embed of embeds) {
 			const dest = this.app.metadataCache.getFirstLinkpathDest(
@@ -435,10 +463,30 @@ export class EnhancedPlayerRegistrar {
 				view.file.path,
 			);
 			if (dest && paths.has(dest.path)) {
-				return true;
+				matchedPaths.add(dest.path);
 			}
 		}
-		return false;
+		return matchedPaths;
+	}
+
+	/**
+	 * Keeps a scoped upgrade alive briefly when the media probe finished before
+	 * Obsidian indexed the newly inserted embed in metadataCache.
+	 * @param unmatchedPaths - Probed audio paths not found in open note caches
+	 */
+	private rescheduleUnmatchedRerenders(unmatchedPaths: Set<string>): void {
+		for (const path of unmatchedPaths) {
+			const retryCount = this.pendingRerenderRetries.get(path) ?? 0;
+			if (retryCount >= SCOPED_RERENDER_RETRY_LIMIT) {
+				this.pendingRerenderRetries.delete(path);
+				continue;
+			}
+			this.pendingRerenderRetries.set(path, retryCount + 1);
+			this.pendingRerenderPaths.add(path);
+		}
+		if (this.pendingRerenderPaths.size > 0) {
+			this.scheduleRerender();
+		}
 	}
 
 	/**

--- a/tests/unit/EnhancedPlayerRegistrar.test.ts
+++ b/tests/unit/EnhancedPlayerRegistrar.test.ts
@@ -13,8 +13,8 @@
  * design.
  */
 
-import { MarkdownView } from 'obsidian';
-import type { App, Plugin, TFile, WorkspaceLeaf } from 'obsidian';
+import { MarkdownView, TFile } from 'obsidian';
+import type { App, Plugin, WorkspaceLeaf } from 'obsidian';
 import { EnhancedPlayerRegistrar } from 'src/player/EnhancedPlayerRegistrar';
 import { AudioPlayer } from 'src/player/AudioPlayer';
 import { AudioPlayerRegistry } from 'src/player/AudioPlayerRegistry';
@@ -119,6 +119,7 @@ function setup(enabled = true): {
 		embedRegistry: { embedByExtension },
 		vault: {
 			getResourcePath: () => 'app://media',
+			getAbstractFileByPath: (path: string) => fileFromPath(path),
 			on: jest.fn(() => ({})),
 		},
 		metadataCache: {
@@ -169,8 +170,16 @@ function setup(enabled = true): {
 	};
 }
 
+function fileFromPath(path: string): TFile {
+	const extension = path.split('.').pop() ?? '';
+	return Object.assign(Object.create(TFile.prototype), {
+		path,
+		extension,
+	}) as TFile;
+}
+
 function fileOf(extension: string): TFile {
-	return { path: `recording.${extension}`, extension } as TFile;
+	return fileFromPath(`recording.${extension}`);
 }
 
 const info: EmbedInfo = {
@@ -315,6 +324,28 @@ describe('EnhancedPlayerRegistrar re-renders only when needed', () => {
 
 		// The probe found audio, so a re-render is requested to upgrade it
 		expect(getLeaves).toHaveBeenCalledWith('markdown');
+	});
+
+	it('primes a saved recording for enhancement without waiting for native embed render', async () => {
+		probeMock.mockResolvedValue('audio');
+		const { registrar, embedsByNote, leaves } = setup(true);
+		const previewLeaf = leaves.preview as unknown as {
+			rebuildView: jest.Mock;
+		};
+		embedsByNote['note.md'] = { embeds: [] };
+
+		registrar.primeSavedRecordingsForEnhancement(
+			['recording.mp4'],
+			'note.md',
+		);
+		await flush();
+
+		expect(probeMock).toHaveBeenCalledTimes(1);
+		expect(previewLeaf.rebuildView).toHaveBeenCalledTimes(1);
+		expect(
+			(leaves.source as unknown as { rebuildView: jest.Mock })
+				.rebuildView,
+		).not.toHaveBeenCalled();
 	});
 
 	it('re-renders only the leaves that embed the probed file (scoped upgrade)', async () => {

--- a/tests/unit/EnhancedPlayerRegistrar.test.ts
+++ b/tests/unit/EnhancedPlayerRegistrar.test.ts
@@ -81,6 +81,7 @@ function setup(enabled = true): {
 	settings: AudioRecorderSettings;
 	leaves: { preview: WorkspaceLeaf; source: WorkspaceLeaf };
 	getLeaves: jest.Mock;
+	embedsByNote: Record<string, { embeds: Array<{ link: string }> }>;
 } {
 	const settings: AudioRecorderSettings = {
 		...DEFAULT_SETTINGS,
@@ -164,6 +165,7 @@ function setup(enabled = true): {
 		settings,
 		leaves: { preview: previewLeaf, source: sourceLeaf },
 		getLeaves,
+		embedsByNote,
 	};
 }
 
@@ -332,6 +334,26 @@ describe('EnhancedPlayerRegistrar re-renders only when needed', () => {
 			(leaves.source as unknown as { rebuildView: jest.Mock })
 				.rebuildView,
 		).not.toHaveBeenCalled();
+	});
+
+	it('retries a scoped upgrade when metadata has not indexed the new embed yet', async () => {
+		probeMock.mockResolvedValue('audio');
+		const { creator, embedsByNote, leaves } = setup(true);
+		const previewLeaf = leaves.preview as unknown as {
+			rebuildView: jest.Mock;
+		};
+		const rebuildView = previewLeaf.rebuildView;
+		embedsByNote['note.md'] = { embeds: [] };
+
+		creator(info, fileOf('mp4'), '');
+		await flush();
+
+		expect(rebuildView).not.toHaveBeenCalled();
+
+		embedsByNote['note.md'] = { embeds: [{ link: 'recording.mp4' }] };
+		await flush();
+
+		expect(rebuildView).toHaveBeenCalledTimes(1);
 	});
 
 	it('does not re-render after probing a real video file', async () => {

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -29,6 +29,7 @@ jest.mock('../../src/player/EnhancedPlayerRegistrar', () => ({
 		register: jest.fn(),
 		dispose: jest.fn(),
 		refresh: jest.fn(),
+		primeSavedRecordingsForEnhancement: jest.fn(),
 	})),
 }));
 
@@ -331,6 +332,37 @@ describe('AudioRecorderPlugin settings persistence', () => {
 
 		expect(saveData).not.toHaveBeenCalled();
 		expect(manager.updateSettings).toHaveBeenCalledWith(plugin.settings);
+	});
+
+	it('primes saved recordings for enhanced player rendering', async () => {
+		const { plugin } = createPlugin([null]);
+
+		await onloadWithTimers(plugin);
+
+		const { RecordingManager } = jest.requireMock(
+			'../../src/recording/RecordingManager',
+		);
+		const onRecordingSaved = (RecordingManager as jest.Mock).mock
+			.calls[0][4] as (result: {
+			audioPaths: string[];
+			notePath: string | null;
+		}) => void;
+		const { EnhancedPlayerRegistrar } = jest.requireMock(
+			'../../src/player/EnhancedPlayerRegistrar',
+		);
+		const registrar = (EnhancedPlayerRegistrar as jest.Mock).mock.results[0]
+			.value as {
+			primeSavedRecordingsForEnhancement: jest.Mock;
+		};
+
+		onRecordingSaved({
+			audioPaths: ['recordings/fresh.webm'],
+			notePath: 'notes/daily.md',
+		});
+
+		expect(
+			registrar.primeSavedRecordingsForEnhancement,
+		).toHaveBeenCalledWith(['recordings/fresh.webm'], 'notes/daily.md');
 	});
 
 	it('treats a rejected settings read as a failed read', async () => {


### PR DESCRIPTION
## Summary

Fixes #40.

Fresh recordings could stay on Obsidian's native embed when the enhanced player was enabled. The first render path was too dependent on Obsidian creating a native embed and on `metadataCache` indexing the just-inserted `![[recording.ext]]` link quickly enough.

## Changes

- Add post-save enhanced-player priming from `AudioRecorderPlugin.handleRecordingSaved` using the saved `audioPaths` and target `notePath`.
- Probe freshly saved recording files immediately, then directly rebuild the note that received the embed once the file is confirmed audio-only.
- Keep the metadataCache-scoped rerender path and bounded retry fallback for embeds that are not inserted by the recording pipeline.
- Add regression coverage for saved-recording priming without waiting for a native embed render.

## Validation

- User runtime check: fresh recording now upgrades to the enhanced player immediately after stop.
- `npm test -- EnhancedPlayerRegistrar.test.ts main.test.ts` (34 tests)
- `npm test` (69 suites, 1105 tests)
- `npm run lint`
- `npm run build`