### PR TITLE
fix(transcription): split long recordings for Gemini transcription

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -227,6 +227,16 @@ export const TRANSCRIBE_SAMPLE_RATE = 16000;
 export const TRANSCRIBE_BYTES_PER_SEC = TRANSCRIBE_SAMPLE_RATE * 2;
 
 /**
+ * Conservative lower bound on real-world audio bitrate, in bytes per second
+ * (~8 kbps), used only as a cheap proof that a small file is short enough to
+ * send to a duration-capped provider whole without decoding it to measure its
+ * true length. Set well below any practical speech codec so a file that passes
+ * the proof (bytes <= cap * this) genuinely cannot exceed the duration cap;
+ * larger files fall through to the decode path, which measures exactly.
+ */
+export const MIN_AUDIO_BYTES_PER_SEC = 1000;
+
+/**
  * Default upload size limit per request, in megabytes, for the Whisper
  * API. OpenAI's limit is 25 MB; chunks are sized to stay under it.
  */
@@ -435,6 +445,18 @@ export const GEMINI_PRO_MIN_THINKING_BUDGET = 128;
  * above it (capped at {@link TRANSCRIBE_MAX_REQUEST_TIMEOUT_MS}).
  */
 export const GEMINI_GENERATE_MIN_TIMEOUT_MS = 10 * 60_000;
+
+/**
+ * Longest recording, in seconds, that Gemini transcribes in a single
+ * `generateContent` request. Beyond this the audio is split into parts that
+ * are transcribed separately and stitched back onto the timeline: one request
+ * for a long meeting would otherwise outlast the request timeout and risk
+ * MAX_TOKENS truncation, since both inference time and the output transcript
+ * grow with audio duration. Sized so each part finishes comfortably within
+ * {@link GEMINI_GENERATE_MIN_TIMEOUT_MS}. Splitting resets Gemini's per-request
+ * speaker numbering, so a diarized split surfaces a warning to the user.
+ */
+export const GEMINI_MAX_WHOLE_FILE_SECONDS = 15 * 60;
 
 /**
  * LLM post-processing provider ids. The single source for the string values

--- a/src/transcription/TranscriptionService.ts
+++ b/src/transcription/TranscriptionService.ts
@@ -151,9 +151,10 @@ export class TranscriptionService {
 		this.throwIfCancelled(token);
 
 		if (prepared.diarizationSplitWarning) {
-			// The recording was too large to send whole and this engine numbers
-			// speakers per request, so labels can differ between parts. Tell the
-			// user rather than emitting silently inconsistent speaker labels.
+			// The recording was too long (or too large) for one request and had
+			// to be split. Every engine numbers speakers per request, so labels
+			// can differ between parts; tell the user rather than emitting
+			// silently inconsistent speaker labels.
 			new Notice(
 				'Recording was split into parts for this engine; speaker labels may ' +
 					'differ between parts. Use Deepgram or split the recording for ' +

--- a/src/transcription/audioPrep.ts
+++ b/src/transcription/audioPrep.ts
@@ -19,33 +19,12 @@ import {
 	FORMAT_AAC,
 	FORMAT_FLAC,
 	MIME_TYPE_AUDIO_PREFIX,
+	MIN_AUDIO_BYTES_PER_SEC,
+	TRANSCRIBE_BYTES_PER_SEC,
 	TRANSCRIBE_SAMPLE_RATE,
 } from '../constants';
 import { decodeToMono16k, extractChunkWav, planChunks } from './audioChunks';
 import type { ProviderCapabilities } from './providers/TranscriptionProvider';
-
-/** Bytes in one megabyte, for human-readable size messages. */
-const BYTES_PER_MB = 1024 * 1024;
-
-/**
- * Raised when a file is too large to send whole to a provider that
- * diarizes across an entire request, so it would have to be chunked —
- * which resets speaker numbering per chunk. Refusing is preferable to
- * silently producing inconsistent speaker labels.
- */
-export class WholeFileDiarizationLimitError extends Error {
-	constructor(fileBytes: number, limitBytes: number) {
-		super(
-			`This recording (${String(Math.round(fileBytes / BYTES_PER_MB))} MB) ` +
-				`is too large for diarized transcription with this provider, which ` +
-				`needs the whole file in one request (limit ` +
-				`${String(Math.round(limitBytes / BYTES_PER_MB))} MB). Disable ` +
-				`speaker diarization, split the recording, or use a provider with a ` +
-				`higher limit.`,
-		);
-		this.name = 'WholeFileDiarizationLimitError';
-	}
-}
 
 /** Maps a lowercased file extension to its upload container MIME type. */
 const EXTENSION_MIME: Record<string, string> = {
@@ -74,6 +53,13 @@ export function audioMimeFromExtension(extension: string): string {
 export interface AudioPrepOptions {
 	/** Hard per-request byte ceiling declared by the provider. */
 	maxRequestBytes: number;
+	/**
+	 * Longest recording, in seconds, the provider transcribes in one request.
+	 * A recording longer than this is decoded and split even when its bytes fit
+	 * {@link maxRequestBytes}. Number.POSITIVE_INFINITY disables the duration
+	 * gate (the whole-file decision then rests on bytes alone).
+	 */
+	maxRequestSeconds: number;
 	/** Whether the provider accepts the original container bytes. */
 	acceptsOriginalContainer: boolean;
 	/**
@@ -83,12 +69,6 @@ export interface AudioPrepOptions {
 	chunkBytes: number;
 	/** Whether speaker diarization is requested for this run. */
 	diarize: boolean;
-	/**
-	 * Whether the provider needs the whole file in one request for stable
-	 * speaker numbering. When true and diarization is requested, a file that
-	 * must be chunked is rejected rather than silently re-numbered per chunk.
-	 */
-	diarizesWholeFile: boolean;
 }
 
 /**
@@ -113,43 +93,70 @@ export interface PreparedAudio {
 	/** Ordered payloads to transcribe; segment offsets are pre-computed. */
 	payloads: PreparedPayload[];
 	/**
-	 * True when a diarized run had to be split across multiple chunks on a
-	 * provider that numbers speakers per request (not whole-file), so speaker
-	 * labels can reset between parts. The caller surfaces this to the user
-	 * rather than letting the inconsistency pass silently.
+	 * True when a diarized run had to be split across multiple parts (too large
+	 * or too long for one request), so speaker numbering can reset between parts
+	 * — every provider numbers speakers per request once the recording is split.
+	 * The caller surfaces this to the user rather than letting the inconsistency
+	 * pass silently.
 	 */
 	diarizationSplitWarning: boolean;
 }
 
 /**
- * Whether a diarized run will be split across more than one chunk on a
- * provider that does not diarize the whole request, in which case speaker
- * numbering can differ between parts. Pure so the warning condition is unit
- * tested without decoding audio.
- * @param chunkCount - Number of chunks the audio was split into
+ * Whether a diarized run was split across more than one part, in which case
+ * speaker numbering can differ between parts. Once a recording is split, every
+ * provider numbers speakers per request, so even a whole-file diarizer loses
+ * cross-part consistency. Pure so the warning condition is unit tested without
+ * decoding audio.
+ * @param chunkCount - Number of parts the audio was split into
  * @param diarize - Whether speaker diarization was requested
- * @param diarizesWholeFile - Whether the provider diarizes a whole request
- * @returns True when speaker labels may be inconsistent across chunks
+ * @returns True when speaker labels may be inconsistent across parts
  */
 export function shouldWarnDiarizationSplit(
 	chunkCount: number,
 	diarize: boolean,
-	diarizesWholeFile: boolean,
 ): boolean {
-	return diarize && !diarizesWholeFile && chunkCount > 1;
+	return diarize && chunkCount > 1;
+}
+
+/**
+ * Whether a file's byte size alone proves it is within a provider's per-request
+ * duration cap, so it can be sent whole without first decoding it to measure
+ * its true length. Uses a conservative minimum bitrate ({@link
+ * MIN_AUDIO_BYTES_PER_SEC}): below `cap * minBitrate` bytes even the most
+ * heavily compressed audio cannot exceed the cap. An infinite cap is always
+ * satisfied. A larger file is not necessarily too long — it just cannot be
+ * proven short cheaply, so it falls through to the decode path, which measures
+ * the exact duration.
+ * @param byteLength - Encoded file size in bytes
+ * @param maxRequestSeconds - Provider per-request duration cap in seconds
+ * @returns True when the byte size guarantees the recording is within the cap
+ */
+export function withinDurationCap(
+	byteLength: number,
+	maxRequestSeconds: number,
+): boolean {
+	if (!Number.isFinite(maxRequestSeconds)) {
+		return true;
+	}
+	return byteLength <= maxRequestSeconds * MIN_AUDIO_BYTES_PER_SEC;
 }
 
 /**
  * Prepares an audio file into provider-ready payloads.
  *
- * Whole-file path: when the provider accepts the original container and the
- * encoded file is within its limit, the original bytes are sent as one
- * payload — no decode, so peak memory is just the file size and any
- * whole-file diarization stays consistent.
+ * Whole-file path: when the provider accepts the original container, the
+ * encoded file is within its byte limit, and the byte size proves the
+ * recording is within the provider's per-request duration cap, the original
+ * bytes are sent as one payload — no decode, so peak memory is just the file
+ * size and any whole-file diarization stays consistent.
  *
- * Decode path: otherwise the file is decoded to 16 kHz mono and split into
- * WAV chunks bounded by `chunkBytes` (one chunk when `chunkBytes` is
- * infinite, e.g. a local engine with no upload limit).
+ * Decode path: otherwise (an unsupported container, an over-limit file, or a
+ * recording too long for one request) the file is decoded to 16 kHz mono and
+ * split into WAV chunks bounded by `chunkBytes` (a single chunk when it still
+ * fits, e.g. a duration cap the byte proxy could not rule out cheaply). A
+ * diarized split is flagged so the caller can warn that speaker numbering may
+ * reset between parts.
  * @param raw - Encoded file bytes
  * @param fileName - Source file name (used as the upload filename)
  * @param fileMime - MIME type for the original container
@@ -164,7 +171,8 @@ export async function prepareAudio(
 ): Promise<PreparedAudio> {
 	if (
 		options.acceptsOriginalContainer &&
-		raw.byteLength <= options.maxRequestBytes
+		raw.byteLength <= options.maxRequestBytes &&
+		withinDurationCap(raw.byteLength, options.maxRequestSeconds)
 	) {
 		return {
 			payloads: [
@@ -177,16 +185,6 @@ export async function prepareAudio(
 			],
 			diarizationSplitWarning: false,
 		};
-	}
-
-	// The file must be decoded and split. A provider that diarizes across the
-	// whole request cannot keep speaker numbering stable once chunked, so
-	// refuse rather than emit a transcript with reset speakers per chunk.
-	if (options.diarize && options.diarizesWholeFile) {
-		throw new WholeFileDiarizationLimitError(
-			raw.byteLength,
-			options.maxRequestBytes,
-		);
 	}
 
 	const samples = await decodeToMono16k(raw);
@@ -204,16 +202,19 @@ export async function prepareAudio(
 		diarizationSplitWarning: shouldWarnDiarizationSplit(
 			plans.length,
 			options.diarize,
-			options.diarizesWholeFile,
 		),
 	};
 }
 
 /**
  * Computes provider-ready preparation options from capabilities and the
- * user's preferred chunk size. Network providers honor the user's chunk
- * size (bounded by the provider limit); a local provider with no upload
- * limit produces a single chunk.
+ * user's preferred chunk size. A provider with a per-request duration cap
+ * (Gemini) sizes its parts by that cap, so the whole-file threshold and the
+ * split size agree and a recording just over the cap divides into even parts;
+ * the user's byte-oriented chunk size targets the Whisper API's 25 MB request
+ * limit and does not apply. Otherwise a network provider honors the user's
+ * chunk size (bounded by the provider limit) and a local provider with no
+ * upload limit produces a single chunk.
  * @param capabilities - The provider's declared capabilities
  * @param requiresNetwork - Whether the provider uploads over the network
  * @param userChunkBytes - The user-configured chunk size in bytes
@@ -226,14 +227,16 @@ export function audioPrepOptions(
 	userChunkBytes: number,
 	diarize: boolean,
 ): AudioPrepOptions {
-	const chunkBytes = requiresNetwork
-		? Math.min(capabilities.maxRequestBytes, userChunkBytes)
-		: capabilities.maxRequestBytes;
+	const chunkBytes = Number.isFinite(capabilities.maxRequestSeconds)
+		? capabilities.maxRequestSeconds * TRANSCRIBE_BYTES_PER_SEC
+		: requiresNetwork
+			? Math.min(capabilities.maxRequestBytes, userChunkBytes)
+			: capabilities.maxRequestBytes;
 	return {
 		maxRequestBytes: capabilities.maxRequestBytes,
+		maxRequestSeconds: capabilities.maxRequestSeconds,
 		acceptsOriginalContainer: capabilities.acceptsOriginalContainer,
 		chunkBytes,
 		diarize,
-		diarizesWholeFile: capabilities.diarizesWholeFile,
 	};
 }

--- a/src/transcription/audioPrep.ts
+++ b/src/transcription/audioPrep.ts
@@ -157,6 +157,15 @@ export function withinDurationCap(
  * fits, e.g. a duration cap the byte proxy could not rule out cheaply). A
  * diarized split is flagged so the caller can warn that speaker numbering may
  * reset between parts.
+ *
+ * The decode path always emits WAV, even for a single part that fits whole.
+ * Re-sending the original bytes instead would save the WAV size on an accepted
+ * compressed container, but it would force a second decode in a provider that
+ * decodes containers it does not accept (Gemini re-decodes mp4/webm) — and
+ * those are this plugin's own recording formats, the common case. Emitting WAV
+ * keeps the recorded-file path to a single decode; the only cost is a larger
+ * upload for the uncommon case of an imported accepted container (mp3/aac/…)
+ * big enough to miss the cheap whole-file proof yet short enough to fit.
  * @param raw - Encoded file bytes
  * @param fileName - Source file name (used as the upload filename)
  * @param fileMime - MIME type for the original container
@@ -228,7 +237,10 @@ export function audioPrepOptions(
 	diarize: boolean,
 ): AudioPrepOptions {
 	const chunkBytes = Number.isFinite(capabilities.maxRequestSeconds)
-		? capabilities.maxRequestSeconds * TRANSCRIBE_BYTES_PER_SEC
+		? Math.min(
+				capabilities.maxRequestSeconds * TRANSCRIBE_BYTES_PER_SEC,
+				capabilities.maxRequestBytes,
+			)
 		: requiresNetwork
 			? Math.min(capabilities.maxRequestBytes, userChunkBytes)
 			: capabilities.maxRequestBytes;

--- a/src/transcription/providers/GeminiProvider.ts
+++ b/src/transcription/providers/GeminiProvider.ts
@@ -1,9 +1,10 @@
 /**
- * Transcription via Google Gemini. Uploads the whole audio file with the File
- * API — so speaker numbering stays consistent across the recording — then asks
- * `generateContent` for a structured JSON transcript with timecodes and
- * optional speaker labels. Containers Gemini does not accept (e.g. webm) are
- * decoded to 16 kHz mono WAV before upload.
+ * Transcription via Google Gemini. Uploads one audio payload with the File API,
+ * then asks `generateContent` for a structured JSON transcript with timecodes
+ * and optional speaker labels. The orchestrator sends a short recording whole
+ * (one payload, so speaker numbering stays consistent across it) and splits a
+ * recording too long for one request into parts. Containers Gemini does not
+ * accept (e.g. webm) are decoded to 16 kHz mono WAV before upload.
  * @module transcription/providers/GeminiProvider
  */
 

--- a/src/transcription/providers/TranscriptionProvider.ts
+++ b/src/transcription/providers/TranscriptionProvider.ts
@@ -63,12 +63,6 @@ export interface ProviderCapabilities {
 	 */
 	acceptsOriginalContainer: boolean;
 	/**
-	 * Whether the provider diarizes across an entire request with consistent
-	 * speaker numbering. When true, the service prefers sending the whole
-	 * file so speaker labels stay stable instead of resetting per chunk.
-	 */
-	diarizesWholeFile: boolean;
-	/**
 	 * Whether the provider can return speaker labels at all. Gates the
 	 * diarization UI and the diarize request: an engine that cannot diarize
 	 * (OpenAI's Whisper, local whisper.cpp) must not offer an enabled toggle,

--- a/src/transcription/providers/TranscriptionProvider.ts
+++ b/src/transcription/providers/TranscriptionProvider.ts
@@ -49,6 +49,15 @@ export interface ProviderCapabilities {
 	 */
 	maxRequestBytes: number;
 	/**
+	 * Longest recording, in seconds, the provider transcribes reliably in one
+	 * request. A recording longer than this is decoded and split into parts
+	 * even when its byte size fits {@link maxRequestBytes}, because inference
+	 * time and the output transcript grow with audio duration, not bytes. Use
+	 * Number.POSITIVE_INFINITY when the provider has no practical per-request
+	 * duration limit (a whole-file API like Deepgram, or a local engine).
+	 */
+	maxRequestSeconds: number;
+	/**
 	 * Whether the provider accepts the original container bytes (any common
 	 * audio format). When false, the provider needs decoded 16 kHz mono WAV.
 	 */

--- a/src/transcription/providers/capabilities.ts
+++ b/src/transcription/providers/capabilities.ts
@@ -26,7 +26,6 @@ export const WHISPER_API_CAPABILITIES: ProviderCapabilities = {
 	maxRequestBytes: WHISPER_API_MAX_REQUEST_BYTES,
 	maxRequestSeconds: Number.POSITIVE_INFINITY,
 	acceptsOriginalContainer: true,
-	diarizesWholeFile: false,
 	supportsDiarization: false,
 };
 
@@ -35,7 +34,6 @@ export const DEEPGRAM_CAPABILITIES: ProviderCapabilities = {
 	maxRequestBytes: DEEPGRAM_MAX_REQUEST_BYTES,
 	maxRequestSeconds: Number.POSITIVE_INFINITY,
 	acceptsOriginalContainer: true,
-	diarizesWholeFile: true,
 	supportsDiarization: true,
 };
 
@@ -44,7 +42,6 @@ export const LOCAL_WHISPER_CAPABILITIES: ProviderCapabilities = {
 	maxRequestBytes: Number.POSITIVE_INFINITY,
 	maxRequestSeconds: Number.POSITIVE_INFINITY,
 	acceptsOriginalContainer: false,
-	diarizesWholeFile: false,
 	supportsDiarization: false,
 };
 
@@ -61,7 +58,6 @@ export const GEMINI_CAPABILITIES: ProviderCapabilities = {
 	maxRequestBytes: GEMINI_MAX_REQUEST_BYTES,
 	maxRequestSeconds: GEMINI_MAX_WHOLE_FILE_SECONDS,
 	acceptsOriginalContainer: true,
-	diarizesWholeFile: true,
 	supportsDiarization: true,
 };
 

--- a/src/transcription/providers/capabilities.ts
+++ b/src/transcription/providers/capabilities.ts
@@ -11,6 +11,7 @@
 import {
 	DEEPGRAM_MAX_REQUEST_BYTES,
 	GEMINI_MAX_REQUEST_BYTES,
+	GEMINI_MAX_WHOLE_FILE_SECONDS,
 	TRANSCRIPTION_PROVIDER_IDS,
 	WHISPER_API_MAX_REQUEST_BYTES,
 } from '../../constants';
@@ -23,6 +24,7 @@ import type { ProviderCapabilities } from './TranscriptionProvider';
  */
 export const WHISPER_API_CAPABILITIES: ProviderCapabilities = {
 	maxRequestBytes: WHISPER_API_MAX_REQUEST_BYTES,
+	maxRequestSeconds: Number.POSITIVE_INFINITY,
 	acceptsOriginalContainer: true,
 	diarizesWholeFile: false,
 	supportsDiarization: false,
@@ -31,6 +33,7 @@ export const WHISPER_API_CAPABILITIES: ProviderCapabilities = {
 /** Deepgram pre-recorded API: diarizes a whole request with stable labels. */
 export const DEEPGRAM_CAPABILITIES: ProviderCapabilities = {
 	maxRequestBytes: DEEPGRAM_MAX_REQUEST_BYTES,
+	maxRequestSeconds: Number.POSITIVE_INFINITY,
 	acceptsOriginalContainer: true,
 	diarizesWholeFile: true,
 	supportsDiarization: true,
@@ -39,6 +42,7 @@ export const DEEPGRAM_CAPABILITIES: ProviderCapabilities = {
 /** Local whisper.cpp: no upload limit, needs decoded WAV, no diarization. */
 export const LOCAL_WHISPER_CAPABILITIES: ProviderCapabilities = {
 	maxRequestBytes: Number.POSITIVE_INFINITY,
+	maxRequestSeconds: Number.POSITIVE_INFINITY,
 	acceptsOriginalContainer: false,
 	diarizesWholeFile: false,
 	supportsDiarization: false,
@@ -48,10 +52,14 @@ export const LOCAL_WHISPER_CAPABILITIES: ProviderCapabilities = {
  * Google Gemini: a multimodal model that transcribes a whole file uploaded via
  * the File API in one request, so it diarizes with stable speaker numbering.
  * Accepts the original container (unsupported formats are decoded to WAV inside
- * the provider).
+ * the provider). Bounded by a per-request duration cap: a recording longer than
+ * {@link GEMINI_MAX_WHOLE_FILE_SECONDS} is split into parts so one request never
+ * outlasts the timeout or truncates the output, at the cost of speaker numbering
+ * resetting between parts (surfaced to the user as a warning).
  */
 export const GEMINI_CAPABILITIES: ProviderCapabilities = {
 	maxRequestBytes: GEMINI_MAX_REQUEST_BYTES,
+	maxRequestSeconds: GEMINI_MAX_WHOLE_FILE_SECONDS,
 	acceptsOriginalContainer: true,
 	diarizesWholeFile: true,
 	supportsDiarization: true,

--- a/tests/unit/audioPrep.test.ts
+++ b/tests/unit/audioPrep.test.ts
@@ -1,19 +1,46 @@
 /**
  * Tests for the audio preparation helpers: extension-to-MIME mapping,
- * capability-derived prep options, the whole-file path (sending the
- * original bytes untouched), and the whole-file diarization guard. The
- * decode path is exercised indirectly via planChunks tests, since decoding
- * needs the Web Audio API.
+ * capability-derived prep options, the cheap whole-file path (sending the
+ * original bytes untouched), the duration-cap proof, and the decode/split
+ * path. The real decode needs the Web Audio API, so `decodeToMono16k` is
+ * mocked to return synthetic samples of a chosen length; the chunk planning
+ * and WAV encoding around it run for real.
  */
+
+jest.mock('src/transcription/audioChunks', () => {
+	const actual = jest.requireActual<
+		typeof import('src/transcription/audioChunks')
+	>('src/transcription/audioChunks');
+	return { ...actual, decodeToMono16k: jest.fn() };
+});
 
 import {
 	audioMimeFromExtension,
 	audioPrepOptions,
 	prepareAudio,
 	shouldWarnDiarizationSplit,
-	WholeFileDiarizationLimitError,
+	withinDurationCap,
 } from 'src/transcription/audioPrep';
+import { decodeToMono16k } from 'src/transcription/audioChunks';
+import { TRANSCRIBE_BYTES_PER_SEC } from 'src/constants';
+import { WAV_HEADER_SIZE } from 'src/recording/WavEncoder';
 import type { ProviderCapabilities } from 'src/transcription/providers/TranscriptionProvider';
+
+const decodeMock = jest.mocked(decodeToMono16k);
+
+/** Synthetic 16 kHz mono samples spanning the given number of seconds. */
+function samplesForSeconds(seconds: number): Float32Array {
+	return new Float32Array(seconds * 16000);
+}
+
+/** A chunk byte budget that yields parts of exactly `seconds` each. */
+function chunkBudgetForSeconds(seconds: number): number {
+	return WAV_HEADER_SIZE + seconds * TRANSCRIBE_BYTES_PER_SEC;
+}
+
+beforeEach(() => {
+	decodeMock.mockReset();
+});
 
 describe('audioMimeFromExtension', () => {
 	it('maps known extensions to container MIME types', () => {
@@ -33,9 +60,32 @@ describe('audioMimeFromExtension', () => {
 	});
 });
 
+describe('withinDurationCap', () => {
+	it('is always satisfied by an infinite cap', () => {
+		expect(
+			withinDurationCap(
+				Number.MAX_SAFE_INTEGER,
+				Number.POSITIVE_INFINITY,
+			),
+		).toBe(true);
+	});
+
+	it('proves a small file is within a finite cap', () => {
+		// 900 s cap admits up to 900_000 bytes at the conservative min bitrate.
+		expect(withinDurationCap(500_000, 900)).toBe(true);
+		expect(withinDurationCap(900_000, 900)).toBe(true);
+	});
+
+	it('cannot prove a larger file short (falls through to decode)', () => {
+		expect(withinDurationCap(900_001, 900)).toBe(false);
+		expect(withinDurationCap(65 * 1024 * 1024, 900)).toBe(false);
+	});
+});
+
 describe('audioPrepOptions', () => {
 	const networkCaps: ProviderCapabilities = {
 		maxRequestBytes: 25 * 1024 * 1024,
+		maxRequestSeconds: Number.POSITIVE_INFINITY,
 		acceptsOriginalContainer: true,
 		diarizesWholeFile: false,
 		supportsDiarization: false,
@@ -50,6 +100,7 @@ describe('audioPrepOptions', () => {
 		);
 		expect(options.chunkBytes).toBe(25 * 1024 * 1024);
 		expect(options.maxRequestBytes).toBe(25 * 1024 * 1024);
+		expect(options.maxRequestSeconds).toBe(Number.POSITIVE_INFINITY);
 		expect(options.acceptsOriginalContainer).toBe(true);
 	});
 
@@ -66,6 +117,7 @@ describe('audioPrepOptions', () => {
 	it('produces a single chunk for an unbounded local provider', () => {
 		const localCaps: ProviderCapabilities = {
 			maxRequestBytes: Number.POSITIVE_INFINITY,
+			maxRequestSeconds: Number.POSITIVE_INFINITY,
 			acceptsOriginalContainer: false,
 			diarizesWholeFile: false,
 			supportsDiarization: false,
@@ -79,91 +131,154 @@ describe('audioPrepOptions', () => {
 		expect(options.chunkBytes).toBe(Number.POSITIVE_INFINITY);
 	});
 
-	it('carries the diarization flags through', () => {
+	it('sizes parts by the duration cap, ignoring the user chunk size', () => {
+		// A duration-capped provider chunks by time, not the user's MB setting.
+		const cappedCaps: ProviderCapabilities = {
+			maxRequestBytes: 2 * 1024 * 1024 * 1024,
+			maxRequestSeconds: 900,
+			acceptsOriginalContainer: true,
+			diarizesWholeFile: true,
+			supportsDiarization: true,
+		};
+		const options = audioPrepOptions(
+			cappedCaps,
+			true,
+			24 * 1024 * 1024,
+			true,
+		);
+		expect(options.chunkBytes).toBe(900 * TRANSCRIBE_BYTES_PER_SEC);
+		expect(options.maxRequestSeconds).toBe(900);
+	});
+
+	it('carries the diarization flag and request limits through', () => {
 		const diarizingCaps: ProviderCapabilities = {
 			maxRequestBytes: 1000,
+			maxRequestSeconds: Number.POSITIVE_INFINITY,
 			acceptsOriginalContainer: true,
 			diarizesWholeFile: true,
 			supportsDiarization: true,
 		};
 		const options = audioPrepOptions(diarizingCaps, true, 1000, true);
 		expect(options.diarize).toBe(true);
-		expect(options.diarizesWholeFile).toBe(true);
+		expect(options.maxRequestSeconds).toBe(Number.POSITIVE_INFINITY);
 	});
 });
 
 describe('shouldWarnDiarizationSplit', () => {
-	it('warns when a diarized run is split on a per-request-numbering provider', () => {
-		expect(shouldWarnDiarizationSplit(2, true, false)).toBe(true);
+	it('warns when a diarized run is split into parts', () => {
+		expect(shouldWarnDiarizationSplit(2, true)).toBe(true);
 	});
 
-	it('does not warn for a single chunk', () => {
-		expect(shouldWarnDiarizationSplit(1, true, false)).toBe(false);
+	it('does not warn for a single part', () => {
+		expect(shouldWarnDiarizationSplit(1, true)).toBe(false);
 	});
 
 	it('does not warn when diarization was not requested', () => {
-		expect(shouldWarnDiarizationSplit(3, false, false)).toBe(false);
-	});
-
-	it('does not warn for a provider that diarizes the whole request', () => {
-		expect(shouldWarnDiarizationSplit(3, true, true)).toBe(false);
+		expect(shouldWarnDiarizationSplit(3, false)).toBe(false);
 	});
 });
 
 describe('prepareAudio (whole-file path)', () => {
-	it('sends the original bytes untouched when within the limit', async () => {
+	it('sends the original bytes untouched when within the limits', async () => {
 		const raw = new Uint8Array([1, 2, 3, 4]).buffer;
 		const result = await prepareAudio(raw, 'rec.webm', 'audio/webm', {
 			maxRequestBytes: 1000,
+			maxRequestSeconds: Number.POSITIVE_INFINITY,
 			acceptsOriginalContainer: true,
 			chunkBytes: 1000,
 			diarize: false,
-			diarizesWholeFile: false,
 		});
 		expect(result.payloads).toHaveLength(1);
 		expect(result.payloads[0].createData()).toBe(raw);
 		expect(result.payloads[0].contentType).toBe('audio/webm');
 		expect(result.payloads[0].filename).toBe('rec.webm');
 		expect(result.payloads[0].offsetSeconds).toBe(0);
+		expect(decodeMock).not.toHaveBeenCalled();
 	});
 
 	it('does not flag a diarization split when the whole file is sent', async () => {
 		const raw = new Uint8Array([1, 2, 3, 4]).buffer;
 		const result = await prepareAudio(raw, 'rec.webm', 'audio/webm', {
 			maxRequestBytes: 1000,
+			maxRequestSeconds: Number.POSITIVE_INFINITY,
 			acceptsOriginalContainer: true,
 			chunkBytes: 1000,
 			diarize: true,
-			diarizesWholeFile: false,
 		});
 		expect(result.diarizationSplitWarning).toBe(false);
 	});
 
-	it('sends the whole file even when diarizing, as long as it fits', async () => {
-		const raw = new Uint8Array([1, 2, 3, 4]).buffer;
-		const result = await prepareAudio(raw, 'rec.webm', 'audio/webm', {
-			maxRequestBytes: 1000,
+	it('sends a short file whole when the byte size proves it within the cap', async () => {
+		const raw = new Uint8Array(500).buffer;
+		const result = await prepareAudio(raw, 'rec.mp3', 'audio/mpeg', {
+			maxRequestBytes: 10_000_000,
+			maxRequestSeconds: 900,
 			acceptsOriginalContainer: true,
-			chunkBytes: 1000,
+			chunkBytes: 900 * TRANSCRIBE_BYTES_PER_SEC,
 			diarize: true,
-			diarizesWholeFile: true,
 		});
 		expect(result.payloads).toHaveLength(1);
 		expect(result.payloads[0].createData()).toBe(raw);
+		expect(result.diarizationSplitWarning).toBe(false);
+		expect(decodeMock).not.toHaveBeenCalled();
 	});
 });
 
-describe('prepareAudio (whole-file diarization guard)', () => {
-	it('refuses to chunk a too-large file for a whole-file diarizing provider', async () => {
-		const raw = new Uint8Array(2048).buffer;
-		await expect(
-			prepareAudio(raw, 'rec.webm', 'audio/webm', {
-				maxRequestBytes: 1024,
-				acceptsOriginalContainer: true,
-				chunkBytes: 512,
-				diarize: true,
-				diarizesWholeFile: true,
-			}),
-		).rejects.toBeInstanceOf(WholeFileDiarizationLimitError);
+describe('prepareAudio (duration-cap decode path)', () => {
+	it('decodes and splits a recording too long for one request, even within the byte limit', async () => {
+		// 6 s of audio, parts of 2 s each: the byte size fits the limit but the
+		// duration cap (2 s here) forces a decode-and-split into three parts.
+		decodeMock.mockResolvedValue(samplesForSeconds(6));
+		const raw = new Uint8Array(50_000).buffer;
+		const result = await prepareAudio(raw, 'rec.mp4', 'audio/mp4', {
+			maxRequestBytes: 10_000_000,
+			maxRequestSeconds: 2,
+			acceptsOriginalContainer: true,
+			chunkBytes: chunkBudgetForSeconds(2),
+			diarize: true,
+		});
+		expect(decodeMock).toHaveBeenCalledTimes(1);
+		expect(result.payloads).toHaveLength(3);
+		expect(result.payloads.map((p) => p.offsetSeconds)).toEqual([0, 2, 4]);
+		expect(result.payloads.map((p) => p.filename)).toEqual([
+			'audio-0.wav',
+			'audio-1.wav',
+			'audio-2.wav',
+		]);
+		expect(result.payloads[0].contentType).toBe('audio/wav');
+		expect(result.diarizationSplitWarning).toBe(true);
+	});
+
+	it('does not warn about speakers when diarization is off', async () => {
+		decodeMock.mockResolvedValue(samplesForSeconds(6));
+		const raw = new Uint8Array(50_000).buffer;
+		const result = await prepareAudio(raw, 'rec.mp4', 'audio/mp4', {
+			maxRequestBytes: 10_000_000,
+			maxRequestSeconds: 2,
+			acceptsOriginalContainer: true,
+			chunkBytes: chunkBudgetForSeconds(2),
+			diarize: false,
+		});
+		expect(result.payloads).toHaveLength(3);
+		expect(result.diarizationSplitWarning).toBe(false);
+	});
+
+	it('emits a single decoded part when the recording still fits the cap', async () => {
+		// A 2 MB file exceeds the cheap byte proof (900 s admits < 0.9 MB), so it
+		// is decoded; the measured duration then fits one part, so there is no
+		// split and no speaker warning.
+		decodeMock.mockResolvedValue(samplesForSeconds(2));
+		const raw = new Uint8Array(2_000_000).buffer;
+		const result = await prepareAudio(raw, 'rec.mp4', 'audio/mp4', {
+			maxRequestBytes: 10_000_000,
+			maxRequestSeconds: 900,
+			acceptsOriginalContainer: true,
+			chunkBytes: chunkBudgetForSeconds(900),
+			diarize: true,
+		});
+		expect(decodeMock).toHaveBeenCalledTimes(1);
+		expect(result.payloads).toHaveLength(1);
+		expect(result.payloads[0].filename).toBe('audio.wav');
+		expect(result.diarizationSplitWarning).toBe(false);
 	});
 });

--- a/tests/unit/audioPrep.test.ts
+++ b/tests/unit/audioPrep.test.ts
@@ -22,7 +22,10 @@ import {
 	withinDurationCap,
 } from 'src/transcription/audioPrep';
 import { decodeToMono16k } from 'src/transcription/audioChunks';
-import { TRANSCRIBE_BYTES_PER_SEC } from 'src/constants';
+import {
+	TRANSCRIBE_BYTES_PER_SEC,
+	TRANSCRIBE_SAMPLE_RATE,
+} from 'src/constants';
 import { WAV_HEADER_SIZE } from 'src/recording/WavEncoder';
 import type { ProviderCapabilities } from 'src/transcription/providers/TranscriptionProvider';
 
@@ -30,7 +33,7 @@ const decodeMock = jest.mocked(decodeToMono16k);
 
 /** Synthetic 16 kHz mono samples spanning the given number of seconds. */
 function samplesForSeconds(seconds: number): Float32Array {
-	return new Float32Array(seconds * 16000);
+	return new Float32Array(seconds * TRANSCRIBE_SAMPLE_RATE);
 }
 
 /** A chunk byte budget that yields parts of exactly `seconds` each. */
@@ -87,7 +90,6 @@ describe('audioPrepOptions', () => {
 		maxRequestBytes: 25 * 1024 * 1024,
 		maxRequestSeconds: Number.POSITIVE_INFINITY,
 		acceptsOriginalContainer: true,
-		diarizesWholeFile: false,
 		supportsDiarization: false,
 	};
 
@@ -119,7 +121,6 @@ describe('audioPrepOptions', () => {
 			maxRequestBytes: Number.POSITIVE_INFINITY,
 			maxRequestSeconds: Number.POSITIVE_INFINITY,
 			acceptsOriginalContainer: false,
-			diarizesWholeFile: false,
 			supportsDiarization: false,
 		};
 		const options = audioPrepOptions(
@@ -137,7 +138,6 @@ describe('audioPrepOptions', () => {
 			maxRequestBytes: 2 * 1024 * 1024 * 1024,
 			maxRequestSeconds: 900,
 			acceptsOriginalContainer: true,
-			diarizesWholeFile: true,
 			supportsDiarization: true,
 		};
 		const options = audioPrepOptions(
@@ -155,7 +155,6 @@ describe('audioPrepOptions', () => {
 			maxRequestBytes: 1000,
 			maxRequestSeconds: Number.POSITIVE_INFINITY,
 			acceptsOriginalContainer: true,
-			diarizesWholeFile: true,
 			supportsDiarization: true,
 		};
 		const options = audioPrepOptions(diarizingCaps, true, 1000, true);

--- a/tests/unit/providerCapabilities.test.ts
+++ b/tests/unit/providerCapabilities.test.ts
@@ -33,6 +33,21 @@ describe('transcription provider capabilities', () => {
 		expect(GEMINI_CAPABILITIES.supportsDiarization).toBe(true);
 	});
 
+	it('caps only Gemini by per-request duration; others are unbounded', () => {
+		// Gemini transcribes a whole file in one synchronous request, so a long
+		// recording must be split; the whole-file APIs have no duration limit.
+		expect(GEMINI_CAPABILITIES.maxRequestSeconds).toBe(15 * 60);
+		expect(WHISPER_API_CAPABILITIES.maxRequestSeconds).toBe(
+			Number.POSITIVE_INFINITY,
+		);
+		expect(DEEPGRAM_CAPABILITIES.maxRequestSeconds).toBe(
+			Number.POSITIVE_INFINITY,
+		);
+		expect(LOCAL_WHISPER_CAPABILITIES.maxRequestSeconds).toBe(
+			Number.POSITIVE_INFINITY,
+		);
+	});
+
 	it('maps every engine id to its capabilities', () => {
 		expect(TRANSCRIPTION_PROVIDER_CAPABILITIES['whisper-api']).toBe(
 			WHISPER_API_CAPABILITIES,

--- a/tests/unit/transcriptionCore.test.ts
+++ b/tests/unit/transcriptionCore.test.ts
@@ -207,7 +207,7 @@ describe('provider factories', () => {
 		);
 		expect(provider.id).toBe('deepgram');
 		expect(provider.capabilities.acceptsOriginalContainer).toBe(true);
-		expect(provider.capabilities.diarizesWholeFile).toBe(true);
+		expect(provider.capabilities.supportsDiarization).toBe(true);
 	});
 
 	it('requires an Anthropic key but not an Ollama key', () => {

--- a/tests/unit/transcriptionDiarizeGating.test.ts
+++ b/tests/unit/transcriptionDiarizeGating.test.ts
@@ -40,6 +40,7 @@ function makeProvider(): TranscriptionProvider & {
 		requiresNetwork: false,
 		capabilities: {
 			maxRequestBytes: Number.POSITIVE_INFINITY,
+			maxRequestSeconds: Number.POSITIVE_INFINITY,
 			acceptsOriginalContainer: true,
 			diarizesWholeFile: true,
 			supportsDiarization: true,

--- a/tests/unit/transcriptionDiarizeGating.test.ts
+++ b/tests/unit/transcriptionDiarizeGating.test.ts
@@ -42,7 +42,6 @@ function makeProvider(): TranscriptionProvider & {
 			maxRequestBytes: Number.POSITIVE_INFINITY,
 			maxRequestSeconds: Number.POSITIVE_INFINITY,
 			acceptsOriginalContainer: true,
-			diarizesWholeFile: true,
 			supportsDiarization: true,
 		},
 		lastOptions: null as TranscribeOptions | null,

--- a/tests/unit/transcriptionServiceCancel.test.ts
+++ b/tests/unit/transcriptionServiceCancel.test.ts
@@ -39,7 +39,6 @@ function makeProvider(onTranscribe: () => void): TranscriptionProvider {
 			maxRequestBytes: Number.POSITIVE_INFINITY,
 			maxRequestSeconds: Number.POSITIVE_INFINITY,
 			acceptsOriginalContainer: true,
-			diarizesWholeFile: false,
 			supportsDiarization: false,
 		},
 		transcribe: jest.fn(async () => {

--- a/tests/unit/transcriptionServiceCancel.test.ts
+++ b/tests/unit/transcriptionServiceCancel.test.ts
@@ -37,6 +37,7 @@ function makeProvider(onTranscribe: () => void): TranscriptionProvider {
 		requiresNetwork: false,
 		capabilities: {
 			maxRequestBytes: Number.POSITIVE_INFINITY,
+			maxRequestSeconds: Number.POSITIVE_INFINITY,
 			acceptsOriginalContainer: true,
 			diarizesWholeFile: false,
 			supportsDiarization: false,


### PR DESCRIPTION
## Problem

Gemini transcribes a whole uploaded file in **one synchronous `generateContent` request**, so a long recording outlasts the request timeout and risks `MAX_TOKENS` output truncation — both inference time and the transcript length grow with audio duration. On a 70-minute meeting (`recording-multitrack-...mp4`, 65 MB) the request fails with:

> Request to `…/gemini-2.5-flash:generateContent` timed out after 251856 ms

The orchestrator never split Gemini because its only chunking trigger was the **byte limit** (2 GB), which such a file is nowhere near. The problem is duration, not byte size.

## Fix

Add a per-request **duration cap** to provider capabilities (`maxRequestSeconds`):

- **Gemini** → `GEMINI_MAX_WHOLE_FILE_SECONDS` (15 min). A recording longer than the cap is decoded and split into duration-sized parts, transcribed separately, and stitched back onto the timeline with the existing `stitchChunks`. Each part comfortably finishes within the request timeout and stays well under the output-token budget.
- **Whole-file APIs (Whisper, Deepgram) and the local engine** → unbounded (`Infinity`); behaviour unchanged.

A cheap byte-size proof (`withinDurationCap` / `MIN_AUDIO_BYTES_PER_SEC`) keeps short files on the no-decode whole-file path, so they are not decoded just to measure their length.

Splitting resets Gemini's per-request speaker numbering, so a diarized split now **surfaces the existing warning instead of refusing the run**: the `WholeFileDiarizationLimitError` hard refusal is retired in favour of completing the transcript and warning that speaker labels may differ between parts (use Deepgram for stable speakers across a long recording).

## Verification

- `npm test -- --no-coverage` — 87 suites, **1294 tests** passed
- `npm run lint` — clean
- `npm run build` — `tsc -noEmit` + esbuild production, no errors

New tests cover `withinDurationCap`, the duration-sized chunk budget, the cheap whole-file path, and the decode/split path (with `decodeToMono16k` mocked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)