### PR TITLE
feat(transcription): add minimizable transcription progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,10 @@ Most options also appear in the **Transcribe audio** dialog, so you can choose t
 - **In-note formatting** is fully configurable: a **note heading**, toggles for timestamps and speakers, and three templates — **timestamp format** (`{time}`), **speaker format** (`{speaker}`), and **line format** (`{timestamp} {speaker} {text}`).
 - **Timestamps as player links**: each timestamp can be a `#t=` link that jumps the [enhanced player](#enhanced-audio-player) to that position — click a line to hear it.
 
+### Progress and minimizing
+
+While a transcription runs, the dialog shows a progress bar and a **Cancel** button. Transcription can be slow and may be a paid API call, so you do not have to wait on the open dialog: click **Minimize** to send the job to the status bar and keep working. The status bar then shows live transcription progress; click it (or focus it and press Enter) to reopen the dialog. Recording always takes precedence in the status bar, so the transcription progress reappears once recording finishes. Closing the dialog (instead of minimizing) cancels the running job.
+
 ### LLM post-processing
 
 Optionally pass the transcript through an LLM to **clean up** punctuation/formatting (preserving wording, timestamps, and speakers), **summarize** it into key points and action items, or apply a **custom instruction**. Providers:

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,13 +29,18 @@ import {
 	EncodingWorkerClient,
 	setEncodingWorkerClient,
 } from './recording/EncodingWorkerClient';
-import { updateStatusBar, initializeStatusBar } from './ui/StatusBar';
+import {
+	updateStatusBar,
+	initializeStatusBar,
+	renderTranscriptionStatusBar,
+} from './ui/StatusBar';
 import { updateRibbonIcon, initializeRibbonIcon } from './ui/RibbonIcon';
 import { showDeviceSelectionModal } from './ui/DeviceSelectionModal';
 import { ContextMenu } from './ui/ContextMenu';
 import { EnhancedPlayerRegistrar } from './player/EnhancedPlayerRegistrar';
 import { MarkerStore } from './player/markers/MarkerStore';
 import { TranscriptionModal } from './ui/TranscriptionModal';
+import type { TranscriptionModalOptions } from './ui/TranscriptionModal';
 import { AUDIO_EXTENSIONS } from './constants';
 import { delay } from './utils/TimeUtils';
 
@@ -73,6 +78,15 @@ interface StoredSettingsReadResult {
 }
 
 /**
+ * Status-bar state owned by a minimized transcription modal.
+ */
+interface BackgroundTranscriptionProgress {
+	id: number;
+	progress: SaveProgress;
+	restore: () => void;
+}
+
+/**
  * Advanced Audio Recorder plugin for Obsidian.
  */
 export default class AudioRecorderPlugin extends Plugin {
@@ -84,6 +98,11 @@ export default class AudioRecorderPlugin extends Plugin {
 	private playerRegistrar!: EnhancedPlayerRegistrar;
 	private journal!: SessionJournal;
 	private encodingWorker: EncodingWorkerClient | null = null;
+	private recordingStatus: RecordingStatus = RecordingStatus.Idle;
+	private recordingSaveProgress: SaveProgress | undefined;
+	private backgroundTranscriptionProgress: BackgroundTranscriptionProgress | null =
+		null;
+	private nextBackgroundTranscriptionId = 0;
 	/**
 	 * True when data.json exists on disk but could not be read at load
 	 * time. While set, saveSettings refuses to write so the possibly
@@ -120,13 +139,12 @@ export default class AudioRecorderPlugin extends Plugin {
 			this.app,
 			this.settings,
 			(status: RecordingStatus, saveProgress?: SaveProgress) => {
-				const controls = this.buildRecordingControls(status);
-				updateStatusBar(
-					this.statusBarItem,
-					status,
-					saveProgress,
-					controls,
-				);
+				this.recordingStatus = status;
+				this.recordingSaveProgress =
+					status === RecordingStatus.Saving
+						? saveProgress
+						: undefined;
+				this.renderStatusBar();
 				updateRibbonIcon(this.ribbonIconEl, status);
 			},
 			this.journal,
@@ -146,7 +164,12 @@ export default class AudioRecorderPlugin extends Plugin {
 		);
 		this.setupStatusBar();
 
-		this.contextMenu = new ContextMenu(this.app, this, () => this.settings);
+		this.contextMenu = new ContextMenu(
+			this.app,
+			this,
+			() => this.settings,
+			() => this.createTranscriptionModalOptions(),
+		);
 		this.contextMenu.register();
 
 		this.playerRegistrar = new EnhancedPlayerRegistrar(
@@ -565,6 +588,7 @@ export default class AudioRecorderPlugin extends Plugin {
 						this.app,
 						file,
 						() => this.settings,
+						this.createTranscriptionModalOptions(),
 					).open();
 				}
 				return true;
@@ -610,9 +634,67 @@ export default class AudioRecorderPlugin extends Plugin {
 		// writes the configured outputs (with a file fallback when the note is
 		// not editable).
 		new TranscriptionModal(this.app, file, () => this.settings, {
+			...this.createTranscriptionModalOptions(),
 			autoStart: true,
 			notePath: result.notePath ?? undefined,
 		}).open();
+	}
+
+	/**
+	 * Creates modal options that let a minimized transcription report progress
+	 * in this plugin's status bar.
+	 * @returns Transcription modal options
+	 */
+	private createTranscriptionModalOptions(): TranscriptionModalOptions {
+		const id = ++this.nextBackgroundTranscriptionId;
+		return {
+			backgroundProgress: {
+				show: (progress: SaveProgress, restore: () => void) => {
+					this.backgroundTranscriptionProgress = {
+						id,
+						progress,
+						restore,
+					};
+					this.renderStatusBar();
+				},
+				clear: () => {
+					if (this.backgroundTranscriptionProgress?.id !== id) {
+						return;
+					}
+					this.backgroundTranscriptionProgress = null;
+					this.renderStatusBar();
+				},
+			},
+		};
+	}
+
+	/**
+	 * Renders the shared status bar. Recording states take precedence over
+	 * minimized transcription progress because they carry recording controls.
+	 */
+	private renderStatusBar(): void {
+		if (
+			this.recordingStatus === RecordingStatus.Idle &&
+			this.backgroundTranscriptionProgress
+		) {
+			renderTranscriptionStatusBar(
+				this.statusBarItem,
+				this.backgroundTranscriptionProgress.progress,
+				{
+					onActivate: this.backgroundTranscriptionProgress.restore,
+					activationLabel: 'Restore transcription window',
+				},
+			);
+			return;
+		}
+
+		const controls = this.buildRecordingControls(this.recordingStatus);
+		updateStatusBar(
+			this.statusBarItem,
+			this.recordingStatus,
+			this.recordingSaveProgress,
+			controls,
+		);
 	}
 
 	/**

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,6 +53,9 @@ const SETTINGS_DATA_FILE = 'data.json';
 /** Backup file name for settings, stored next to data.json. */
 const SETTINGS_BACKUP_FILE = 'data.json.bak';
 
+/** Accessible label for the status-bar action that reopens a minimized transcription. */
+const RESTORE_TRANSCRIPTION_LABEL = 'Restore transcription window';
+
 /**
  * Result of reading the stored settings from disk.
  */
@@ -78,10 +81,10 @@ interface StoredSettingsReadResult {
 }
 
 /**
- * Status-bar state owned by a minimized transcription modal.
+ * Status-bar state owned by a minimized transcription modal. The owning
+ * modal id is the map key, so it is not repeated here.
  */
 interface BackgroundTranscriptionProgress {
-	id: number;
 	progress: SaveProgress;
 	restore: () => void;
 }
@@ -100,8 +103,16 @@ export default class AudioRecorderPlugin extends Plugin {
 	private encodingWorker: EncodingWorkerClient | null = null;
 	private recordingStatus: RecordingStatus = RecordingStatus.Idle;
 	private recordingSaveProgress: SaveProgress | undefined;
-	private backgroundTranscriptionProgress: BackgroundTranscriptionProgress | null =
-		null;
+	/**
+	 * Minimized transcriptions reporting progress in the status bar, keyed by
+	 * a per-modal id. Insertion order is preserved, so the most recently
+	 * updated job is the one rendered; clearing it falls back to the previous
+	 * still-minimized job instead of blanking the bar.
+	 */
+	private backgroundTranscriptions = new Map<
+		number,
+		BackgroundTranscriptionProgress
+	>();
 	private nextBackgroundTranscriptionId = 0;
 	/**
 	 * True when data.json exists on disk but could not be read at load
@@ -650,22 +661,38 @@ export default class AudioRecorderPlugin extends Plugin {
 		return {
 			backgroundProgress: {
 				show: (progress: SaveProgress, restore: () => void) => {
-					this.backgroundTranscriptionProgress = {
-						id,
+					// Re-insert so the most recently updated job sorts last and
+					// becomes the rendered one, even when several are minimized.
+					this.backgroundTranscriptions.delete(id);
+					this.backgroundTranscriptions.set(id, {
 						progress,
 						restore,
-					};
+					});
 					this.renderStatusBar();
 				},
 				clear: () => {
-					if (this.backgroundTranscriptionProgress?.id !== id) {
-						return;
+					if (this.backgroundTranscriptions.delete(id)) {
+						this.renderStatusBar();
 					}
-					this.backgroundTranscriptionProgress = null;
-					this.renderStatusBar();
 				},
 			},
 		};
+	}
+
+	/**
+	 * Returns the minimized transcription that should currently occupy the
+	 * status bar (the most recently updated one), or undefined when none are
+	 * minimized.
+	 * @returns The active background transcription, if any
+	 */
+	private activeBackgroundTranscription():
+		| BackgroundTranscriptionProgress
+		| undefined {
+		let active: BackgroundTranscriptionProgress | undefined;
+		for (const entry of this.backgroundTranscriptions.values()) {
+			active = entry;
+		}
+		return active;
 	}
 
 	/**
@@ -673,18 +700,12 @@ export default class AudioRecorderPlugin extends Plugin {
 	 * minimized transcription progress because they carry recording controls.
 	 */
 	private renderStatusBar(): void {
-		if (
-			this.recordingStatus === RecordingStatus.Idle &&
-			this.backgroundTranscriptionProgress
-		) {
-			renderTranscriptionStatusBar(
-				this.statusBarItem,
-				this.backgroundTranscriptionProgress.progress,
-				{
-					onActivate: this.backgroundTranscriptionProgress.restore,
-					activationLabel: 'Restore transcription window',
-				},
-			);
+		const active = this.activeBackgroundTranscription();
+		if (this.recordingStatus === RecordingStatus.Idle && active) {
+			renderTranscriptionStatusBar(this.statusBarItem, active.progress, {
+				onActivate: active.restore,
+				activationLabel: RESTORE_TRANSCRIPTION_LABEL,
+			});
 			return;
 		}
 

--- a/src/ui/ContextMenu.ts
+++ b/src/ui/ContextMenu.ts
@@ -23,6 +23,7 @@ import { AudioFileInfoModal } from './AudioFileInfoModal';
 import { ConversionModal } from './ConversionModal';
 import { SplitModal } from './SplitModal';
 import { TranscriptionModal } from './TranscriptionModal';
+import type { TranscriptionModalOptions } from './TranscriptionModal';
 import type { AudioRecorderSettings } from '../settings/Settings';
 
 /** CodeMirror view attached to Editor (internal Obsidian API). */
@@ -55,11 +56,13 @@ export class ContextMenu {
 	 * @param app - The Obsidian App instance.
 	 * @param plugin - The plugin instance.
 	 * @param getSettings - Returns current plugin settings.
+	 * @param createTranscriptionModalOptions - Builds per-modal transcription options.
 	 */
 	constructor(
 		private app: App,
 		private plugin: Plugin,
 		private getSettings: () => AudioRecorderSettings,
+		private createTranscriptionModalOptions: () => TranscriptionModalOptions = () => ({}),
 	) {}
 
 	/**
@@ -334,6 +337,7 @@ export class ContextMenu {
 						this.app,
 						file,
 						this.getSettings,
+						this.createTranscriptionModalOptions(),
 					).open();
 				});
 		});

--- a/src/ui/StatusBar.ts
+++ b/src/ui/StatusBar.ts
@@ -125,8 +125,8 @@ function renderSavingState(el: HTMLElement, saveProgress?: SaveProgress): void {
 }
 
 /**
- * Renders a minimized transcription job in the status bar. Double-clicking
- * the progress surface or focusing it and pressing Enter/Space restores the
+ * Renders a minimized transcription job in the status bar. Clicking the
+ * progress surface or focusing it and pressing Enter/Space restores the
  * transcription modal.
  * @param statusBarItem - The status bar HTML element
  * @param progress - Current transcription progress
@@ -179,8 +179,11 @@ function renderProgressState(
 		wrapper.setAttribute('role', 'button');
 		wrapper.setAttribute('aria-label', options.activationLabel);
 		wrapper.tabIndex = 0;
-		wrapper.addEventListener('dblclick', (event: MouseEvent) => {
-			event.preventDefault();
+		// Single click matches the sibling recording controls and the
+		// role="button" semantics; stop propagation so the surrounding status
+		// bar item does not also react.
+		wrapper.addEventListener('click', (event: MouseEvent) => {
+			event.stopPropagation();
 			options.onActivate();
 		});
 		wrapper.addEventListener('keydown', (event: KeyboardEvent) => {

--- a/src/ui/StatusBar.ts
+++ b/src/ui/StatusBar.ts
@@ -8,6 +8,16 @@ import { RecordingStatus } from '../types';
 import type { SaveProgress, RecordingControls } from '../types';
 
 /**
+ * Options for an interactive background progress indicator.
+ */
+export type BackgroundProgressOptions = {
+	/** Restores the hidden UI associated with the background task. */
+	onActivate: () => void;
+	/** Accessible label for the restore action. */
+	activationLabel: string;
+};
+
+/**
  * Updates the status bar element based on recording status.
  * Uses Obsidian's extended HTMLElement methods.
  * @param statusBarItem - The status bar HTML element
@@ -56,6 +66,7 @@ function renderRecordingState(
 	el.empty();
 	el.classList.add('is-recording');
 	el.classList.remove('is-saving');
+	el.classList.remove('is-transcribing');
 
 	const container = el.createDiv({ cls: 'aar-recording-controls' });
 	const text = container.createSpan({ cls: 'aar-recording-label' });
@@ -110,20 +121,87 @@ function createControlButton(
  * @param saveProgress - Optional save progress info
  */
 function renderSavingState(el: HTMLElement, saveProgress?: SaveProgress): void {
+	renderProgressState(el, saveProgress, 'is-saving', 'Saving...');
+}
+
+/**
+ * Renders a minimized transcription job in the status bar. Double-clicking
+ * the progress surface or focusing it and pressing Enter/Space restores the
+ * transcription modal.
+ * @param statusBarItem - The status bar HTML element
+ * @param progress - Current transcription progress
+ * @param options - Restore action metadata
+ */
+export function renderTranscriptionStatusBar(
+	statusBarItem: HTMLElement | null,
+	progress: SaveProgress,
+	options: BackgroundProgressOptions,
+): void {
+	if (!statusBarItem) {
+		return;
+	}
+	renderProgressState(
+		statusBarItem,
+		progress,
+		'is-transcribing',
+		'Transcribing...',
+		options,
+	);
+}
+
+/**
+ * Renders a compact progress indicator in the status bar.
+ * @param el - The status bar HTML element
+ * @param progress - Optional progress info
+ * @param stateClass - CSS class for the active state
+ * @param defaultDescription - Fallback text
+ * @param options - Optional restore action metadata
+ */
+function renderProgressState(
+	el: HTMLElement,
+	progress: SaveProgress | undefined,
+	stateClass: 'is-saving' | 'is-transcribing',
+	defaultDescription: string,
+	options?: BackgroundProgressOptions,
+): void {
 	el.empty();
 	el.classList.remove('is-recording');
-	el.classList.add('is-saving');
+	el.classList.remove('is-saving');
+	el.classList.remove('is-transcribing');
+	el.classList.add(stateClass);
 
-	const text = el.createSpan();
-	text.textContent = saveProgress?.description ?? 'Saving...';
+	const wrapper = el.createDiv({
+		cls: options
+			? 'aar-status-progress-content aar-status-progress-actionable'
+			: 'aar-status-progress-content',
+	});
+	if (options) {
+		wrapper.setAttribute('role', 'button');
+		wrapper.setAttribute('aria-label', options.activationLabel);
+		wrapper.tabIndex = 0;
+		wrapper.addEventListener('dblclick', (event: MouseEvent) => {
+			event.preventDefault();
+			options.onActivate();
+		});
+		wrapper.addEventListener('keydown', (event: KeyboardEvent) => {
+			if (event.key !== 'Enter' && event.key !== ' ') {
+				return;
+			}
+			event.preventDefault();
+			options.onActivate();
+		});
+	}
 
-	const progressContainer = el.createDiv({
+	const text = wrapper.createSpan();
+	text.textContent = progress?.description ?? defaultDescription;
+
+	const progressContainer = wrapper.createDiv({
 		cls: 'aar-save-progress',
 	});
 	const progressBar = progressContainer.createDiv({
 		cls: 'aar-save-progress-bar',
 	});
-	const percent = saveProgress?.percent ?? 0;
+	const percent = progress?.percent ?? 0;
 	progressBar.setCssProps({
 		'--save-progress': `${String(percent)}%`,
 	});
@@ -138,6 +216,7 @@ function renderIdleState(el: HTMLElement): void {
 	el.textContent = '';
 	el.classList.remove('is-recording');
 	el.classList.remove('is-saving');
+	el.classList.remove('is-transcribing');
 }
 
 /**

--- a/src/ui/TranscriptionModal.ts
+++ b/src/ui/TranscriptionModal.ts
@@ -36,6 +36,26 @@ import {
 	TranscriptionCancelledError,
 	type CancellationToken,
 } from '../transcription/TranscriptionService';
+import type { SaveProgress } from '../types';
+
+/**
+ * Callbacks used when the modal is minimized while transcription continues.
+ */
+export type TranscriptionBackgroundProgressCallbacks = {
+	/** Shows or updates the status-bar progress entry. */
+	show: (progress: SaveProgress, restore: () => void) => void;
+	/** Removes the status-bar progress entry owned by this modal. */
+	clear: () => void;
+};
+
+/**
+ * Options for a transcription modal instance.
+ */
+export type TranscriptionModalOptions = {
+	autoStart?: boolean;
+	notePath?: string;
+	backgroundProgress?: TranscriptionBackgroundProgressCallbacks;
+};
 
 /**
  * Transcription dialog for a single audio file.
@@ -47,7 +67,14 @@ export class TranscriptionModal extends Modal {
 	private progressFillEl: HTMLElement | null = null;
 	private configEl: HTMLElement | null = null;
 	private runButton: ButtonComponent | null = null;
+	private minimizeButton: ButtonComponent | null = null;
 	private secondaryButton: ButtonComponent | null = null;
+	private rendered = false;
+	private minimized = false;
+	private lastProgress: SaveProgress = {
+		percent: 0,
+		description: 'Transcribing...',
+	};
 	/** Per-run settings copy: edited here, never persisted to plugin data. */
 	private readonly runSettings: AudioRecorderSettings;
 	/**
@@ -61,10 +88,7 @@ export class TranscriptionModal extends Modal {
 		app: App,
 		private readonly file: TFile,
 		getSettings: () => AudioRecorderSettings,
-		private readonly options: {
-			autoStart?: boolean;
-			notePath?: string;
-		} = {},
+		private readonly options: TranscriptionModalOptions = {},
 	) {
 		super(app);
 		// Shallow copy is enough: every option edited here is a primitive.
@@ -86,6 +110,12 @@ export class TranscriptionModal extends Modal {
 	}
 
 	onOpen(): void {
+		if (this.rendered) {
+			this.minimized = false;
+			this.clearBackgroundProgress();
+			return;
+		}
+
 		const { contentEl } = this;
 		contentEl.empty();
 		new Setting(contentEl).setName('Transcribe audio').setHeading();
@@ -117,6 +147,15 @@ export class TranscriptionModal extends Modal {
 					});
 			})
 			.addButton((button) => {
+				this.minimizeButton = button;
+				button
+					.setButtonText('Minimize')
+					.setDisabled(true)
+					.onClick(() => {
+						this.minimize();
+					});
+			})
+			.addButton((button) => {
 				this.secondaryButton = button;
 				button.setButtonText('Close').onClick(() => {
 					if (this.running) {
@@ -126,6 +165,8 @@ export class TranscriptionModal extends Modal {
 					}
 				});
 			});
+
+		this.rendered = true;
 
 		if (this.options.autoStart) {
 			// Auto-run for the transcribe-on-save hook: the modal still shows
@@ -248,6 +289,7 @@ export class TranscriptionModal extends Modal {
 			return;
 		}
 		this.setRunning(true);
+		this.updateProgress(0, 'Transcribing...');
 		// Snapshot the options so a control toggled mid-run cannot change an
 		// in-flight job; edits only affect the next attempt after a failure.
 		const settings = { ...this.runSettings };
@@ -260,7 +302,15 @@ export class TranscriptionModal extends Modal {
 					this.updateProgress(fraction, label);
 				},
 			});
-			this.close();
+			this.setRunning(false);
+			this.clearBackgroundProgress();
+			if (this.minimized) {
+				this.minimized = false;
+				this.contentEl.empty();
+				this.rendered = false;
+			} else {
+				this.close();
+			}
 		} catch (error) {
 			if (error instanceof TranscriptionCancelledError) {
 				new Notice('Transcription cancelled.');
@@ -271,8 +321,14 @@ export class TranscriptionModal extends Modal {
 				new Notice(`Transcription failed: ${message}`);
 				this.statusEl?.setText(`Failed: ${message}`);
 			}
+			if (this.minimized) {
+				this.restore();
+			}
 		} finally {
-			this.setRunning(false);
+			if (this.running) {
+				this.setRunning(false);
+			}
+			this.clearBackgroundProgress();
 		}
 	}
 
@@ -288,6 +344,7 @@ export class TranscriptionModal extends Modal {
 			this.cancelled = false;
 		}
 		this.runButton?.setDisabled(running);
+		this.minimizeButton?.setDisabled(!running);
 		this.secondaryButton?.setButtonText(running ? 'Cancel' : 'Close');
 		this.configEl?.toggleClass('aar-transcribe-options-disabled', running);
 	}
@@ -301,13 +358,66 @@ export class TranscriptionModal extends Modal {
 			const percent = Math.round(
 				Math.max(0, Math.min(1, fraction)) * 100,
 			);
+			this.lastProgress = { percent, description: label };
 			this.progressFillEl.setCssProps({
 				'--aar-transcribe-progress': `${String(percent)}%`,
 			});
+			this.reportBackgroundProgress();
 		}
 	}
 
+	/**
+	 * Minimizes the modal while keeping the current transcription running.
+	 */
+	private minimize(): void {
+		if (!this.running || this.minimized) {
+			return;
+		}
+		this.minimized = true;
+		this.reportBackgroundProgress();
+		this.close();
+	}
+
+	/**
+	 * Restores a minimized modal.
+	 */
+	private restore(): void {
+		if (!this.minimized) {
+			return;
+		}
+		this.minimized = false;
+		this.clearBackgroundProgress();
+		this.open();
+	}
+
+	/**
+	 * Publishes the latest progress to the status bar while minimized.
+	 */
+	private reportBackgroundProgress(): void {
+		if (!this.minimized) {
+			return;
+		}
+		this.options.backgroundProgress?.show(this.lastProgress, () => {
+			this.restore();
+		});
+	}
+
+	/**
+	 * Clears this modal's background progress entry.
+	 */
+	private clearBackgroundProgress(): void {
+		this.options.backgroundProgress?.clear();
+	}
+
 	onClose(): void {
+		if (this.minimized && this.running) {
+			return;
+		}
+		if (this.running) {
+			this.cancelled = true;
+		}
+		this.clearBackgroundProgress();
 		this.contentEl.empty();
+		this.rendered = false;
 	}
 }

--- a/src/ui/TranscriptionModal.ts
+++ b/src/ui/TranscriptionModal.ts
@@ -38,6 +38,9 @@ import {
 } from '../transcription/TranscriptionService';
 import type { SaveProgress } from '../types';
 
+/** Default status label shown before the engine reports a finer-grained stage. */
+const DEFAULT_TRANSCRIBE_LABEL = 'Transcribing...';
+
 /**
  * Callbacks used when the modal is minimized while transcription continues.
  */
@@ -73,7 +76,7 @@ export class TranscriptionModal extends Modal {
 	private minimized = false;
 	private lastProgress: SaveProgress = {
 		percent: 0,
-		description: 'Transcribing...',
+		description: DEFAULT_TRANSCRIBE_LABEL,
 	};
 	/** Per-run settings copy: edited here, never persisted to plugin data. */
 	private readonly runSettings: AudioRecorderSettings;
@@ -289,7 +292,7 @@ export class TranscriptionModal extends Modal {
 			return;
 		}
 		this.setRunning(true);
-		this.updateProgress(0, 'Transcribing...');
+		this.updateProgress(0, DEFAULT_TRANSCRIBE_LABEL);
 		// Snapshot the options so a control toggled mid-run cannot change an
 		// in-flight job; edits only affect the next attempt after a failure.
 		const settings = { ...this.runSettings };

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -37,6 +37,12 @@ If your plugin does not need CSS, delete this file.
     white-space: nowrap;
 }
 
+.is-transcribing {
+    color: var(--color-accent);
+    font-weight: bold;
+    white-space: nowrap;
+}
+
 .side-dock-ribbon-action.is-saving svg {
     color: var(--color-accent);
     animation: pulse-saving 1.5s ease-in-out infinite;
@@ -83,6 +89,20 @@ If your plugin does not need CSS, delete this file.
 }
 
 /* Save progress */
+.aar-status-progress-content {
+    width: 100%;
+}
+
+.aar-status-progress-actionable {
+    cursor: pointer;
+}
+
+.aar-status-progress-actionable:focus-visible {
+    outline: 1px solid var(--color-accent);
+    outline-offset: 2px;
+    border-radius: 3px;
+}
+
 .aar-save-progress {
     height: 3px;
     width: 100%;

--- a/tests/unit/StatusBar.test.ts
+++ b/tests/unit/StatusBar.test.ts
@@ -244,7 +244,7 @@ describe('StatusBar', () => {
 			);
 		});
 
-		it('should restore transcription on double click', () => {
+		it('should restore transcription on a single click', () => {
 			const onActivate = jest.fn();
 			renderTranscriptionStatusBar(
 				statusBarItem,
@@ -261,11 +261,35 @@ describe('StatusBar', () => {
 			const action = statusBarItem.querySelector(
 				'.aar-status-progress-actionable',
 			);
+			action?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+			expect(onActivate).toHaveBeenCalledTimes(1);
+		});
+
+		it('should not restore transcription on a double click only', () => {
+			const onActivate = jest.fn();
+			renderTranscriptionStatusBar(
+				statusBarItem,
+				{
+					percent: 10,
+					description: 'Transcribing...',
+				},
+				{
+					onActivate,
+					activationLabel: 'Restore transcription window',
+				},
+			);
+
+			const action = statusBarItem.querySelector(
+				'.aar-status-progress-actionable',
+			);
+			// A bare dblclick event no longer triggers the restore; only the
+			// click events a real double click also fires would.
 			action?.dispatchEvent(
 				new MouseEvent('dblclick', { bubbles: true }),
 			);
 
-			expect(onActivate).toHaveBeenCalledTimes(1);
+			expect(onActivate).not.toHaveBeenCalled();
 		});
 
 		it('should restore transcription from keyboard activation', () => {

--- a/tests/unit/StatusBar.test.ts
+++ b/tests/unit/StatusBar.test.ts
@@ -5,7 +5,11 @@
  */
 /** @jest-environment jsdom */
 
-import { updateStatusBar, initializeStatusBar } from '../../src/ui/StatusBar';
+import {
+	updateStatusBar,
+	initializeStatusBar,
+	renderTranscriptionStatusBar,
+} from '../../src/ui/StatusBar';
 import { RecordingStatus } from '../../src/types';
 import type { RecordingControls } from '../../src/types';
 
@@ -173,6 +177,27 @@ describe('StatusBar', () => {
 			expect(statusBarItem.textContent).toContain('Recording...');
 		});
 
+		it('should clear transcription state when transitioning to recording', () => {
+			renderTranscriptionStatusBar(
+				statusBarItem,
+				{
+					percent: 50,
+					description: 'Transcribing audio...',
+				},
+				{
+					onActivate: jest.fn(),
+					activationLabel: 'Restore transcription window',
+				},
+			);
+
+			updateStatusBar(statusBarItem, RecordingStatus.Recording);
+
+			expect(statusBarItem.classList.contains('is-transcribing')).toBe(
+				false,
+			);
+			expect(statusBarItem.textContent).toContain('Recording...');
+		});
+
 		it('should handle default case same as idle', () => {
 			statusBarItem.classList.add('is-recording');
 
@@ -182,6 +207,98 @@ describe('StatusBar', () => {
 			expect(statusBarItem.classList.contains('is-recording')).toBe(
 				false,
 			);
+		});
+	});
+
+	describe('transcription progress', () => {
+		it('should show minimized transcription progress in the status bar', () => {
+			renderTranscriptionStatusBar(
+				statusBarItem,
+				{
+					percent: 35,
+					description: 'Transcribing chunk 1...',
+				},
+				{
+					onActivate: jest.fn(),
+					activationLabel: 'Restore transcription window',
+				},
+			);
+
+			expect(statusBarItem.classList.contains('is-transcribing')).toBe(
+				true,
+			);
+			expect(statusBarItem.classList.contains('is-recording')).toBe(
+				false,
+			);
+			expect(statusBarItem.classList.contains('is-saving')).toBe(false);
+			expect(statusBarItem.textContent).toContain(
+				'Transcribing chunk 1...',
+			);
+
+			const progressBar = statusBarItem.querySelector(
+				'.aar-save-progress-bar',
+			) as HTMLElement;
+			expect(progressBar).not.toBeNull();
+			expect(progressBar.style.getPropertyValue('--save-progress')).toBe(
+				'35%',
+			);
+		});
+
+		it('should restore transcription on double click', () => {
+			const onActivate = jest.fn();
+			renderTranscriptionStatusBar(
+				statusBarItem,
+				{
+					percent: 10,
+					description: 'Transcribing...',
+				},
+				{
+					onActivate,
+					activationLabel: 'Restore transcription window',
+				},
+			);
+
+			const action = statusBarItem.querySelector(
+				'.aar-status-progress-actionable',
+			);
+			action?.dispatchEvent(
+				new MouseEvent('dblclick', { bubbles: true }),
+			);
+
+			expect(onActivate).toHaveBeenCalledTimes(1);
+		});
+
+		it('should restore transcription from keyboard activation', () => {
+			const onActivate = jest.fn();
+			renderTranscriptionStatusBar(
+				statusBarItem,
+				{
+					percent: 10,
+					description: 'Transcribing...',
+				},
+				{
+					onActivate,
+					activationLabel: 'Restore transcription window',
+				},
+			);
+
+			const action = statusBarItem.querySelector(
+				'.aar-status-progress-actionable',
+			);
+			action?.dispatchEvent(
+				new KeyboardEvent('keydown', {
+					key: 'Enter',
+					bubbles: true,
+				}),
+			);
+			action?.dispatchEvent(
+				new KeyboardEvent('keydown', {
+					key: ' ',
+					bubbles: true,
+				}),
+			);
+
+			expect(onActivate).toHaveBeenCalledTimes(2);
 		});
 	});
 

--- a/tests/unit/TranscriptionModal.test.ts
+++ b/tests/unit/TranscriptionModal.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Unit tests for TranscriptionModal background/minimize behavior.
+ * @module tests/unit/TranscriptionModal.test
+ */
+/** @jest-environment jsdom */
+
+import { App, TFile } from 'obsidian';
+import { DEFAULT_SETTINGS } from '../../src/settings/Settings';
+import { TranscriptionModal } from '../../src/ui/TranscriptionModal';
+import type { AudioRecorderSettings } from '../../src/settings/Settings';
+
+type TranscriptionModalInternals = {
+	setRunning: (running: boolean) => void;
+	updateProgress: (fraction: number, label: string) => void;
+	minimize: () => void;
+	restore: () => void;
+	cancelled: boolean;
+	minimized: boolean;
+};
+
+function createAudioFile(): TFile {
+	const file = new TFile('Audio/meeting.webm');
+	Object.defineProperty(file, 'name', { value: 'meeting.webm' });
+	return file;
+}
+
+function getSettings(): AudioRecorderSettings {
+	return { ...DEFAULT_SETTINGS };
+}
+
+function createModal(callbacks: {
+	show: jest.Mock;
+	clear: jest.Mock;
+}): TranscriptionModal {
+	return new TranscriptionModal(new App(), createAudioFile(), getSettings, {
+		backgroundProgress: callbacks,
+	});
+}
+
+describe('TranscriptionModal minimize behavior', () => {
+	it('publishes status-bar progress without cancelling the running job', () => {
+		const callbacks = {
+			show: jest.fn(),
+			clear: jest.fn(),
+		};
+		const modal = createModal(callbacks);
+		const internals = modal as unknown as TranscriptionModalInternals;
+
+		modal.onOpen();
+		internals.setRunning(true);
+		internals.updateProgress(0.42, 'Uploading audio...');
+		internals.minimize();
+		modal.onClose();
+
+		expect(callbacks.show).toHaveBeenCalledWith(
+			{
+				percent: 42,
+				description: 'Uploading audio...',
+			},
+			expect.any(Function),
+		);
+		expect(callbacks.clear).not.toHaveBeenCalled();
+		expect(internals.cancelled).toBe(false);
+		expect(internals.minimized).toBe(true);
+		expect(modal.contentEl.textContent).toContain('Source: meeting.webm');
+	});
+
+	it('clears background progress when the minimized modal is restored', () => {
+		const callbacks = {
+			show: jest.fn(),
+			clear: jest.fn(),
+		};
+		const modal = createModal(callbacks);
+		const internals = modal as unknown as TranscriptionModalInternals;
+
+		modal.onOpen();
+		internals.setRunning(true);
+		internals.updateProgress(0.25, 'Transcribing chunk...');
+		internals.minimize();
+
+		const lastShowCall =
+			callbacks.show.mock.calls[callbacks.show.mock.calls.length - 1];
+		const restore = lastShowCall?.[1] as (() => void) | undefined;
+		restore?.();
+
+		expect(callbacks.clear).toHaveBeenCalledTimes(1);
+		expect(internals.minimized).toBe(false);
+	});
+
+	it('cancels a running transcription when the modal is closed directly', () => {
+		const callbacks = {
+			show: jest.fn(),
+			clear: jest.fn(),
+		};
+		const modal = createModal(callbacks);
+		const internals = modal as unknown as TranscriptionModalInternals;
+
+		modal.onOpen();
+		internals.setRunning(true);
+		modal.onClose();
+
+		expect(internals.cancelled).toBe(true);
+		expect(callbacks.clear).toHaveBeenCalledTimes(1);
+		expect(modal.contentEl.textContent).toBe('');
+	});
+});

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -6,6 +6,8 @@
 import { App } from 'obsidian';
 import AudioRecorderPlugin from '../../src/main';
 import { DEFAULT_SETTINGS } from '../../src/settings/Settings';
+import type { SaveProgress } from '../../src/types';
+import type { TranscriptionModalOptions } from '../../src/ui/TranscriptionModal';
 
 jest.mock('../../src/recording/RecordingManager', () => ({
 	RecordingManager: jest.fn().mockImplementation(() => ({
@@ -567,5 +569,98 @@ describe('AudioRecorderPlugin crash recovery wiring', () => {
 			expect.any(Error),
 		);
 		consoleErrorSpy.mockRestore();
+	});
+});
+
+describe('AudioRecorderPlugin background transcription status bar', () => {
+	beforeEach(() => {
+		jest.useFakeTimers();
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+		jest.clearAllMocks();
+	});
+
+	/** Builds per-modal background-progress callbacks via the private factory. */
+	const buildBackgroundProgress = (
+		plugin: AudioRecorderPlugin,
+	): NonNullable<TranscriptionModalOptions['backgroundProgress']> => {
+		const factory = plugin as unknown as {
+			createTranscriptionModalOptions: () => TranscriptionModalOptions;
+		};
+		const options = factory.createTranscriptionModalOptions();
+		if (!options.backgroundProgress) {
+			throw new Error('Expected background progress callbacks');
+		}
+		return options.backgroundProgress;
+	};
+
+	const progress = (percent: number, description: string): SaveProgress => ({
+		percent,
+		description,
+	});
+
+	it('renders the most recent minimized transcription and falls back when it clears', async () => {
+		const { plugin } = createPlugin([null]);
+		await onloadWithTimers(plugin);
+
+		const { renderTranscriptionStatusBar, updateStatusBar } =
+			jest.requireMock('../../src/ui/StatusBar');
+		(renderTranscriptionStatusBar as jest.Mock).mockClear();
+
+		const first = buildBackgroundProgress(plugin);
+		const second = buildBackgroundProgress(plugin);
+		const restoreFirst = jest.fn();
+		const restoreSecond = jest.fn();
+
+		first.show(progress(10, 'First job'), restoreFirst);
+		second.show(progress(60, 'Second job'), restoreSecond);
+
+		// The most recently updated job occupies the single status-bar slot.
+		expect(renderTranscriptionStatusBar).toHaveBeenLastCalledWith(
+			expect.anything(),
+			progress(60, 'Second job'),
+			expect.objectContaining({ onActivate: restoreSecond }),
+		);
+
+		// Clearing the active job falls back to the other still-minimized job
+		// instead of blanking the bar.
+		second.clear();
+		expect(renderTranscriptionStatusBar).toHaveBeenLastCalledWith(
+			expect.anything(),
+			progress(10, 'First job'),
+			expect.objectContaining({ onActivate: restoreFirst }),
+		);
+
+		// Clearing the last job releases the slot to the idle renderer.
+		(updateStatusBar as jest.Mock).mockClear();
+		first.clear();
+		expect(updateStatusBar).toHaveBeenCalled();
+	});
+
+	it('keeps the active job displayed when a superseded job clears', async () => {
+		const { plugin } = createPlugin([null]);
+		await onloadWithTimers(plugin);
+
+		const { renderTranscriptionStatusBar } = jest.requireMock(
+			'../../src/ui/StatusBar',
+		);
+
+		const first = buildBackgroundProgress(plugin);
+		const second = buildBackgroundProgress(plugin);
+		const restoreSecond = jest.fn();
+
+		first.show(progress(10, 'First job'), jest.fn());
+		second.show(progress(60, 'Second job'), restoreSecond);
+
+		(renderTranscriptionStatusBar as jest.Mock).mockClear();
+		// The earlier job finishes while the later one still owns the slot.
+		first.clear();
+		expect(renderTranscriptionStatusBar).toHaveBeenLastCalledWith(
+			expect.anything(),
+			progress(60, 'Second job'),
+			expect.objectContaining({ onActivate: restoreSecond }),
+		);
 	});
 });

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -36,6 +36,7 @@ jest.mock('../../src/player/EnhancedPlayerRegistrar', () => ({
 jest.mock('../../src/ui/StatusBar', () => ({
 	updateStatusBar: jest.fn(),
 	initializeStatusBar: jest.fn(),
+	renderTranscriptionStatusBar: jest.fn(),
 }));
 
 jest.mock('../../src/ui/RibbonIcon', () => ({


### PR DESCRIPTION
## Summary

Adds a **minimizable transcription progress** flow so a running transcription no longer blocks the UI behind a modal. The progress can be collapsed into the status bar and restored on demand.

## Changes

- **`src/ui/TranscriptionModal.ts`** — modal can be minimized while a transcription is in flight; reopening restores live progress instead of restarting.
- **`src/ui/StatusBar.ts`** — status bar shows ongoing transcription progress and lets the user restore the minimized modal.
- **`src/ui/ContextMenu.ts`** — wiring to surface the minimized transcription.
- **`src/main.ts`** — orchestration between the modal, status bar, and the transcription service lifecycle.
- **`styles/styles.css`** — styling for the status-bar progress / restore affordance.

## Tests

- `tests/unit/StatusBar.test.ts`, `tests/unit/TranscriptionModal.test.ts`, `tests/unit/main.test.ts` updated/added to cover minimize/restore and progress reporting.

## Verification

- `npm test -- --no-coverage` → **70 suites, 1112 tests passed**
- `npm run lint` → clean
- `npm run build` → success

🤖 Generated with [Claude Code](https://claude.com/claude-code)
