### PR TITLE
feat(recording): add markers and chapters during recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ All commands are available via the command palette (`Ctrl/Cmd + P`) and can be a
 |---------|-------------|
 | **Start/stop recording** | Starts a new recording session or stops the current one. The recorded file is saved and a link is inserted into the active note. |
 | **Pause/resume recording** | Pauses an active recording and resumes it. Available only while recording is active. |
+| **Add marker/chapter at current position** | Drops a bookmark or chapter at the live recording position while recording or paused. Available only when **Markers and chapters** is enabled. |
 | **Select audio input device** | Opens a quick device picker modal. The selected device is saved to settings immediately. |
 
 > **Tip:** The plugin does not assign default hotkeys to avoid conflicts. Assign your own hotkeys in **Settings > Hotkeys** for the best experience.
@@ -53,7 +54,11 @@ Click the **microphone icon** in the ribbon or run `Start/stop recording` from t
 
 During recording:
 - The **ribbon icon** changes from a microphone to an active recording indicator.
-- The **status bar** displays `Recording...` with **Pause** and **Stop** buttons.
+- The **status bar** displays `Recording...` with **Pause** and **Stop** buttons. When **Markers and chapters** is enabled, an **Add marker** button appears next to them.
+
+### Marking moments while recording
+
+When **Markers and chapters** is enabled, you can drop a bookmark or chapter at the current position without waiting for playback: click the **Add marker** button in the status bar or run `Add marker/chapter at current position` (available while recording or paused). A small dialog lets you name the marker and pick its kind; the timestamp is **frozen at the moment you triggered it**, so naming never shifts the position. The marker is attached to the recording's sidecar at save and shows up in the enhanced player once the recording stops.
 
 ### Pausing and resuming
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,6 +39,7 @@ import { showDeviceSelectionModal } from './ui/DeviceSelectionModal';
 import { ContextMenu } from './ui/ContextMenu';
 import { EnhancedPlayerRegistrar } from './player/EnhancedPlayerRegistrar';
 import { MarkerStore } from './player/markers/MarkerStore';
+import { RecordingMarkerModal } from './ui/MarkerModal';
 import { TranscriptionModal } from './ui/TranscriptionModal';
 import type { TranscriptionModalOptions } from './ui/TranscriptionModal';
 import { AUDIO_EXTENSIONS } from './constants';
@@ -146,6 +147,10 @@ export default class AudioRecorderPlugin extends Plugin {
 			this.getPluginFilePath(JOURNAL_FILE_NAME),
 			this.app,
 		);
+		// One MarkerStore is shared by recording (which writes live markers
+		// at stop) and the player registrar (which reads/edits them), so
+		// their cache and serialized write chain stay unified.
+		const markerStore = new MarkerStore(this.app);
 		this.recordingManager = new RecordingManager(
 			this.app,
 			this.settings,
@@ -162,6 +167,7 @@ export default class AudioRecorderPlugin extends Plugin {
 			(result: RecordingSaveResult) => {
 				this.handleRecordingSaved(result);
 			},
+			markerStore,
 		);
 
 		this.addSettingTab(new AudioRecorderSettingTab(this.app, this));
@@ -187,7 +193,7 @@ export default class AudioRecorderPlugin extends Plugin {
 			this,
 			this.app,
 			() => this.settings,
-			new MarkerStore(this.app),
+			markerStore,
 		);
 		this.playerRegistrar.register();
 
@@ -570,6 +576,20 @@ export default class AudioRecorderPlugin extends Plugin {
 		});
 
 		this.addCommand({
+			id: 'add-recording-marker',
+			name: 'Add marker/chapter at current position',
+			checkCallback: (checking: boolean) => {
+				if (!this.recordingManager.canDropMarker()) {
+					return false;
+				}
+				if (!checking) {
+					this.openMarkerModal();
+				}
+				return true;
+			},
+		});
+
+		this.addCommand({
 			id: 'select-audio-input-device',
 			name: 'Select audio input device',
 			callback: () => {
@@ -742,7 +762,26 @@ export default class AudioRecorderPlugin extends Plugin {
 				void this.recordingManager.stopRecording();
 			},
 			isPaused: status === RecordingStatus.Paused,
+			// Only offered when markers are enabled, since they are surfaced
+			// solely by the enhanced player; absent hides the status-bar button
+			onAddMarker: this.settings.playerEnableMarkers
+				? () => {
+						this.openMarkerModal();
+					}
+				: undefined,
 		};
+	}
+
+	/**
+	 * Captures a marker at the current recording position and opens the
+	 * naming modal. No-op when a marker cannot be dropped right now.
+	 */
+	private openMarkerModal(): void {
+		const handle = this.recordingManager.captureMarkerDraft();
+		if (!handle) {
+			return;
+		}
+		new RecordingMarkerModal(this.app, handle).open();
 	}
 
 	/**

--- a/src/player/AudioPlayer.ts
+++ b/src/player/AudioPlayer.ts
@@ -56,6 +56,7 @@ import {
 	type MarkerKind,
 	type PlayerMarker,
 } from './markers/markerModel';
+import { defaultMarkerLabel, generateMarkerId } from './markers/markerFactory';
 import { formatPlaybackRate, speedMenuItems } from './playbackRate';
 import { isEditableContext } from './playerMode';
 import {
@@ -91,20 +92,6 @@ const DURATION_PROBE_TIMEOUT_MS = 5000;
  * Obsidian's embed markup), so the player is never left unrendered.
  */
 const EMBED_LOAD_FALLBACK_MS = 400;
-
-/**
- * Generates a short, collision-resistant marker id. Uses crypto.randomUUID
- * when available, falling back to a timestamp-and-random combination.
- */
-function generateMarkerId(): string {
-	const cryptoApi = (
-		activeWindow as Window & { crypto?: { randomUUID?: () => string } }
-	).crypto;
-	if (cryptoApi?.randomUUID) {
-		return cryptoApi.randomUUID();
-	}
-	return `${String(Date.now())}-${Math.random().toString(36).slice(2)}`;
-}
 
 /**
  * Options passed to a player when it is created for an embed.
@@ -1381,13 +1368,7 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 	 */
 	private async addMarkerAt(time: number, kind: MarkerKind): Promise<void> {
 		const safeTime = Math.max(0, time);
-		const sameKindCount = this.markers.filter(
-			(marker) => marker.kind === kind,
-		).length;
-		const label =
-			kind === MARKER_KIND.chapter
-				? `Chapter ${String(sameKindCount + 1)}`
-				: `Marker ${String(sameKindCount + 1)}`;
+		const label = defaultMarkerLabel(this.markers, kind);
 		this.markers = addMarker(this.markers, {
 			id: generateMarkerId(),
 			time: safeTime,

--- a/src/player/markers/markerFactory.ts
+++ b/src/player/markers/markerFactory.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared factory helpers for creating player markers: id generation and
+ * the default label scheme. Living in one module keeps the recording-time
+ * marker capture and the in-player "add marker" action producing identical
+ * ids and labels instead of drifting apart.
+ * @module player/markers/markerFactory
+ */
+
+import { MARKER_KIND, type MarkerKind } from './markerModel';
+
+/**
+ * Generates a short, collision-resistant marker id. Uses crypto.randomUUID
+ * when available, falling back to a timestamp-and-random combination.
+ */
+export function generateMarkerId(): string {
+	const cryptoApi = (
+		activeWindow as Window & { crypto?: { randomUUID?: () => string } }
+	).crypto;
+	if (cryptoApi?.randomUUID) {
+		return cryptoApi.randomUUID();
+	}
+	return `${String(Date.now())}-${Math.random().toString(36).slice(2)}`;
+}
+
+/**
+ * Builds the default label for a new marker of the given kind, numbered
+ * after the existing markers of the same kind (Bookmark/chapter counts are
+ * independent). Accepts anything carrying a `kind` so both PlayerMarker
+ * lists and recording-time drafts can be counted.
+ * @param markers - Existing markers to count by kind
+ * @param kind - Kind of the marker being created
+ */
+export function defaultMarkerLabel(
+	markers: readonly { kind: MarkerKind }[],
+	kind: MarkerKind,
+): string {
+	const sameKindCount = markers.filter(
+		(marker) => marker.kind === kind,
+	).length;
+	return kind === MARKER_KIND.chapter
+		? `Chapter ${String(sameKindCount + 1)}`
+		: `Marker ${String(sameKindCount + 1)}`;
+}

--- a/src/recording/PartRotationController.ts
+++ b/src/recording/PartRotationController.ts
@@ -23,6 +23,10 @@ import {
 import type { TrackWriteQueue } from './TrackWriteQueue';
 import type { RecordingFinalizer } from './RecordingFinalizer';
 import { SessionJournal } from './SessionJournal';
+import {
+	computePartPosition,
+	type PartPosition,
+} from './recordingMarkers';
 
 /**
  * Callbacks into the RecordingManager: recorder lifecycle stays with
@@ -48,6 +52,10 @@ export class PartRotationController {
 	private session: RecordingSessionConfig | null = null;
 	/** Active (unpaused) milliseconds accumulated in the current part. */
 	private partActiveMs = 0;
+	/** Active (unpaused) milliseconds accumulated across the whole session. */
+	private sessionActiveMs = 0;
+	/** Count of completed part rotations (the current part index). */
+	private sessionPartOrdinal = 0;
 	/** Timestamp of the last start/resume/rotation for active-time tracking. */
 	private activeAnchor = 0;
 	/** In-flight MediaRecorder part rotation, if any. */
@@ -94,16 +102,47 @@ export class PartRotationController {
 	beginSession(session: RecordingSessionConfig): void {
 		this.session = session;
 		this.partActiveMs = 0;
+		this.sessionActiveMs = 0;
+		this.sessionPartOrdinal = 0;
 		this.activeAnchor = Date.now();
 		this.rotationPromise = null;
 		this.isStopping = false;
 	}
 
 	/**
-	 * Freezes active-time accounting when the recording is paused.
+	 * Freezes active-time accounting when the recording is paused. Folds the
+	 * elapsed active span into both the per-part and the whole-session
+	 * counters so paused time is excluded from marker positions too.
 	 */
 	markPaused(): void {
-		this.partActiveMs += Date.now() - this.activeAnchor;
+		const elapsed = Date.now() - this.activeAnchor;
+		this.partActiveMs += elapsed;
+		this.sessionActiveMs += elapsed;
+	}
+
+	/**
+	 * Returns the current marker position: the part ordinal that is
+	 * recording now and the offset within it. Derived from the controller's
+	 * own active-time accounting in one synchronous read, so the pair is
+	 * always internally consistent even mid-rotation. The live span since
+	 * the last anchor is added only while actually recording, so a position
+	 * taken during a pause excludes the paused time.
+	 * @param status - Current recording status
+	 */
+	getCurrentPartPosition(status: RecordingStatus): PartPosition {
+		const session = this.session;
+		const liveMs =
+			status === RecordingStatus.Recording
+				? Date.now() - this.activeAnchor
+				: 0;
+		return computePartPosition({
+			isWavPcm: session?.isWavPcm ?? false,
+			splitEnabled: session?.splitEnabled ?? false,
+			partMinutes: session?.partMinutes ?? 0,
+			partActiveMs: this.partActiveMs + liveMs,
+			sessionActiveMs: this.sessionActiveMs + liveMs,
+			sessionPartOrdinal: this.sessionPartOrdinal,
+		});
 	}
 
 	/**
@@ -319,6 +358,11 @@ export class PartRotationController {
 			) {
 				this.hooks.restartRecorders();
 			}
+			// Close out the part that just ended: fold its active span into
+			// the session clock, open a new part, and advance the ordinal so
+			// markers dropped after this point attach to the new part.
+			this.sessionActiveMs += Date.now() - this.activeAnchor;
+			this.sessionPartOrdinal += 1;
 			this.partActiveMs = 0;
 			this.activeAnchor = Date.now();
 		}

--- a/src/recording/PartRotationController.ts
+++ b/src/recording/PartRotationController.ts
@@ -23,10 +23,7 @@ import {
 import type { TrackWriteQueue } from './TrackWriteQueue';
 import type { RecordingFinalizer } from './RecordingFinalizer';
 import { SessionJournal } from './SessionJournal';
-import {
-	computePartPosition,
-	type PartPosition,
-} from './recordingMarkers';
+import { computePartPosition, type PartPosition } from './recordingMarkers';
 
 /**
  * Callbacks into the RecordingManager: recorder lifecycle stays with

--- a/src/recording/RecordingFinalizer.ts
+++ b/src/recording/RecordingFinalizer.ts
@@ -269,7 +269,11 @@ export class RecordingFinalizer {
 				}
 			}
 		} else {
-			for (let trackIndex = 0; trackIndex < targets.length; trackIndex++) {
+			for (
+				let trackIndex = 0;
+				trackIndex < targets.length;
+				trackIndex++
+			) {
 				const target = targets[trackIndex];
 				const paths = await this.finalizeTrackFiles(target);
 				const files = [...target.partPaths, ...paths];

--- a/src/recording/RecordingFinalizer.ts
+++ b/src/recording/RecordingFinalizer.ts
@@ -14,6 +14,7 @@ import type {
 	RecordingSessionConfig,
 	RecordingTarget,
 	SaveProgress,
+	TrackFileGroup,
 } from '../types';
 import type { AudioRecorderSettings } from '../settings/Settings';
 import { PLUGIN_LOG_PREFIX, FORMAT_WAV } from '../constants';
@@ -140,6 +141,7 @@ export class RecordingFinalizer {
 		const effectiveTimestamp =
 			timestamp ?? new Date().toISOString().replace(/[:.]/g, '-');
 		const fileLinks: string[] = [];
+		const trackFiles: TrackFileGroup[] = [];
 
 		this.reportProgress(20, 'Flushing buffers...');
 
@@ -147,7 +149,9 @@ export class RecordingFinalizer {
 			if (targets.length === 1) {
 				const target = targets[0];
 				const paths = await this.finalizeTrackFiles(target);
-				fileLinks.push(...target.partPaths, ...paths);
+				const files = [...target.partPaths, ...paths];
+				fileLinks.push(...files);
+				trackFiles.push({ trackIndex: 0, files });
 			} else {
 				if (!session.isWavPcm) {
 					await Promise.all(
@@ -242,6 +246,9 @@ export class RecordingFinalizer {
 						);
 					}
 					fileLinks.push(filePath);
+					// One merged file carries every track's timeline, so all
+					// markers resolve against this single file (part ordinal 0).
+					trackFiles.push({ trackIndex: 0, files: [filePath] });
 				} else {
 					// An empty merged blob writes no final file; the
 					// segment files are the only copy of the captured
@@ -262,9 +269,12 @@ export class RecordingFinalizer {
 				}
 			}
 		} else {
-			for (const target of targets) {
+			for (let trackIndex = 0; trackIndex < targets.length; trackIndex++) {
+				const target = targets[trackIndex];
 				const paths = await this.finalizeTrackFiles(target);
-				fileLinks.push(...target.partPaths, ...paths);
+				const files = [...target.partPaths, ...paths];
+				fileLinks.push(...files);
+				trackFiles.push({ trackIndex, files });
 			}
 		}
 
@@ -275,7 +285,7 @@ export class RecordingFinalizer {
 		} else {
 			new Notice('No audio data recorded');
 		}
-		return { audioPaths: fileLinks, notePath };
+		return { audioPaths: fileLinks, notePath, trackFiles };
 	}
 
 	/**

--- a/src/recording/RecordingManager.ts
+++ b/src/recording/RecordingManager.ts
@@ -11,7 +11,24 @@ import type {
 	RecordingSaveResult,
 	RecordingTarget,
 	SaveProgress,
+	TrackFileGroup,
 } from '../types';
+import { MarkerStore } from '../player/markers/MarkerStore';
+import {
+	MARKER_KIND,
+	sortMarkers,
+	type MarkerKind,
+	type PlayerMarker,
+} from '../player/markers/markerModel';
+import {
+	defaultMarkerLabel,
+	generateMarkerId,
+} from '../player/markers/markerFactory';
+import {
+	groupMarkersByFile,
+	type RecordingMarkerDraft,
+	type RecordingMarkerHandle,
+} from './recordingMarkers';
 import type { AudioRecorderSettings, OutputMode } from '../settings/Settings';
 import {
 	getAudioStreams,
@@ -90,6 +107,10 @@ export class RecordingManager {
 	private readonly finalizer: RecordingFinalizer;
 	/** Auto-split part rotation (timing, reentry, part finalization). */
 	private readonly rotation: PartRotationController;
+	/** Markers captured during the current session, flushed at stop. */
+	private markerBuffer: RecordingMarkerDraft[] = [];
+	/** Last marker kind chosen in the modal, preselected next time. */
+	private lastMarkerKind: MarkerKind = MARKER_KIND.bookmark;
 
 	/**
 	 * Creates a new RecordingManager.
@@ -111,6 +132,7 @@ export class RecordingManager {
 		private readonly onRecordingSaved?: (
 			result: RecordingSaveResult,
 		) => void,
+		private readonly markerStore: MarkerStore = new MarkerStore(app),
 	) {
 		this.onStatusChange = onStatusChange;
 		this.debugLogger = new DebugLogger(settings);
@@ -155,6 +177,111 @@ export class RecordingManager {
 	 */
 	getStatus(): RecordingStatus {
 		return this.status;
+	}
+
+	/**
+	 * Whether a marker can be dropped right now: a session must be active
+	 * (recording or paused) and the player markers feature must be enabled,
+	 * since markers are only ever surfaced by the enhanced player.
+	 */
+	canDropMarker(): boolean {
+		return (
+			(this.status === RecordingStatus.Recording ||
+				this.status === RecordingStatus.Paused) &&
+			this.settings.playerEnableMarkers
+		);
+	}
+
+	/**
+	 * Captures a marker at the current position and adds it to the session
+	 * buffer immediately, so it survives even if the recording stops while
+	 * the naming modal is still open. Returns an editing handle for the
+	 * modal, or null when a marker cannot be dropped now.
+	 */
+	captureMarkerDraft(): RecordingMarkerHandle | null {
+		if (!this.canDropMarker()) {
+			return null;
+		}
+		const position = this.rotation.getCurrentPartPosition(this.status);
+		const draft: RecordingMarkerDraft = {
+			id: generateMarkerId(),
+			partOrdinal: position.partOrdinal,
+			offsetSeconds: position.offsetSeconds,
+			kind: this.lastMarkerKind,
+			label: this.nextMarkerLabel(this.lastMarkerKind, null),
+		};
+		this.markerBuffer.push(draft);
+		return {
+			initialKind: draft.kind,
+			defaultLabelFor: (kind: MarkerKind) =>
+				this.nextMarkerLabel(kind, draft.id),
+			commit: (label: string, kind: MarkerKind) => {
+				draft.kind = kind;
+				const trimmed = label.trim();
+				draft.label =
+					trimmed.length > 0
+						? trimmed
+						: this.nextMarkerLabel(kind, draft.id);
+				this.lastMarkerKind = kind;
+			},
+			cancel: () => {
+				const index = this.markerBuffer.findIndex(
+					(entry) => entry.id === draft.id,
+				);
+				if (index !== -1) {
+					this.markerBuffer.splice(index, 1);
+				}
+			},
+		};
+	}
+
+	/**
+	 * Default label for a new marker of the given kind, numbered after the
+	 * markers already buffered this session (excluding the given draft so it
+	 * never counts itself).
+	 * @param kind - Marker kind being labelled
+	 * @param excludeId - Draft id to exclude from the count, or null
+	 */
+	private nextMarkerLabel(kind: MarkerKind, excludeId: string | null): string {
+		const others = this.markerBuffer.filter(
+			(entry) => entry.id !== excludeId,
+		);
+		return defaultMarkerLabel(others, kind);
+	}
+
+	/**
+	 * Writes the session's buffered markers into the sidecars of the final
+	 * files. Each marker resolves to its part's file per track and fans out
+	 * to every track (they share one timeline). Never throws: a marker write
+	 * failure must not break the stop sequence.
+	 * @param result - The finalized save result with per-track file groups
+	 */
+	private async persistMarkers(result: RecordingSaveResult): Promise<void> {
+		if (this.markerBuffer.length === 0) {
+			return;
+		}
+		const groups: TrackFileGroup[] = result.trackFiles ?? [
+			{ trackIndex: 0, files: result.audioPaths },
+		];
+		const writes = groupMarkersByFile(this.markerBuffer, groups);
+		for (const { path, markers } of writes) {
+			try {
+				const existing = await this.markerStore.get(path);
+				const added: PlayerMarker[] = markers.map((marker) => ({
+					id: generateMarkerId(),
+					...marker,
+				}));
+				await this.markerStore.set(
+					path,
+					sortMarkers([...existing, ...added]),
+				);
+			} catch (error) {
+				console.error(
+					`${PLUGIN_LOG_PREFIX} Failed to persist recording markers for ${path}:`,
+					error,
+				);
+			}
+		}
 	}
 
 	/**
@@ -242,6 +369,7 @@ export class RecordingManager {
 				.toISOString()
 				.replace(/[:.]/g, '-');
 			this.totalChunks = 0;
+			this.markerBuffer = [];
 
 			if (this.isWavPcmRecording) {
 				await this.initPcmRecording();
@@ -329,6 +457,7 @@ export class RecordingManager {
 		this.trackOrder = [];
 		this.recordingTimestamp = null;
 		this.insertionContext = null;
+		this.markerBuffer = [];
 	}
 
 	/**
@@ -570,6 +699,9 @@ export class RecordingManager {
 				this.recordingTimestamp,
 				this.insertionContext,
 			);
+			// Persist live markers before the hook so they are on disk when a
+			// post-save action (e.g. opening the player) reads the sidecar
+			await this.persistMarkers(saveResult);
 			if (saveResult.audioPaths.length > 0) {
 				// Fire-and-forget post-save hook (e.g. transcribe-on-save);
 				// failures must never break the stop sequence
@@ -610,6 +742,7 @@ export class RecordingManager {
 			this.isWavPcmRecording = false;
 			this.insertionContext = null;
 			this.sessionSplitEnabled = false;
+			this.markerBuffer = [];
 			this.setStatus(RecordingStatus.Idle);
 		}
 	}

--- a/src/recording/RecordingManager.ts
+++ b/src/recording/RecordingManager.ts
@@ -16,9 +16,10 @@ import type {
 import { MarkerStore } from '../player/markers/MarkerStore';
 import {
 	MARKER_KIND,
+	removeMarker,
 	sortMarkers,
+	updateMarker,
 	type MarkerKind,
-	type PlayerMarker,
 } from '../player/markers/markerModel';
 import {
 	defaultMarkerLabel,
@@ -111,6 +112,13 @@ export class RecordingManager {
 	private markerBuffer: RecordingMarkerDraft[] = [];
 	/** Last marker kind chosen in the modal, preselected next time. */
 	private lastMarkerKind: MarkerKind = MARKER_KIND.bookmark;
+	/**
+	 * Sidecar paths each persisted marker landed in, keyed by draft id.
+	 * Populated at stop so a naming modal still open when the session ends
+	 * can edit or discard the already-saved marker rather than silently
+	 * losing the change. Reset when a new session starts.
+	 */
+	private readonly persistedMarkerPaths = new Map<string, string[]>();
 
 	/**
 	 * Creates a new RecordingManager.
@@ -223,6 +231,10 @@ export class RecordingManager {
 						? trimmed
 						: this.nextMarkerLabel(kind, draft.id);
 				this.lastMarkerKind = kind;
+				// If the session finalized while the modal was open the draft
+				// was already persisted with its default label; push the edit
+				// through to the sidecar so the user's name/kind is not lost.
+				void this.syncPersistedMarker(draft);
 			},
 			cancel: () => {
 				const index = this.markerBuffer.findIndex(
@@ -231,6 +243,9 @@ export class RecordingManager {
 				if (index !== -1) {
 					this.markerBuffer.splice(index, 1);
 				}
+				// Same race: a draft persisted before the modal closed must be
+				// removed from its sidecar so cancelling truly discards it.
+				void this.removePersistedMarker(draft.id);
 			},
 		};
 	}
@@ -242,7 +257,10 @@ export class RecordingManager {
 	 * @param kind - Marker kind being labelled
 	 * @param excludeId - Draft id to exclude from the count, or null
 	 */
-	private nextMarkerLabel(kind: MarkerKind, excludeId: string | null): string {
+	private nextMarkerLabel(
+		kind: MarkerKind,
+		excludeId: string | null,
+	): string {
 		const others = this.markerBuffer.filter(
 			(entry) => entry.id !== excludeId,
 		);
@@ -264,20 +282,84 @@ export class RecordingManager {
 			{ trackIndex: 0, files: result.audioPaths },
 		];
 		const writes = groupMarkersByFile(this.markerBuffer, groups);
+		// Record where each draft landed before any await runs, so a modal
+		// still open can reach its persisted marker by id. Done in one
+		// synchronous pass: no commit/cancel can interleave mid-write.
+		for (const { path, markers } of writes) {
+			for (const marker of markers) {
+				const paths = this.persistedMarkerPaths.get(marker.id) ?? [];
+				paths.push(path);
+				this.persistedMarkerPaths.set(marker.id, paths);
+			}
+		}
 		for (const { path, markers } of writes) {
 			try {
 				const existing = await this.markerStore.get(path);
-				const added: PlayerMarker[] = markers.map((marker) => ({
-					id: generateMarkerId(),
-					...marker,
-				}));
 				await this.markerStore.set(
 					path,
-					sortMarkers([...existing, ...added]),
+					sortMarkers([...existing, ...markers]),
 				);
 			} catch (error) {
 				console.error(
 					`${PLUGIN_LOG_PREFIX} Failed to persist recording markers for ${path}:`,
+					error,
+				);
+			}
+		}
+	}
+
+	/**
+	 * Pushes a draft's edited label and kind onto every sidecar it was
+	 * already persisted to. No-op while the session is still active (the
+	 * draft is then edited in place in the buffer instead). Never throws: a
+	 * sidecar write failure must not surface from a UI commit handler.
+	 * @param draft - The edited draft
+	 */
+	private async syncPersistedMarker(
+		draft: RecordingMarkerDraft,
+	): Promise<void> {
+		const paths = this.persistedMarkerPaths.get(draft.id);
+		if (!paths) {
+			return;
+		}
+		for (const path of paths) {
+			try {
+				const existing = await this.markerStore.get(path);
+				await this.markerStore.set(
+					path,
+					updateMarker(existing, draft.id, {
+						label: draft.label,
+						kind: draft.kind,
+					}),
+				);
+			} catch (error) {
+				console.error(
+					`${PLUGIN_LOG_PREFIX} Failed to update persisted marker for ${path}:`,
+					error,
+				);
+			}
+		}
+	}
+
+	/**
+	 * Removes an already-persisted marker from every sidecar it landed in.
+	 * No-op while the session is still active (the draft is just dropped from
+	 * the buffer instead). Never throws.
+	 * @param id - The draft/marker id to remove
+	 */
+	private async removePersistedMarker(id: string): Promise<void> {
+		const paths = this.persistedMarkerPaths.get(id);
+		if (!paths) {
+			return;
+		}
+		this.persistedMarkerPaths.delete(id);
+		for (const path of paths) {
+			try {
+				const existing = await this.markerStore.get(path);
+				await this.markerStore.set(path, removeMarker(existing, id));
+			} catch (error) {
+				console.error(
+					`${PLUGIN_LOG_PREFIX} Failed to remove persisted marker for ${path}:`,
 					error,
 				);
 			}
@@ -370,6 +452,7 @@ export class RecordingManager {
 				.replace(/[:.]/g, '-');
 			this.totalChunks = 0;
 			this.markerBuffer = [];
+			this.persistedMarkerPaths.clear();
 
 			if (this.isWavPcmRecording) {
 				await this.initPcmRecording();

--- a/src/recording/recordingMarkers.ts
+++ b/src/recording/recordingMarkers.ts
@@ -1,0 +1,176 @@
+/**
+ * Pure helpers for placing markers during a recording session. A marker is
+ * captured live at the instant the user triggers it; its position is stored
+ * as a (part ordinal, within-part offset) pair so it can be resolved to the
+ * right final file once the session is finalized — correctly across plain,
+ * auto-split, and multi-track recordings.
+ *
+ * Everything here is pure (no DOM, no I/O, no clock) so the position and
+ * file-resolution arithmetic can be unit tested directly.
+ * @module recording/recordingMarkers
+ */
+
+import type { MarkerKind } from '../player/markers/markerModel';
+import type { TrackFileGroup } from '../types';
+
+/**
+ * A marker captured during recording, before it is resolved to a file.
+ * `offsetSeconds` is the offset from the START of its part (auto-split) or
+ * from the start of the recording (no split); `partOrdinal` is the 0-based
+ * index of the part that was recording when the marker was dropped.
+ */
+export interface RecordingMarkerDraft {
+	/** Stable id, reused as the persisted marker id. */
+	id: string;
+	/** 0-based part index that was recording at trigger time. */
+	partOrdinal: number;
+	/** Offset in seconds from the start of that part. */
+	offsetSeconds: number;
+	/** Whether this is a bookmark or a chapter. */
+	kind: MarkerKind;
+	/** User-facing label (default, then editable in the modal). */
+	label: string;
+}
+
+/**
+ * Editing handle returned when a marker is captured during recording. The
+ * draft is already frozen in the session buffer at the captured time; the
+ * modal uses this to fill the default label, commit the user's edits, or
+ * discard the draft if cancelled.
+ */
+export interface RecordingMarkerHandle {
+	/** The session's last-used kind, used to preselect the modal. */
+	initialKind: MarkerKind;
+	/** Default label for a kind, numbered excluding this draft. */
+	defaultLabelFor(kind: MarkerKind): string;
+	/** Commits the user's label and kind onto the buffered draft. */
+	commit(label: string, kind: MarkerKind): void;
+	/** Discards the buffered draft (modal cancelled or closed unconfirmed). */
+	cancel(): void;
+}
+
+/**
+ * Snapshot of the rotation controller's active-time accounting needed to
+ * derive a marker position. The caller folds the live (since-anchor) term
+ * into both ms values before calling so this stays clock-free.
+ */
+export interface PartPositionState {
+	/** Whether the session captures raw PCM for WAV output. */
+	isWavPcm: boolean;
+	/** Whether auto-split is active for the session. */
+	splitEnabled: boolean;
+	/** Auto-split part duration in minutes. */
+	partMinutes: number;
+	/** Active (unpaused) ms accumulated in the current part. */
+	partActiveMs: number;
+	/** Active (unpaused) ms accumulated across the whole session. */
+	sessionActiveMs: number;
+	/** Count of completed part rotations (current part index). */
+	sessionPartOrdinal: number;
+}
+
+/** A resolved marker position: which part and the offset within it. */
+export interface PartPosition {
+	partOrdinal: number;
+	offsetSeconds: number;
+}
+
+/**
+ * Derives the current (part ordinal, within-part offset) from the session's
+ * active-time accounting. Without auto-split there is a single part, so the
+ * offset is the whole-session active time. With auto-split the boundaries are
+ * synchronized by audio time across all tracks: compressed sessions reset the
+ * per-part clock on each rotation (so the part ordinal comes from the rotation
+ * counter), while PCM sessions split sample-exact at exactly partMinutes of
+ * audio (so the ordinal is derived deterministically from the session clock).
+ * @param state - Active-time snapshot with the live term already folded in
+ */
+export function computePartPosition(state: PartPositionState): PartPosition {
+	if (!state.splitEnabled) {
+		return { partOrdinal: 0, offsetSeconds: state.sessionActiveMs / 1000 };
+	}
+	if (state.isWavPcm) {
+		const totalSeconds = state.sessionActiveMs / 1000;
+		const partSeconds = state.partMinutes * 60;
+		const partOrdinal = Math.floor(totalSeconds / partSeconds);
+		return {
+			partOrdinal,
+			offsetSeconds: totalSeconds - partOrdinal * partSeconds,
+		};
+	}
+	return {
+		partOrdinal: state.sessionPartOrdinal,
+		offsetSeconds: state.partActiveMs / 1000,
+	};
+}
+
+/**
+ * Resolves which file in a track's ordered part list a marker belongs to.
+ * Clamps to the last file so a marker whose part failed to save (its audio
+ * was carried into a later part) still lands in a real file, and returns -1
+ * when the track produced no files at all.
+ * @param partOrdinal - 0-based part index captured at trigger time
+ * @param fileCount - Number of files this track produced
+ */
+export function resolvePartFileIndex(
+	partOrdinal: number,
+	fileCount: number,
+): number {
+	if (fileCount <= 0) {
+		return -1;
+	}
+	return Math.min(Math.max(0, partOrdinal), fileCount - 1);
+}
+
+/** A label/kind/time triple destined for one file's sidecar (id assigned later). */
+export interface MarkerFileWrite {
+	path: string;
+	markers: { time: number; label: string; kind: MarkerKind }[];
+}
+
+/**
+ * Groups buffered markers by the final file they belong to. Every marker
+ * fans out to each track at the file resolved for its part ordinal, since
+ * all tracks share one timeline. Tracks that produced no files contribute
+ * nothing. Insertion order of files is preserved for deterministic output.
+ * @param drafts - Markers captured during the session
+ * @param groups - Per-track ordered file lists from finalization
+ */
+export function groupMarkersByFile(
+	drafts: readonly RecordingMarkerDraft[],
+	groups: readonly TrackFileGroup[],
+): MarkerFileWrite[] {
+	const byPath = new Map<string, MarkerFileWrite>();
+	const order: string[] = [];
+	for (const group of groups) {
+		for (const draft of drafts) {
+			const fileIndex = resolvePartFileIndex(
+				draft.partOrdinal,
+				group.files.length,
+			);
+			if (fileIndex === -1) {
+				continue;
+			}
+			const path = group.files[fileIndex];
+			let entry = byPath.get(path);
+			if (!entry) {
+				entry = { path, markers: [] };
+				byPath.set(path, entry);
+				order.push(path);
+			}
+			entry.markers.push({
+				time: draft.offsetSeconds,
+				label: draft.label,
+				kind: draft.kind,
+			});
+		}
+	}
+	return order.map((path) => {
+		const entry = byPath.get(path);
+		if (!entry) {
+			// Unreachable: every path in `order` was just inserted.
+			return { path, markers: [] };
+		}
+		return entry;
+	});
+}

--- a/src/recording/recordingMarkers.ts
+++ b/src/recording/recordingMarkers.ts
@@ -82,7 +82,14 @@ export interface PartPosition {
  * synchronized by audio time across all tracks: compressed sessions reset the
  * per-part clock on each rotation (so the part ordinal comes from the rotation
  * counter), while PCM sessions split sample-exact at exactly partMinutes of
- * audio (so the ordinal is derived deterministically from the session clock).
+ * audio, so the ordinal is derived from the session clock.
+ *
+ * For PCM the session clock is wall-clock active time, used as a proxy for
+ * captured-sample time. The two can drift by the audio-hardware-vs-system
+ * clock skew (well under a second per part in practice), so a marker dropped
+ * within that skew of a part boundary may resolve to the neighbouring part;
+ * `resolvePartFileIndex` then clamps it into a real file. This is accepted in
+ * exchange for one position mechanism shared by compressed and PCM sessions.
  * @param state - Active-time snapshot with the live term already folded in
  */
 export function computePartPosition(state: PartPositionState): PartPosition {
@@ -122,10 +129,14 @@ export function resolvePartFileIndex(
 	return Math.min(Math.max(0, partOrdinal), fileCount - 1);
 }
 
-/** A label/kind/time triple destined for one file's sidecar (id assigned later). */
+/**
+ * A marker destined for one file's sidecar. Carries the originating draft's
+ * id so the same logical marker keeps a stable identity across the tracks it
+ * fans out to, and can still be found and edited after it is persisted.
+ */
 export interface MarkerFileWrite {
 	path: string;
-	markers: { time: number; label: string; kind: MarkerKind }[];
+	markers: { id: string; time: number; label: string; kind: MarkerKind }[];
 }
 
 /**
@@ -159,6 +170,7 @@ export function groupMarkersByFile(
 				order.push(path);
 			}
 			entry.markers.push({
+				id: draft.id,
 				time: draft.offsetSeconds,
 				label: draft.label,
 				kind: draft.kind,

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,9 @@ export type RecordingControls = {
 	onPauseResume: () => void;
 	onStop: () => void;
 	isPaused: boolean;
+	/** Drops a marker/chapter at the current position; absent when markers
+	 * are disabled, so the button is hidden. */
+	onAddMarker?: () => void;
 };
 
 /**
@@ -56,6 +59,24 @@ export interface RecordingSaveResult {
 	audioPaths: string[];
 	/** Note the audio links were inserted into, or null when none was. */
 	notePath: string | null;
+	/** Written files grouped per track in part order, so recording-time
+	 * markers can be resolved to the right file. Absent only when a caller
+	 * (e.g. a test mock) does not provide it. */
+	trackFiles?: TrackFileGroup[];
+}
+
+/**
+ * One track's final files in part order: a single file for a plain track,
+ * the ordered part files for an auto-split track, or the one merged file for
+ * a single-output multi-track session. All tracks of a session share one
+ * audio timeline, so a marker at a given part/offset applies to each track's
+ * file at the same index.
+ */
+export interface TrackFileGroup {
+	/** Index of the track in the session's target order. */
+	trackIndex: number;
+	/** This track's files, ordered: [...parts, residual]. */
+	files: string[];
 }
 
 /**

--- a/src/ui/MarkerModal.ts
+++ b/src/ui/MarkerModal.ts
@@ -6,12 +6,21 @@
  * @module ui/MarkerModal
  */
 
-import { App, Modal, Setting } from 'obsidian';
-import {
-	MARKER_KIND,
-	type MarkerKind,
-} from '../player/markers/markerModel';
+import { App, Modal, setIcon } from 'obsidian';
+import { MARKER_KIND, type MarkerKind } from '../player/markers/markerModel';
 import type { RecordingMarkerHandle } from '../recording/recordingMarkers';
+
+/** A selectable kind option rendered as a segmented-toggle button. */
+interface KindOption {
+	kind: MarkerKind;
+	label: string;
+	icon: string;
+}
+
+const KIND_OPTIONS: KindOption[] = [
+	{ kind: MARKER_KIND.bookmark, label: 'Bookmark', icon: 'bookmark' },
+	{ kind: MARKER_KIND.chapter, label: 'Chapter', icon: 'list' },
+];
 
 /**
  * Naming dialog for a recording-time marker.
@@ -22,6 +31,7 @@ export class RecordingMarkerModal extends Modal {
 	private label: string;
 	private committed = false;
 	private inputEl: HTMLInputElement | null = null;
+	private readonly kindButtons = new Map<MarkerKind, HTMLButtonElement>();
 
 	/**
 	 * @param app - The Obsidian App instance
@@ -35,62 +45,85 @@ export class RecordingMarkerModal extends Modal {
 	}
 
 	/**
-	 * Builds the modal contents.
+	 * Builds the modal contents: a compact kind toggle and a full-width
+	 * name field over a standard button row.
 	 */
 	onOpen(): void {
 		const { contentEl } = this;
 		contentEl.addClass('aar-marker-modal');
+		this.setTitle('Add marker');
 
-		new Setting(contentEl).setName('Add marker').setHeading();
-
-		new Setting(contentEl).setName('Type').addDropdown((dropdown) => {
-			dropdown.addOption(MARKER_KIND.bookmark, 'Bookmark');
-			dropdown.addOption(MARKER_KIND.chapter, 'Chapter');
-			dropdown.setValue(this.kind);
-			dropdown.onChange((value) => {
-				const nextKind = value as MarkerKind;
-				// Refresh the default label only while the user has not
-				// typed a custom one, so toggling type keeps the numbering
-				// sensible without clobbering manual input.
-				if (this.inputEl && this.inputEl.value === this.label) {
-					this.label = this.handle.defaultLabelFor(nextKind);
-					this.inputEl.value = this.label;
-				}
-				this.kind = nextKind;
+		const toggle = contentEl.createDiv({ cls: 'aar-marker-type' });
+		for (const option of KIND_OPTIONS) {
+			const button = toggle.createEl('button', {
+				cls: 'aar-marker-type-btn',
 			});
+			setIcon(button.createSpan({ cls: 'aar-marker-type-icon' }), option.icon);
+			button.createSpan({ text: option.label });
+			button.addEventListener('click', () => {
+				this.selectKind(option.kind);
+			});
+			this.kindButtons.set(option.kind, button);
+		}
+
+		this.inputEl = contentEl.createEl('input', {
+			cls: 'aar-marker-name-input',
+			type: 'text',
+		});
+		this.inputEl.value = this.label;
+		this.inputEl.addEventListener('keydown', (event) => {
+			if (event.key === 'Enter') {
+				event.preventDefault();
+				this.confirm();
+			}
 		});
 
-		new Setting(contentEl).setName('Name').addText((text) => {
-			text.setValue(this.label);
-			this.inputEl = text.inputEl;
-			text.inputEl.addEventListener('keydown', (event) => {
-				if (event.key === 'Enter') {
-					event.preventDefault();
-					this.confirm();
-				}
-			});
+		const actions = contentEl.createDiv({ cls: 'modal-button-container' });
+		const addButton = actions.createEl('button', {
+			cls: 'mod-cta',
+			text: 'Add',
+		});
+		addButton.addEventListener('click', () => {
+			this.confirm();
+		});
+		const cancelButton = actions.createEl('button', { text: 'Cancel' });
+		cancelButton.addEventListener('click', () => {
+			this.close();
 		});
 
-		const actions = new Setting(contentEl);
-		actions.addButton((button) =>
-			button
-				.setButtonText('Add')
-				.setCta()
-				.onClick(() => {
-					this.confirm();
-				}),
-		);
-		actions.addButton((button) =>
-			button.setButtonText('Cancel').onClick(() => {
-				this.close();
-			}),
-		);
-
+		this.refreshKindButtons();
 		// Defer focus until the modal is in the DOM so select() works
 		activeWindow.setTimeout(() => {
 			this.inputEl?.focus();
 			this.inputEl?.select();
 		}, 0);
+	}
+
+	/**
+	 * Switches the marker kind. Refreshes the default label only while the
+	 * user has not typed a custom one, so toggling type keeps the numbering
+	 * sensible without clobbering manual input.
+	 * @param kind - Newly selected kind
+	 */
+	private selectKind(kind: MarkerKind): void {
+		if (kind === this.kind) {
+			return;
+		}
+		if (this.inputEl && this.inputEl.value === this.label) {
+			this.label = this.handle.defaultLabelFor(kind);
+			this.inputEl.value = this.label;
+		}
+		this.kind = kind;
+		this.refreshKindButtons();
+	}
+
+	/**
+	 * Highlights the button of the active kind.
+	 */
+	private refreshKindButtons(): void {
+		for (const [kind, button] of this.kindButtons) {
+			button.toggleClass('is-active', kind === this.kind);
+		}
 	}
 
 	/**

--- a/src/ui/MarkerModal.ts
+++ b/src/ui/MarkerModal.ts
@@ -58,7 +58,10 @@ export class RecordingMarkerModal extends Modal {
 			const button = toggle.createEl('button', {
 				cls: 'aar-marker-type-btn',
 			});
-			setIcon(button.createSpan({ cls: 'aar-marker-type-icon' }), option.icon);
+			setIcon(
+				button.createSpan({ cls: 'aar-marker-type-icon' }),
+				option.icon,
+			);
 			button.createSpan({ text: option.label });
 			button.addEventListener('click', () => {
 				this.selectKind(option.kind);
@@ -93,7 +96,7 @@ export class RecordingMarkerModal extends Modal {
 
 		this.refreshKindButtons();
 		// Defer focus until the modal is in the DOM so select() works
-		activeWindow.setTimeout(() => {
+		window.setTimeout(() => {
 			this.inputEl?.focus();
 			this.inputEl?.select();
 		}, 0);

--- a/src/ui/MarkerModal.ts
+++ b/src/ui/MarkerModal.ts
@@ -1,0 +1,114 @@
+/**
+ * Modal for naming a marker dropped during recording. The marker's time is
+ * already frozen in the session buffer when this opens; the modal only edits
+ * the label and kind. Confirming commits the edits; closing without
+ * confirming discards the buffered draft.
+ * @module ui/MarkerModal
+ */
+
+import { App, Modal, Setting } from 'obsidian';
+import {
+	MARKER_KIND,
+	type MarkerKind,
+} from '../player/markers/markerModel';
+import type { RecordingMarkerHandle } from '../recording/recordingMarkers';
+
+/**
+ * Naming dialog for a recording-time marker.
+ */
+export class RecordingMarkerModal extends Modal {
+	private readonly handle: RecordingMarkerHandle;
+	private kind: MarkerKind;
+	private label: string;
+	private committed = false;
+	private inputEl: HTMLInputElement | null = null;
+
+	/**
+	 * @param app - The Obsidian App instance
+	 * @param handle - Editing handle for the buffered marker draft
+	 */
+	constructor(app: App, handle: RecordingMarkerHandle) {
+		super(app);
+		this.handle = handle;
+		this.kind = handle.initialKind;
+		this.label = handle.defaultLabelFor(this.kind);
+	}
+
+	/**
+	 * Builds the modal contents.
+	 */
+	onOpen(): void {
+		const { contentEl } = this;
+		contentEl.addClass('aar-marker-modal');
+
+		new Setting(contentEl).setName('Add marker').setHeading();
+
+		new Setting(contentEl).setName('Type').addDropdown((dropdown) => {
+			dropdown.addOption(MARKER_KIND.bookmark, 'Bookmark');
+			dropdown.addOption(MARKER_KIND.chapter, 'Chapter');
+			dropdown.setValue(this.kind);
+			dropdown.onChange((value) => {
+				const nextKind = value as MarkerKind;
+				// Refresh the default label only while the user has not
+				// typed a custom one, so toggling type keeps the numbering
+				// sensible without clobbering manual input.
+				if (this.inputEl && this.inputEl.value === this.label) {
+					this.label = this.handle.defaultLabelFor(nextKind);
+					this.inputEl.value = this.label;
+				}
+				this.kind = nextKind;
+			});
+		});
+
+		new Setting(contentEl).setName('Name').addText((text) => {
+			text.setValue(this.label);
+			this.inputEl = text.inputEl;
+			text.inputEl.addEventListener('keydown', (event) => {
+				if (event.key === 'Enter') {
+					event.preventDefault();
+					this.confirm();
+				}
+			});
+		});
+
+		const actions = new Setting(contentEl);
+		actions.addButton((button) =>
+			button
+				.setButtonText('Add')
+				.setCta()
+				.onClick(() => {
+					this.confirm();
+				}),
+		);
+		actions.addButton((button) =>
+			button.setButtonText('Cancel').onClick(() => {
+				this.close();
+			}),
+		);
+
+		// Defer focus until the modal is in the DOM so select() works
+		activeWindow.setTimeout(() => {
+			this.inputEl?.focus();
+			this.inputEl?.select();
+		}, 0);
+	}
+
+	/**
+	 * Commits the current label and kind onto the draft and closes.
+	 */
+	private confirm(): void {
+		this.handle.commit(this.inputEl?.value ?? this.label, this.kind);
+		this.committed = true;
+		this.close();
+	}
+
+	/**
+	 * Discards the draft when the modal closes without confirmation.
+	 */
+	onClose(): void {
+		if (!this.committed) {
+			this.handle.cancel();
+		}
+		this.contentEl.empty();
+	}
+}

--- a/src/ui/StatusBar.ts
+++ b/src/ui/StatusBar.ts
@@ -76,6 +76,14 @@ function renderRecordingState(
 		const buttons = container.createSpan({
 			cls: 'aar-recording-buttons',
 		});
+		if (controls.onAddMarker) {
+			createControlButton(
+				buttons,
+				'bookmark',
+				'Add marker',
+				controls.onAddMarker,
+			);
+		}
 		createControlButton(
 			buttons,
 			controls.isPaused ? 'play' : 'pause',

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -88,6 +88,44 @@ If your plugin does not need CSS, delete this file.
     height: 14px;
 }
 
+/* Add-marker modal */
+.aar-marker-modal .aar-marker-type {
+    display: flex;
+    gap: 6px;
+    margin: 4px 0 12px;
+}
+
+.aar-marker-type-btn {
+    flex: 1;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    padding: 8px 10px;
+    cursor: pointer;
+}
+
+.aar-marker-type-btn.is-active {
+    background-color: var(--interactive-accent);
+    color: var(--text-on-accent);
+    box-shadow: none;
+}
+
+.aar-marker-type-icon {
+    display: inline-flex;
+    align-items: center;
+}
+
+.aar-marker-type-icon svg {
+    width: 16px;
+    height: 16px;
+}
+
+.aar-marker-name-input {
+    width: 100%;
+    margin-bottom: 4px;
+}
+
 /* Save progress */
 .aar-status-progress-content {
     width: 100%;

--- a/tests/unit/PartRotationController.test.ts
+++ b/tests/unit/PartRotationController.test.ts
@@ -481,7 +481,9 @@ describe('PartRotationController', () => {
 		});
 
 		it('advances the compressed part ordinal after a rotation', async () => {
-			buildController(createSession({ splitEnabled: true, partMinutes: 15 }));
+			buildController(
+				createSession({ splitEnabled: true, partMinutes: 15 }),
+			);
 
 			jest.advanceTimersByTime(15 * MS_PER_MINUTE);
 			controller.maybeRotate();

--- a/tests/unit/PartRotationController.test.ts
+++ b/tests/unit/PartRotationController.test.ts
@@ -418,4 +418,80 @@ describe('PartRotationController', () => {
 			expect(target.partPaths).toHaveLength(0);
 		});
 	});
+
+	describe('getCurrentPartPosition', () => {
+		it('reports the whole-session offset when auto-split is off', () => {
+			buildController(createSession({ splitEnabled: false }));
+
+			jest.advanceTimersByTime(5000);
+
+			expect(
+				controller.getCurrentPartPosition(RecordingStatus.Recording),
+			).toEqual({ partOrdinal: 0, offsetSeconds: 5 });
+		});
+
+		it('is zero immediately after the session starts', () => {
+			buildController(createSession({ splitEnabled: false }));
+
+			expect(
+				controller.getCurrentPartPosition(RecordingStatus.Recording),
+			).toEqual({ partOrdinal: 0, offsetSeconds: 0 });
+		});
+
+		it('excludes paused time from the offset', () => {
+			buildController(createSession({ splitEnabled: false }));
+
+			jest.advanceTimersByTime(3000);
+			controller.markPaused();
+			jest.advanceTimersByTime(4000);
+
+			expect(
+				controller.getCurrentPartPosition(RecordingStatus.Paused),
+			).toEqual({ partOrdinal: 0, offsetSeconds: 3 });
+		});
+
+		it('resumes counting active time after a pause', () => {
+			buildController(createSession({ splitEnabled: false }));
+
+			jest.advanceTimersByTime(3000);
+			controller.markPaused();
+			jest.advanceTimersByTime(4000);
+			controller.markResumed();
+			jest.advanceTimersByTime(2000);
+
+			expect(
+				controller.getCurrentPartPosition(RecordingStatus.Recording),
+			).toEqual({ partOrdinal: 0, offsetSeconds: 5 });
+		});
+
+		it('derives the PCM split ordinal and offset from the session clock', () => {
+			buildController(
+				createSession({
+					isWavPcm: true,
+					splitEnabled: true,
+					partMinutes: 1,
+				}),
+			);
+
+			jest.advanceTimersByTime(90_000);
+
+			expect(
+				controller.getCurrentPartPosition(RecordingStatus.Recording),
+			).toEqual({ partOrdinal: 1, offsetSeconds: 30 });
+		});
+
+		it('advances the compressed part ordinal after a rotation', async () => {
+			buildController(createSession({ splitEnabled: true, partMinutes: 15 }));
+
+			jest.advanceTimersByTime(15 * MS_PER_MINUTE);
+			controller.maybeRotate();
+			await controller.waitForPendingRotation();
+
+			const position = controller.getCurrentPartPosition(
+				RecordingStatus.Recording,
+			);
+			expect(position.partOrdinal).toBe(1);
+			expect(position.offsetSeconds).toBeLessThan(1);
+		});
+	});
 });

--- a/tests/unit/RecordingFinalizer.test.ts
+++ b/tests/unit/RecordingFinalizer.test.ts
@@ -408,6 +408,86 @@ describe('RecordingFinalizer', () => {
 			expect(result.notePath).toBeNull();
 		});
 
+		// The recording-marker feature resolves each marker to a file via
+		// these per-track groups, so the grouping must always flatten back
+		// to audioPaths in order across every output topology.
+		const flattenTrackFiles = (files?: { files: string[] }[]): string[] =>
+			(files ?? []).flatMap((group) => group.files);
+
+		it('groups files per track in multiple mode', async () => {
+			buildFinalizer(createSession({ outputMode: 'multiple' }));
+			const targets = [
+				createTarget({ segmentPaths: ['a-part1.webm.tmp'] }),
+				createTarget({
+					fileBaseName: 'recording-Track2-stamp',
+					segmentPaths: ['b-part1.webm.tmp'],
+				}),
+			];
+
+			const result = await finalizer.saveRecording(targets, 'stamp', null);
+
+			expect(result.trackFiles).toHaveLength(2);
+			expect(result.trackFiles?.map((group) => group.trackIndex)).toEqual([
+				0, 1,
+			]);
+			expect(flattenTrackFiles(result.trackFiles)).toEqual(
+				result.audioPaths,
+			);
+		});
+
+		it('groups a split track as its parts followed by the residual', async () => {
+			buildFinalizer(
+				createSession({ outputMode: 'single', splitEnabled: true }),
+			);
+			const target = createTarget({
+				partPaths: ['rec-part1.webm'],
+				partIndex: 1,
+				segmentPaths: ['rec-part2.webm.tmp'],
+			});
+
+			const result = await finalizer.saveRecording([target], 'stamp', null);
+
+			expect(result.trackFiles).toHaveLength(1);
+			expect(result.trackFiles?.[0].trackIndex).toBe(0);
+			expect(result.trackFiles?.[0].files[0]).toBe('rec-part1.webm');
+			expect(flattenTrackFiles(result.trackFiles)).toEqual(
+				result.audioPaths,
+			);
+		});
+
+		it('groups a merged multi-track recording as a single file', async () => {
+			buildFinalizer(createSession({ outputMode: 'single' }));
+			const targets = [
+				createTarget({ segmentPaths: ['a.tmp'] }),
+				createTarget({
+					fileBaseName: 'recording-Track2-stamp',
+					segmentPaths: ['b.tmp'],
+				}),
+			];
+
+			const result = await finalizer.saveRecording(targets, 'stamp', null);
+
+			expect(result.trackFiles).toHaveLength(1);
+			expect(result.trackFiles?.[0].trackIndex).toBe(0);
+			expect(result.audioPaths).toHaveLength(1);
+			expect(flattenTrackFiles(result.trackFiles)).toEqual(
+				result.audioPaths,
+			);
+		});
+
+		it('keeps the grouping empty when nothing was recorded', async () => {
+			buildFinalizer(createSession({ outputMode: 'multiple' }));
+
+			const result = await finalizer.saveRecording(
+				[createTarget()],
+				'stamp',
+				null,
+			);
+
+			expect(flattenTrackFiles(result.trackFiles)).toEqual([]);
+			expect(result.audioPaths).toEqual([]);
+		});
+
 		it('should follow the session outputMode snapshot over live settings', async () => {
 			// The live settings switched to 'single' mid-recording; the
 			// session snapshot taken at start must keep the per-track

--- a/tests/unit/RecordingFinalizer.test.ts
+++ b/tests/unit/RecordingFinalizer.test.ts
@@ -424,12 +424,16 @@ describe('RecordingFinalizer', () => {
 				}),
 			];
 
-			const result = await finalizer.saveRecording(targets, 'stamp', null);
+			const result = await finalizer.saveRecording(
+				targets,
+				'stamp',
+				null,
+			);
 
 			expect(result.trackFiles).toHaveLength(2);
-			expect(result.trackFiles?.map((group) => group.trackIndex)).toEqual([
-				0, 1,
-			]);
+			expect(result.trackFiles?.map((group) => group.trackIndex)).toEqual(
+				[0, 1],
+			);
 			expect(flattenTrackFiles(result.trackFiles)).toEqual(
 				result.audioPaths,
 			);
@@ -445,7 +449,11 @@ describe('RecordingFinalizer', () => {
 				segmentPaths: ['rec-part2.webm.tmp'],
 			});
 
-			const result = await finalizer.saveRecording([target], 'stamp', null);
+			const result = await finalizer.saveRecording(
+				[target],
+				'stamp',
+				null,
+			);
 
 			expect(result.trackFiles).toHaveLength(1);
 			expect(result.trackFiles?.[0].trackIndex).toBe(0);
@@ -465,7 +473,11 @@ describe('RecordingFinalizer', () => {
 				}),
 			];
 
-			const result = await finalizer.saveRecording(targets, 'stamp', null);
+			const result = await finalizer.saveRecording(
+				targets,
+				'stamp',
+				null,
+			);
 
 			expect(result.trackFiles).toHaveLength(1);
 			expect(result.trackFiles?.[0].trackIndex).toBe(0);

--- a/tests/unit/RecordingManager.test.ts
+++ b/tests/unit/RecordingManager.test.ts
@@ -7,6 +7,9 @@
 
 import { RecordingManager } from '../../src/recording/RecordingManager';
 import { RecordingStatus } from '../../src/types';
+import { MARKER_KIND } from '../../src/player/markers/markerModel';
+import type { PlayerMarker } from '../../src/player/markers/markerModel';
+import type { MarkerStore } from '../../src/player/markers/MarkerStore';
 import {
 	DEFAULT_SETTINGS,
 	AudioRecorderSettings,
@@ -2319,6 +2322,155 @@ describe('RecordingManager', () => {
 			};
 			expect(result.audioPaths.length).toBeGreaterThan(0);
 			expect(result.notePath).toBe('Notes/active.md');
+		});
+
+		const makeFakeMarkerStore = (): {
+			store: MarkerStore;
+			set: jest.Mock;
+		} => {
+			const set = jest.fn().mockResolvedValue(undefined);
+			const store = {
+				get: jest.fn().mockResolvedValue([]),
+				set,
+			} as unknown as MarkerStore;
+			return { store, set };
+		};
+
+		const feedChunkAndStop = async (): Promise<void> => {
+			const chunk = new Blob([new Uint8Array([1, 2, 3])], {
+				type: 'audio/webm',
+			});
+			mockMediaRecorder.ondataavailable?.({ data: chunk } as BlobEvent);
+			await Promise.resolve();
+			await manager.stopRecording();
+		};
+
+		it('persists a marker dropped during recording to the sidecar at stop', async () => {
+			const { store, set } = makeFakeMarkerStore();
+			mockSettings = {
+				...DEFAULT_SETTINGS,
+				playerEnableMarkers: true,
+				insertAtOriginalPosition: false,
+			};
+			manager = new RecordingManager(
+				mockApp,
+				mockSettings,
+				statusChangeCallback,
+				undefined,
+				undefined,
+				store,
+			);
+
+			await manager.startRecording();
+			const handle = manager.captureMarkerDraft();
+			expect(handle).not.toBeNull();
+			handle?.commit('Intro', MARKER_KIND.bookmark);
+			await feedChunkAndStop();
+
+			expect(set).toHaveBeenCalledTimes(1);
+			const [path, markers] = set.mock.calls[0] as [string, PlayerMarker[]];
+			expect(typeof path).toBe('string');
+			expect(markers).toHaveLength(1);
+			expect(markers[0]).toMatchObject({
+				label: 'Intro',
+				kind: MARKER_KIND.bookmark,
+			});
+			expect(markers[0].time).toBeGreaterThanOrEqual(0);
+			expect(markers[0].id.length).toBeGreaterThan(0);
+		});
+
+		it('numbers default marker labels sequentially within a session', async () => {
+			const { store, set } = makeFakeMarkerStore();
+			mockSettings = {
+				...DEFAULT_SETTINGS,
+				playerEnableMarkers: true,
+				insertAtOriginalPosition: false,
+			};
+			manager = new RecordingManager(
+				mockApp,
+				mockSettings,
+				statusChangeCallback,
+				undefined,
+				undefined,
+				store,
+			);
+
+			await manager.startRecording();
+			// Empty labels fall back to the auto-numbered default
+			manager.captureMarkerDraft()?.commit('', MARKER_KIND.bookmark);
+			manager.captureMarkerDraft()?.commit('', MARKER_KIND.bookmark);
+			await feedChunkAndStop();
+
+			const markers = set.mock.calls[0][1] as PlayerMarker[];
+			expect(markers.map((marker) => marker.label).sort()).toEqual([
+				'Marker 1',
+				'Marker 2',
+			]);
+		});
+
+		it('discards a cancelled marker so it is never persisted', async () => {
+			const { store, set } = makeFakeMarkerStore();
+			mockSettings = {
+				...DEFAULT_SETTINGS,
+				playerEnableMarkers: true,
+				insertAtOriginalPosition: false,
+			};
+			manager = new RecordingManager(
+				mockApp,
+				mockSettings,
+				statusChangeCallback,
+				undefined,
+				undefined,
+				store,
+			);
+
+			await manager.startRecording();
+			manager.captureMarkerDraft()?.cancel();
+			await feedChunkAndStop();
+
+			expect(set).not.toHaveBeenCalled();
+		});
+
+		it('refuses to drop a marker when no recording is active', () => {
+			mockSettings = { ...DEFAULT_SETTINGS, playerEnableMarkers: true };
+			manager = new RecordingManager(
+				mockApp,
+				mockSettings,
+				statusChangeCallback,
+			);
+
+			expect(manager.canDropMarker()).toBe(false);
+			expect(manager.captureMarkerDraft()).toBeNull();
+		});
+
+		it('refuses to drop a marker when markers are disabled', async () => {
+			mockSettings = { ...DEFAULT_SETTINGS, playerEnableMarkers: false };
+			manager = new RecordingManager(
+				mockApp,
+				mockSettings,
+				statusChangeCallback,
+			);
+
+			await manager.startRecording();
+			expect(manager.canDropMarker()).toBe(false);
+			expect(manager.captureMarkerDraft()).toBeNull();
+			await manager.stopRecording();
+		});
+
+		it('still allows dropping a marker while paused', async () => {
+			mockSettings = { ...DEFAULT_SETTINGS, playerEnableMarkers: true };
+			manager = new RecordingManager(
+				mockApp,
+				mockSettings,
+				statusChangeCallback,
+			);
+
+			await manager.startRecording();
+			manager.togglePauseResume();
+			expect(manager.getStatus()).toBe(RecordingStatus.Paused);
+			expect(manager.canDropMarker()).toBe(true);
+			expect(manager.captureMarkerDraft()).not.toBeNull();
+			await manager.stopRecording();
 		});
 
 		it('should use replaceRange at stored position when insertAtOriginalPosition is enabled', async () => {

--- a/tests/unit/RecordingManager.test.ts
+++ b/tests/unit/RecordingManager.test.ts
@@ -2336,6 +2336,35 @@ describe('RecordingManager', () => {
 			return { store, set };
 		};
 
+		// A store that actually remembers what was written, so reach-through
+		// edits/removals after stop can be asserted against the final state.
+		const makeStatefulMarkerStore = (): {
+			store: MarkerStore;
+			set: jest.Mock;
+			read: (path: string) => PlayerMarker[];
+		} => {
+			const data = new Map<string, PlayerMarker[]>();
+			const set = jest.fn((path: string, markers: PlayerMarker[]) => {
+				data.set(path, [...markers]);
+				return Promise.resolve();
+			});
+			const store = {
+				get: jest.fn((path: string) =>
+					Promise.resolve(data.get(path) ?? []),
+				),
+				set,
+			} as unknown as MarkerStore;
+			return { store, set, read: (path) => data.get(path) ?? [] };
+		};
+
+		// A commit/cancel queues fire-and-forget sidecar writes (get -> set is
+		// two microtask hops); draining a few turns lets them settle.
+		const flushMicrotasks = async (): Promise<void> => {
+			for (let i = 0; i < 5; i++) {
+				await Promise.resolve();
+			}
+		};
+
 		const feedChunkAndStop = async (): Promise<void> => {
 			const chunk = new Blob([new Uint8Array([1, 2, 3])], {
 				type: 'audio/webm',
@@ -2368,7 +2397,10 @@ describe('RecordingManager', () => {
 			await feedChunkAndStop();
 
 			expect(set).toHaveBeenCalledTimes(1);
-			const [path, markers] = set.mock.calls[0] as [string, PlayerMarker[]];
+			const [path, markers] = set.mock.calls[0] as [
+				string,
+				PlayerMarker[],
+			];
 			expect(typeof path).toBe('string');
 			expect(markers).toHaveLength(1);
 			expect(markers[0]).toMatchObject({
@@ -2429,6 +2461,67 @@ describe('RecordingManager', () => {
 			await feedChunkAndStop();
 
 			expect(set).not.toHaveBeenCalled();
+		});
+
+		it('applies a label edit committed after the session has stopped', async () => {
+			const { store, set, read } = makeStatefulMarkerStore();
+			mockSettings = {
+				...DEFAULT_SETTINGS,
+				playerEnableMarkers: true,
+				insertAtOriginalPosition: false,
+			};
+			manager = new RecordingManager(
+				mockApp,
+				mockSettings,
+				statusChangeCallback,
+				undefined,
+				undefined,
+				store,
+			);
+
+			await manager.startRecording();
+			const handle = manager.captureMarkerDraft();
+			// Stop persists the draft with its default label while the modal
+			// is still open; the user then finishes naming it.
+			await feedChunkAndStop();
+			handle?.commit('Renamed live', MARKER_KIND.chapter);
+			await flushMicrotasks();
+
+			const path = set.mock.calls[0][0] as string;
+			const final = read(path);
+			expect(final).toHaveLength(1);
+			expect(final[0]).toMatchObject({
+				label: 'Renamed live',
+				kind: MARKER_KIND.chapter,
+			});
+		});
+
+		it('removes a marker cancelled after the session has stopped', async () => {
+			const { store, set, read } = makeStatefulMarkerStore();
+			mockSettings = {
+				...DEFAULT_SETTINGS,
+				playerEnableMarkers: true,
+				insertAtOriginalPosition: false,
+			};
+			manager = new RecordingManager(
+				mockApp,
+				mockSettings,
+				statusChangeCallback,
+				undefined,
+				undefined,
+				store,
+			);
+
+			await manager.startRecording();
+			const handle = manager.captureMarkerDraft();
+			await feedChunkAndStop();
+			const path = set.mock.calls[0][0] as string;
+			expect(read(path)).toHaveLength(1);
+
+			handle?.cancel();
+			await flushMicrotasks();
+
+			expect(read(path)).toHaveLength(0);
 		});
 
 		it('refuses to drop a marker when no recording is active', () => {

--- a/tests/unit/markerFactory.test.ts
+++ b/tests/unit/markerFactory.test.ts
@@ -26,14 +26,22 @@ describe('defaultMarkerLabel', () => {
 			MARKER_KIND.chapter,
 			MARKER_KIND.bookmark,
 		]);
-		expect(defaultMarkerLabel(markers, MARKER_KIND.bookmark)).toBe('Marker 3');
-		expect(defaultMarkerLabel(markers, MARKER_KIND.chapter)).toBe('Chapter 2');
+		expect(defaultMarkerLabel(markers, MARKER_KIND.bookmark)).toBe(
+			'Marker 3',
+		);
+		expect(defaultMarkerLabel(markers, MARKER_KIND.chapter)).toBe(
+			'Chapter 2',
+		);
 	});
 
 	it('numbers bookmarks and chapters independently', () => {
 		const markers = kinds([MARKER_KIND.chapter, MARKER_KIND.chapter]);
-		expect(defaultMarkerLabel(markers, MARKER_KIND.bookmark)).toBe('Marker 1');
-		expect(defaultMarkerLabel(markers, MARKER_KIND.chapter)).toBe('Chapter 3');
+		expect(defaultMarkerLabel(markers, MARKER_KIND.bookmark)).toBe(
+			'Marker 1',
+		);
+		expect(defaultMarkerLabel(markers, MARKER_KIND.chapter)).toBe(
+			'Chapter 3',
+		);
 	});
 });
 

--- a/tests/unit/markerFactory.test.ts
+++ b/tests/unit/markerFactory.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Tests for the shared marker factory: default label numbering and id
+ * generation reused by both the player and recording-time marker capture.
+ * @module tests/unit/markerFactory.test
+ */
+/** @jest-environment jsdom */
+
+import {
+	defaultMarkerLabel,
+	generateMarkerId,
+} from 'src/player/markers/markerFactory';
+import { MARKER_KIND, type MarkerKind } from 'src/player/markers/markerModel';
+
+const kinds = (list: MarkerKind[]): { kind: MarkerKind }[] =>
+	list.map((kind) => ({ kind }));
+
+describe('defaultMarkerLabel', () => {
+	it('numbers from 1 on an empty list', () => {
+		expect(defaultMarkerLabel([], MARKER_KIND.bookmark)).toBe('Marker 1');
+		expect(defaultMarkerLabel([], MARKER_KIND.chapter)).toBe('Chapter 1');
+	});
+
+	it('counts only markers of the same kind', () => {
+		const markers = kinds([
+			MARKER_KIND.bookmark,
+			MARKER_KIND.chapter,
+			MARKER_KIND.bookmark,
+		]);
+		expect(defaultMarkerLabel(markers, MARKER_KIND.bookmark)).toBe('Marker 3');
+		expect(defaultMarkerLabel(markers, MARKER_KIND.chapter)).toBe('Chapter 2');
+	});
+
+	it('numbers bookmarks and chapters independently', () => {
+		const markers = kinds([MARKER_KIND.chapter, MARKER_KIND.chapter]);
+		expect(defaultMarkerLabel(markers, MARKER_KIND.bookmark)).toBe('Marker 1');
+		expect(defaultMarkerLabel(markers, MARKER_KIND.chapter)).toBe('Chapter 3');
+	});
+});
+
+describe('generateMarkerId', () => {
+	it('returns a non-empty string', () => {
+		const id = generateMarkerId();
+		expect(typeof id).toBe('string');
+		expect(id.length).toBeGreaterThan(0);
+	});
+
+	it('returns distinct ids on successive calls', () => {
+		const ids = new Set([
+			generateMarkerId(),
+			generateMarkerId(),
+			generateMarkerId(),
+		]);
+		expect(ids.size).toBe(3);
+	});
+});

--- a/tests/unit/recordingMarkers.test.ts
+++ b/tests/unit/recordingMarkers.test.ts
@@ -39,7 +39,9 @@ const draft = (
 describe('computePartPosition', () => {
 	it('returns the whole-session offset when auto-split is off', () => {
 		expect(
-			computePartPosition(state({ splitEnabled: false, sessionActiveMs: 42000 })),
+			computePartPosition(
+				state({ splitEnabled: false, sessionActiveMs: 42000 }),
+			),
 		).toEqual({ partOrdinal: 0, offsetSeconds: 42 });
 	});
 
@@ -160,11 +162,19 @@ describe('resolvePartFileIndex', () => {
 
 describe('groupMarkersByFile', () => {
 	it('maps a single-file recording to that one file', () => {
-		const groups: TrackFileGroup[] = [{ trackIndex: 0, files: ['rec.webm'] }];
+		const groups: TrackFileGroup[] = [
+			{ trackIndex: 0, files: ['rec.webm'] },
+		];
 		expect(
-			groupMarkersByFile([draft({ offsetSeconds: 12, label: 'M' })], groups),
+			groupMarkersByFile(
+				[draft({ offsetSeconds: 12, label: 'M' })],
+				groups,
+			),
 		).toEqual([
-			{ path: 'rec.webm', markers: [{ time: 12, label: 'M', kind: 'bookmark' }] },
+			{
+				path: 'rec.webm',
+				markers: [{ id: 'd', time: 12, label: 'M', kind: 'bookmark' }],
+			},
 		]);
 	});
 
@@ -174,12 +184,18 @@ describe('groupMarkersByFile', () => {
 			{ trackIndex: 1, files: ['system.webm'] },
 		];
 		expect(
-			groupMarkersByFile([draft({ offsetSeconds: 8, label: 'Q' })], groups),
+			groupMarkersByFile(
+				[draft({ offsetSeconds: 8, label: 'Q' })],
+				groups,
+			),
 		).toEqual([
-			{ path: 'mic.webm', markers: [{ time: 8, label: 'Q', kind: 'bookmark' }] },
+			{
+				path: 'mic.webm',
+				markers: [{ id: 'd', time: 8, label: 'Q', kind: 'bookmark' }],
+			},
 			{
 				path: 'system.webm',
-				markers: [{ time: 8, label: 'Q', kind: 'bookmark' }],
+				markers: [{ id: 'd', time: 8, label: 'Q', kind: 'bookmark' }],
 			},
 		]);
 	});
@@ -189,29 +205,53 @@ describe('groupMarkersByFile', () => {
 			{ trackIndex: 0, files: ['merged.wav'] },
 		];
 		expect(
-			groupMarkersByFile([draft({ partOrdinal: 0, offsetSeconds: 5 })], groups),
+			groupMarkersByFile(
+				[draft({ partOrdinal: 0, offsetSeconds: 5 })],
+				groups,
+			),
 		).toEqual([
 			{
 				path: 'merged.wav',
-				markers: [{ time: 5, label: 'Marker 1', kind: 'bookmark' }],
+				markers: [
+					{ id: 'd', time: 5, label: 'Marker 1', kind: 'bookmark' },
+				],
 			},
 		]);
 	});
 
 	it('routes split-recording markers to the part file of their ordinal', () => {
 		const groups: TrackFileGroup[] = [
-			{ trackIndex: 0, files: ['rec-part1.wav', 'rec-part2.wav', 'rec.wav'] },
+			{
+				trackIndex: 0,
+				files: ['rec-part1.wav', 'rec-part2.wav', 'rec.wav'],
+			},
 		];
 		const writes = groupMarkersByFile(
 			[
-				draft({ id: 'a', partOrdinal: 0, offsetSeconds: 4, label: 'A' }),
-				draft({ id: 'b', partOrdinal: 2, offsetSeconds: 6, label: 'B' }),
+				draft({
+					id: 'a',
+					partOrdinal: 0,
+					offsetSeconds: 4,
+					label: 'A',
+				}),
+				draft({
+					id: 'b',
+					partOrdinal: 2,
+					offsetSeconds: 6,
+					label: 'B',
+				}),
 			],
 			groups,
 		);
 		expect(writes).toEqual([
-			{ path: 'rec-part1.wav', markers: [{ time: 4, label: 'A', kind: 'bookmark' }] },
-			{ path: 'rec.wav', markers: [{ time: 6, label: 'B', kind: 'bookmark' }] },
+			{
+				path: 'rec-part1.wav',
+				markers: [{ id: 'a', time: 4, label: 'A', kind: 'bookmark' }],
+			},
+			{
+				path: 'rec.wav',
+				markers: [{ id: 'b', time: 6, label: 'B', kind: 'bookmark' }],
+			},
 		]);
 	});
 
@@ -222,16 +262,38 @@ describe('groupMarkersByFile', () => {
 		];
 		const writes = groupMarkersByFile(
 			[
-				draft({ id: 'a', partOrdinal: 0, offsetSeconds: 3, label: 'A' }),
-				draft({ id: 'b', partOrdinal: 1, offsetSeconds: 9, label: 'B' }),
+				draft({
+					id: 'a',
+					partOrdinal: 0,
+					offsetSeconds: 3,
+					label: 'A',
+				}),
+				draft({
+					id: 'b',
+					partOrdinal: 1,
+					offsetSeconds: 9,
+					label: 'B',
+				}),
 			],
 			groups,
 		);
 		expect(writes).toEqual([
-			{ path: 'mic-part1.wav', markers: [{ time: 3, label: 'A', kind: 'bookmark' }] },
-			{ path: 'mic.wav', markers: [{ time: 9, label: 'B', kind: 'bookmark' }] },
-			{ path: 'sys-part1.wav', markers: [{ time: 3, label: 'A', kind: 'bookmark' }] },
-			{ path: 'sys.wav', markers: [{ time: 9, label: 'B', kind: 'bookmark' }] },
+			{
+				path: 'mic-part1.wav',
+				markers: [{ id: 'a', time: 3, label: 'A', kind: 'bookmark' }],
+			},
+			{
+				path: 'mic.wav',
+				markers: [{ id: 'b', time: 9, label: 'B', kind: 'bookmark' }],
+			},
+			{
+				path: 'sys-part1.wav',
+				markers: [{ id: 'a', time: 3, label: 'A', kind: 'bookmark' }],
+			},
+			{
+				path: 'sys.wav',
+				markers: [{ id: 'b', time: 9, label: 'B', kind: 'bookmark' }],
+			},
 		]);
 	});
 
@@ -240,11 +302,16 @@ describe('groupMarkersByFile', () => {
 			{ trackIndex: 0, files: ['part1.wav', 'residual.wav'] },
 		];
 		expect(
-			groupMarkersByFile([draft({ partOrdinal: 5, offsetSeconds: 7 })], groups),
+			groupMarkersByFile(
+				[draft({ partOrdinal: 5, offsetSeconds: 7 })],
+				groups,
+			),
 		).toEqual([
 			{
 				path: 'residual.wav',
-				markers: [{ time: 7, label: 'Marker 1', kind: 'bookmark' }],
+				markers: [
+					{ id: 'd', time: 7, label: 'Marker 1', kind: 'bookmark' },
+				],
 			},
 		]);
 	});
@@ -255,7 +322,9 @@ describe('groupMarkersByFile', () => {
 	});
 
 	it('returns nothing for an empty marker buffer', () => {
-		const groups: TrackFileGroup[] = [{ trackIndex: 0, files: ['rec.webm'] }];
+		const groups: TrackFileGroup[] = [
+			{ trackIndex: 0, files: ['rec.webm'] },
+		];
 		expect(groupMarkersByFile([], groups)).toEqual([]);
 	});
 
@@ -281,8 +350,8 @@ describe('groupMarkersByFile', () => {
 			{
 				path: 'x.webm',
 				markers: [
-					{ time: 2, label: 'A', kind: 'bookmark' },
-					{ time: 1, label: 'C1', kind: 'chapter' },
+					{ id: 'a', time: 2, label: 'A', kind: 'bookmark' },
+					{ id: 'b', time: 1, label: 'C1', kind: 'chapter' },
 				],
 			},
 		]);

--- a/tests/unit/recordingMarkers.test.ts
+++ b/tests/unit/recordingMarkers.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Tests for the pure recording-marker helpers: position derivation,
+ * file-index resolution, and the per-file fan-out used to persist markers
+ * across plain, split, and multi-track recordings (and their mixes).
+ * @module tests/unit/recordingMarkers.test
+ */
+
+import {
+	computePartPosition,
+	groupMarkersByFile,
+	resolvePartFileIndex,
+	type PartPositionState,
+	type RecordingMarkerDraft,
+} from 'src/recording/recordingMarkers';
+import { MARKER_KIND } from 'src/player/markers/markerModel';
+import type { TrackFileGroup } from 'src/types';
+
+const state = (over: Partial<PartPositionState> = {}): PartPositionState => ({
+	isWavPcm: false,
+	splitEnabled: false,
+	partMinutes: 15,
+	partActiveMs: 0,
+	sessionActiveMs: 0,
+	sessionPartOrdinal: 0,
+	...over,
+});
+
+const draft = (
+	over: Partial<RecordingMarkerDraft> = {},
+): RecordingMarkerDraft => ({
+	id: 'd',
+	partOrdinal: 0,
+	offsetSeconds: 10,
+	kind: MARKER_KIND.bookmark,
+	label: 'Marker 1',
+	...over,
+});
+
+describe('computePartPosition', () => {
+	it('returns the whole-session offset when auto-split is off', () => {
+		expect(
+			computePartPosition(state({ splitEnabled: false, sessionActiveMs: 42000 })),
+		).toEqual({ partOrdinal: 0, offsetSeconds: 42 });
+	});
+
+	it('is zero at the very start of a recording', () => {
+		expect(computePartPosition(state())).toEqual({
+			partOrdinal: 0,
+			offsetSeconds: 0,
+		});
+	});
+
+	it('uses the rotation counter and per-part clock for a compressed split', () => {
+		expect(
+			computePartPosition(
+				state({
+					splitEnabled: true,
+					partActiveMs: 12000,
+					sessionActiveMs: 912000,
+					sessionPartOrdinal: 2,
+				}),
+			),
+		).toEqual({ partOrdinal: 2, offsetSeconds: 12 });
+	});
+
+	it('ignores the session clock for compressed split offsets', () => {
+		// Compressed offset comes from the per-part clock, not the session
+		// clock, so a large sessionActiveMs must not leak into the offset.
+		expect(
+			computePartPosition(
+				state({
+					splitEnabled: true,
+					partActiveMs: 1000,
+					sessionActiveMs: 9_999_000,
+					sessionPartOrdinal: 5,
+				}),
+			),
+		).toEqual({ partOrdinal: 5, offsetSeconds: 1 });
+	});
+
+	it('derives the PCM split ordinal at an exact part boundary', () => {
+		expect(
+			computePartPosition(
+				state({
+					isWavPcm: true,
+					splitEnabled: true,
+					partMinutes: 1,
+					sessionActiveMs: 60000,
+				}),
+			),
+		).toEqual({ partOrdinal: 1, offsetSeconds: 0 });
+	});
+
+	it('derives the PCM split ordinal and offset mid-part', () => {
+		expect(
+			computePartPosition(
+				state({
+					isWavPcm: true,
+					splitEnabled: true,
+					partMinutes: 1,
+					sessionActiveMs: 90000,
+				}),
+			),
+		).toEqual({ partOrdinal: 1, offsetSeconds: 30 });
+	});
+
+	it('keeps the first PCM part for times below one part length', () => {
+		expect(
+			computePartPosition(
+				state({
+					isWavPcm: true,
+					splitEnabled: true,
+					partMinutes: 1,
+					sessionActiveMs: 30000,
+				}),
+			),
+		).toEqual({ partOrdinal: 0, offsetSeconds: 30 });
+	});
+
+	it('computes a high PCM ordinal across many parts', () => {
+		// 7.5 minutes at 1-minute parts => part 7, 30s in.
+		expect(
+			computePartPosition(
+				state({
+					isWavPcm: true,
+					splitEnabled: true,
+					partMinutes: 1,
+					sessionActiveMs: 450000,
+				}),
+			),
+		).toEqual({ partOrdinal: 7, offsetSeconds: 30 });
+	});
+});
+
+describe('resolvePartFileIndex', () => {
+	it('returns the ordinal when it is within range', () => {
+		expect(resolvePartFileIndex(1, 3)).toBe(1);
+	});
+
+	it('returns the first file for ordinal 0', () => {
+		expect(resolvePartFileIndex(0, 1)).toBe(0);
+	});
+
+	it('returns the last file for the residual ordinal', () => {
+		expect(resolvePartFileIndex(2, 3)).toBe(2);
+	});
+
+	it('clamps to the last file when the ordinal overflows', () => {
+		expect(resolvePartFileIndex(9, 3)).toBe(2);
+	});
+
+	it('clamps a negative ordinal to the first file', () => {
+		expect(resolvePartFileIndex(-1, 3)).toBe(0);
+	});
+
+	it('returns -1 when the track produced no files', () => {
+		expect(resolvePartFileIndex(0, 0)).toBe(-1);
+	});
+});
+
+describe('groupMarkersByFile', () => {
+	it('maps a single-file recording to that one file', () => {
+		const groups: TrackFileGroup[] = [{ trackIndex: 0, files: ['rec.webm'] }];
+		expect(
+			groupMarkersByFile([draft({ offsetSeconds: 12, label: 'M' })], groups),
+		).toEqual([
+			{ path: 'rec.webm', markers: [{ time: 12, label: 'M', kind: 'bookmark' }] },
+		]);
+	});
+
+	it('fans one marker out to every track of a multi-track recording', () => {
+		const groups: TrackFileGroup[] = [
+			{ trackIndex: 0, files: ['mic.webm'] },
+			{ trackIndex: 1, files: ['system.webm'] },
+		];
+		expect(
+			groupMarkersByFile([draft({ offsetSeconds: 8, label: 'Q' })], groups),
+		).toEqual([
+			{ path: 'mic.webm', markers: [{ time: 8, label: 'Q', kind: 'bookmark' }] },
+			{
+				path: 'system.webm',
+				markers: [{ time: 8, label: 'Q', kind: 'bookmark' }],
+			},
+		]);
+	});
+
+	it('maps a merged multi-track recording to the single file at ordinal 0', () => {
+		const groups: TrackFileGroup[] = [
+			{ trackIndex: 0, files: ['merged.wav'] },
+		];
+		expect(
+			groupMarkersByFile([draft({ partOrdinal: 0, offsetSeconds: 5 })], groups),
+		).toEqual([
+			{
+				path: 'merged.wav',
+				markers: [{ time: 5, label: 'Marker 1', kind: 'bookmark' }],
+			},
+		]);
+	});
+
+	it('routes split-recording markers to the part file of their ordinal', () => {
+		const groups: TrackFileGroup[] = [
+			{ trackIndex: 0, files: ['rec-part1.wav', 'rec-part2.wav', 'rec.wav'] },
+		];
+		const writes = groupMarkersByFile(
+			[
+				draft({ id: 'a', partOrdinal: 0, offsetSeconds: 4, label: 'A' }),
+				draft({ id: 'b', partOrdinal: 2, offsetSeconds: 6, label: 'B' }),
+			],
+			groups,
+		);
+		expect(writes).toEqual([
+			{ path: 'rec-part1.wav', markers: [{ time: 4, label: 'A', kind: 'bookmark' }] },
+			{ path: 'rec.wav', markers: [{ time: 6, label: 'B', kind: 'bookmark' }] },
+		]);
+	});
+
+	it('handles a split + multi-track mix, fanning each part across tracks', () => {
+		const groups: TrackFileGroup[] = [
+			{ trackIndex: 0, files: ['mic-part1.wav', 'mic.wav'] },
+			{ trackIndex: 1, files: ['sys-part1.wav', 'sys.wav'] },
+		];
+		const writes = groupMarkersByFile(
+			[
+				draft({ id: 'a', partOrdinal: 0, offsetSeconds: 3, label: 'A' }),
+				draft({ id: 'b', partOrdinal: 1, offsetSeconds: 9, label: 'B' }),
+			],
+			groups,
+		);
+		expect(writes).toEqual([
+			{ path: 'mic-part1.wav', markers: [{ time: 3, label: 'A', kind: 'bookmark' }] },
+			{ path: 'mic.wav', markers: [{ time: 9, label: 'B', kind: 'bookmark' }] },
+			{ path: 'sys-part1.wav', markers: [{ time: 3, label: 'A', kind: 'bookmark' }] },
+			{ path: 'sys.wav', markers: [{ time: 9, label: 'B', kind: 'bookmark' }] },
+		]);
+	});
+
+	it('clamps a marker whose part failed to save into the last file', () => {
+		const groups: TrackFileGroup[] = [
+			{ trackIndex: 0, files: ['part1.wav', 'residual.wav'] },
+		];
+		expect(
+			groupMarkersByFile([draft({ partOrdinal: 5, offsetSeconds: 7 })], groups),
+		).toEqual([
+			{
+				path: 'residual.wav',
+				markers: [{ time: 7, label: 'Marker 1', kind: 'bookmark' }],
+			},
+		]);
+	});
+
+	it('skips a track that produced no files', () => {
+		const groups: TrackFileGroup[] = [{ trackIndex: 0, files: [] }];
+		expect(groupMarkersByFile([draft({})], groups)).toEqual([]);
+	});
+
+	it('returns nothing for an empty marker buffer', () => {
+		const groups: TrackFileGroup[] = [{ trackIndex: 0, files: ['rec.webm'] }];
+		expect(groupMarkersByFile([], groups)).toEqual([]);
+	});
+
+	it('returns nothing when there are no track groups', () => {
+		expect(groupMarkersByFile([draft({})], [])).toEqual([]);
+	});
+
+	it('groups several markers into one file in insertion order', () => {
+		const groups: TrackFileGroup[] = [{ trackIndex: 0, files: ['x.webm'] }];
+		const writes = groupMarkersByFile(
+			[
+				draft({ id: 'a', offsetSeconds: 2, label: 'A' }),
+				draft({
+					id: 'b',
+					offsetSeconds: 1,
+					label: 'C1',
+					kind: MARKER_KIND.chapter,
+				}),
+			],
+			groups,
+		);
+		expect(writes).toEqual([
+			{
+				path: 'x.webm',
+				markers: [
+					{ time: 2, label: 'A', kind: 'bookmark' },
+					{ time: 1, label: 'C1', kind: 'chapter' },
+				],
+			},
+		]);
+	});
+});


### PR DESCRIPTION
## What

Adds the ability to drop a **bookmark** or **chapter** while a recording is in progress, instead of only being able to add them later in the enhanced player.

- Status-bar button (next to pause/stop) and a hotkey-bindable command `Add marker/chapter at current position`, both available while `Recording` or `Paused`.
- A modal names the marker (default `Marker N` / `Chapter N`, editable) and picks its kind; the last-used kind is preselected next time.
- The marker timestamp is **frozen at the trigger instant**, not when the modal is confirmed, so naming never shifts the position.
- Gated by the existing `playerEnableMarkers` setting (markers are only ever surfaced by the enhanced player).

## Why

Marking an important moment live (a thought, a new interview question, a topic change) is the most common reason to want markers at all. Until now they could only be placed by re-listening to a finished recording and hunting for the spot.

## How it stays correct across recording topologies

A marker's `time` is an offset from the start of its file, so each marker must resolve to the right `(file, offset)`. The hard cases are auto-split (one track → many part files) and multi-track (many files).

- Position is captured as an authoritative `(partOrdinal, offsetSeconds)` pair from `PartRotationController.getCurrentPartPosition`, derived in one synchronous read — not from a live `target.partIndex`, which is unsafe during the rotation transcode window and can diverge per track on a failed part save.
- Part boundaries are synchronized by audio time across tracks (compressed: shared active-time threshold; PCM: byte limit equals exactly `partMinutes` of audio for every track), so one position applies to all tracks.
- `RecordingFinalizer` now returns per-track ordered file groups (`trackFiles`); each marker resolves to its track's file by part ordinal with a clamp into the residual file, then fans out to every track. Paused time is excluded from the offset.

Markers reuse the player's `PlayerMarker` model and `MarkerStore` sidecars, so they appear in the enhanced player immediately after stop. A single shared `MarkerStore` is now injected into the recording side so its cache and write chain stay unified with the player.

## Tests

New and extended unit tests cover boundary and negative cases plus scenario mixes:

- `recordingMarkers`: position math (no-split / compressed / PCM — exact boundary, mid-part, zero, many parts), file-index resolution (in range, residual, overflow clamp, negative, empty → -1), and per-file fan-out across single / multi-track / merged / split-single / split+multi-track.
- `PartRotationController.getCurrentPartPosition`: live time, paused exclusion, resume, PCM split, ordinal increment after rotation.
- `RecordingFinalizer`: `trackFiles` grouping invariant (`flatten(trackFiles) === audioPaths`) for multiple / split-single / merged / nothing-recorded.
- `RecordingManager`: end-to-end persistence at stop, sequential default labels, cancel discards, refusal when idle or markers disabled, allowed while paused.

```
npm test       1160 passed, 72 suites
npm run lint   clean
npm run build  clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
