### PR TITLE
feat(transcription): rework LLM post-processing settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,13 +268,15 @@ While a transcription runs, the dialog shows a progress bar and a **Cancel** but
 
 ### LLM post-processing
 
-Optionally pass the transcript through an LLM to **clean up** punctuation/formatting (preserving wording, timestamps, and speakers), **summarize** it into key points and action items, or apply a **custom instruction**. Providers:
+Optionally pass the transcript through an LLM to **clean up** punctuation/formatting (preserving wording, timestamps, and speakers), **summarize** it into key points and action items, or apply a **custom instruction**. Each task has its own editable prompt: the cleanup and summary prompts ship with sensible defaults and have the transcript language appended automatically, while the custom instruction is sent verbatim and gets a larger editor. Providers:
 
-- **OpenAI / Groq / Ollama** (OpenAI-compatible chat API — a local Ollama server needs no key).
+- **OpenAI** — defaults to `gpt-4o-mini`.
 - **Anthropic (Claude)** — defaults to `claude-opus-4-8`.
 - **Google Gemini** — defaults to `gemini-2.5-flash`.
 
-> **API keys** are stored in the plugin's `data.json` on this device and are never written to diagnostics output. Avoid syncing `data.json` to untrusted locations. Local whisper.cpp and Ollama keep everything offline.
+The model is chosen from a per-provider picker — the same control used for transcription models: pick from the saved list, add a custom model id, or remove one. The API key is shared per vendor with the transcription engines: set the OpenAI key once and it serves both the Whisper API engine and the OpenAI LLM, and likewise for Google Gemini; Anthropic has its own key.
+
+> **API keys** are stored in the plugin's `data.json` on this device and are never written to diagnostics output. Avoid syncing `data.json` to untrusted locations. Local whisper.cpp keeps everything offline.
 
 ## Formats and containers
 

--- a/README.md
+++ b/README.md
@@ -264,7 +264,9 @@ Most options also appear in the **Transcribe audio** dialog, so you can choose t
 
 ### Progress and minimizing
 
-While a transcription runs, the dialog shows a progress bar and a **Cancel** button. Transcription can be slow and may be a paid API call, so you do not have to wait on the open dialog: click **Minimize** to send the job to the status bar and keep working. The status bar then shows live transcription progress; click it (or focus it and press Enter) to reopen the dialog. Recording always takes precedence in the status bar, so the transcription progress reappears once recording finishes. Closing the dialog (instead of minimizing) cancels the running job.
+While a transcription runs, the dialog shows a progress bar, an elapsed-time counter, and a **Cancel** button. Transcription can be slow and may be a paid API call, so you do not have to wait on the open dialog: click **Minimize** to send the job to the status bar and keep working. The status bar then shows live transcription progress; click it (or focus it and press Enter) to reopen the dialog. Recording always takes precedence in the status bar, so the transcription progress reappears once recording finishes. Closing the dialog (instead of minimizing) cancels the running job.
+
+Each network request (one part of a long recording, or a whole-file upload) is bounded by a configurable **Request timeout** (default 10 minutes) under the transcription settings, so a stalled request fails that part and is reported rather than hanging the run indefinitely. Cancellation is checked between requests, so pressing **Cancel** during an in-flight request takes effect once that request returns or hits the timeout.
 
 ### LLM post-processing
 

--- a/docs/audio-cleanup.md
+++ b/docs/audio-cleanup.md
@@ -106,13 +106,13 @@ Start conservative and re-run with stronger settings if needed — the original 
 ## Limitations
 
 - **Output is always WAV.** Convert it afterwards with **Convert audio format** from the context menu if you need a compressed format.
-- **Size and length caps.** Cleanup decodes the whole file into memory and runs part of the work on the main thread, so a file is refused with a clear message when it is larger than 1 GB (checked before decoding), longer than two hours, or decodes to more samples than the working set allows (checked right after decoding). The decoded-size cap catches a heavily compressed file that is small on disk yet expands to several gigabytes once decoded. In every case, split it first (**Split audio into parts**) and clean each part.
+- **Size and length caps.** Cleanup decodes the whole file into memory, then processes it one time segment at a time so memory stays bounded regardless of the recording length — a roughly 45-minute stereo recording is cleaned up in memory without splitting it first. A file is still refused with a clear message when it is larger than 1 GB (checked before decoding), longer than two hours, or decodes to more samples than the working set allows (checked right after decoding). The decoded-size cap catches a heavily compressed file that is small on disk yet expands to several gigabytes once decoded. For a file over the cap, split it first (**Split audio into parts**) and clean each part.
 - **Desktop only.** The plugin is desktop-only, so cleanup runs only in the Obsidian desktop app. Processing a long file briefly uses significant memory and CPU.
 - **Not real-time.** This is post-processing. To shape the signal *during* recording, use the browser input toggles under **Audio processing & feedback** instead.
 
 ## Troubleshooting
 
-- **"Audio file is too large to clean up here"** — the file exceeds the 1 GB on-disk limit, or it decodes to a buffer too large to process here. Split it into parts and process each part.
+- **"Audio file is too large to clean up here"** — the file exceeds the 1 GB on-disk limit, or it decodes to more samples than the working set allows (roughly a 45-minute stereo recording). Split it into parts and process each part.
 - **"Audio is too long to clean up here"** — the file exceeds the two-hour limit. Split it into parts and process each part.
 - **"The file contains no decodable audio data"** — the file is empty or its container/codec can't be decoded by the app. Check the file with **Audio file info**, or convert it first.
 - **"Audio processing failed: …"** — decoding or writing failed; the message carries the cause. Verify the file is a valid audio file and that there is free space in the vault.

--- a/src/cleanup/AudioProcessingModal.ts
+++ b/src/cleanup/AudioProcessingModal.ts
@@ -43,10 +43,22 @@ export class AudioProcessingModal extends Modal {
 	private deleteSource = false;
 	private processing = false;
 
+	/**
+	 * @param app - Obsidian app handle
+	 * @param file - Source audio file to clean up
+	 * @param settings - Plugin settings (seed the default stage config)
+	 * @param onProcessed - Called after a successful write, before the source is
+	 *   trashed, so a caller can link the result into the note while the source
+	 *   embed still resolves. `replaceSource` mirrors the delete-source choice.
+	 */
 	constructor(
 		app: App,
 		private readonly file: TFile,
 		settings: AudioRecorderSettings,
+		private readonly onProcessed?: (result: {
+			outputPath: string;
+			replaceSource: boolean;
+		}) => void | Promise<void>,
 	) {
 		super(app);
 		this.config = resolveAudioDspConfig(settings);
@@ -190,6 +202,22 @@ export class AudioProcessingModal extends Modal {
 		try {
 			const service = new AudioProcessingService(this.app);
 			const outputPath = await service.process(this.file, this.config);
+			// Link the result into the note before the source is trashed, so the
+			// source embed still resolves when it is matched and replaced. A
+			// failure here is non-fatal: the processed file is already written.
+			if (this.onProcessed) {
+				try {
+					await this.onProcessed({
+						outputPath,
+						replaceSource: this.deleteSource,
+					});
+				} catch (linkError) {
+					console.warn(
+						`${PLUGIN_LOG_PREFIX} Failed to link the processed file into the note:`,
+						linkError,
+					);
+				}
+			}
 			if (this.deleteSource) {
 				try {
 					await this.app.fileManager.trashFile(this.file);

--- a/src/cleanup/AudioProcessingService.ts
+++ b/src/cleanup/AudioProcessingService.ts
@@ -31,7 +31,7 @@ import {
  * @param sample - Sample in the range -1..1
  * @returns Signed 16-bit PCM value
  */
-function floatToInt16(sample: number): number {
+export function floatToInt16(sample: number): number {
 	const clamped = Math.max(-1, Math.min(1, sample));
 	return Math.round(clamped < 0 ? clamped * 0x8000 : clamped * 0x7fff);
 }
@@ -73,45 +73,6 @@ const LEVELING_COMPRESSOR_KNEE_DB = 30;
 const LEVELING_COMPRESSOR_RATIO = 12;
 const LEVELING_COMPRESSOR_ATTACK_S = 0.003;
 const LEVELING_COMPRESSOR_RELEASE_S = 0.25;
-
-/**
- * Encodes per-channel Float32 samples (range -1..1) into an interleaved
- * 16-bit PCM WAV file.
- * @param channels - Per-channel sample data (all the same length)
- * @param sampleRate - Sample rate in Hz
- * @returns WAV-encoded bytes
- */
-export function encodeWavInterleaved(
-	channels: Float32Array[],
-	sampleRate: number,
-): ArrayBuffer {
-	const numChannels = Math.max(1, channels.length);
-	const numFrames = channels[0]?.length ?? 0;
-	// The interleave loop indexes every channel up to numFrames (taken
-	// from channel 0). Enforce the equal-length invariant the JSDoc
-	// promises, so a mismatched channel fails loudly instead of writing
-	// NaN (-> silent 0) samples for the missing tail.
-	for (let channel = 1; channel < channels.length; channel++) {
-		if (channels[channel].length !== numFrames) {
-			throw new Error(
-				'Cannot encode WAV: all channels must have the same length.',
-			);
-		}
-	}
-	const pcmByteLength = numFrames * numChannels * 2;
-	const header = createWavHeader(numChannels, sampleRate, pcmByteLength);
-	const out = new ArrayBuffer(WAV_HEADER_SIZE + pcmByteLength);
-	new Uint8Array(out).set(new Uint8Array(header), 0);
-	const view = new DataView(out, WAV_HEADER_SIZE);
-	let offset = 0;
-	for (let frame = 0; frame < numFrames; frame++) {
-		for (let channel = 0; channel < numChannels; channel++) {
-			view.setInt16(offset, floatToInt16(channels[channel][frame]), true);
-			offset += 2;
-		}
-	}
-	return out;
-}
 
 /**
  * Runs the offline audio-cleanup pipeline.

--- a/src/cleanup/AudioProcessingService.ts
+++ b/src/cleanup/AudioProcessingService.ts
@@ -8,17 +8,64 @@
 
 import type { App, TFile } from 'obsidian';
 import {
+	CLEANUP_SEGMENT_SECONDS,
+	CLEANUP_WARMUP_SECONDS,
 	MAX_AUDIO_CLEANUP_BYTES,
 	MAX_AUDIO_CLEANUP_SECONDS,
 	MAX_AUDIO_CLEANUP_DECODED_SAMPLES,
 } from '../constants';
 import { createWavHeader, WAV_HEADER_SIZE } from '../recording/WavEncoder';
 import { resolveUniquePathInDirectory } from '../recording/RecordingFileManager';
+import { delay } from '../utils/TimeUtils';
 import {
 	applyNoiseGateToChannel,
 	dbToGain,
 	type AudioDspConfig,
 } from './audioDsp';
+
+/**
+ * Maps a Float32 sample (range -1..1) to a little-endian int16 value. Uses the
+ * full negative rail (-32768) for negatives and 32767 for positives, matching
+ * the project's int16 mapping (PcmStreamRecorder), rather than scaling both
+ * rails by 32767.
+ * @param sample - Sample in the range -1..1
+ * @returns Signed 16-bit PCM value
+ */
+function floatToInt16(sample: number): number {
+	const clamped = Math.max(-1, Math.min(1, sample));
+	return Math.round(clamped < 0 ? clamped * 0x8000 : clamped * 0x7fff);
+}
+
+/**
+ * Writes `frameCount` interleaved 16-bit PCM frames from `channels`, starting
+ * at source frame `srcFrom`, into the WAV PCM region at destination frame
+ * `destFrame`. Used to fill the output one processed segment at a time.
+ * @param pcm - DataView over the WAV PCM region (after the header)
+ * @param channels - Per-channel segment samples
+ * @param srcFrom - First source frame to copy (skips the discarded warm-up)
+ * @param frameCount - Number of frames to write
+ * @param destFrame - Destination frame offset within the output
+ */
+function writeWavSegment(
+	pcm: DataView,
+	channels: Float32Array[],
+	srcFrom: number,
+	frameCount: number,
+	destFrame: number,
+): void {
+	const numChannels = channels.length;
+	let offset = destFrame * numChannels * 2;
+	for (let frame = 0; frame < frameCount; frame++) {
+		for (let channel = 0; channel < numChannels; channel++) {
+			pcm.setInt16(
+				offset,
+				floatToInt16(channels[channel][srcFrom + frame]),
+				true,
+			);
+			offset += 2;
+		}
+	}
+}
 
 /** Loudness-leveling compressor curve, fixed and tuned for speech. */
 const LEVELING_COMPRESSOR_THRESHOLD_DB = -24;
@@ -59,15 +106,7 @@ export function encodeWavInterleaved(
 	let offset = 0;
 	for (let frame = 0; frame < numFrames; frame++) {
 		for (let channel = 0; channel < numChannels; channel++) {
-			const sample = channels[channel][frame];
-			const clamped = Math.max(-1, Math.min(1, sample));
-			// Match the project's int16 mapping (PcmStreamRecorder): use the
-			// full negative range (-32768) for negatives and 32767 for
-			// positives, rather than scaling both rails by 32767.
-			const pcm = Math.round(
-				clamped < 0 ? clamped * 0x8000 : clamped * 0x7fff,
-			);
-			view.setInt16(offset, pcm, true);
+			view.setInt16(offset, floatToInt16(channels[channel][frame]), true);
 			offset += 2;
 		}
 	}
@@ -78,10 +117,23 @@ export function encodeWavInterleaved(
  * Runs the offline audio-cleanup pipeline.
  */
 export class AudioProcessingService {
-	constructor(private readonly app: App) {}
+	/**
+	 * @param app - Obsidian app handle
+	 * @param segmentSeconds - Processing segment length; defaults to
+	 *   {@link CLEANUP_SEGMENT_SECONDS}. Overridable so tests can force
+	 *   multi-segment behavior on a short clip.
+	 */
+	constructor(
+		private readonly app: App,
+		private readonly segmentSeconds: number = CLEANUP_SEGMENT_SECONDS,
+	) {}
 
 	/**
-	 * Processes an audio file and writes a cleaned WAV copy.
+	 * Processes an audio file and writes a cleaned WAV copy. The signal is
+	 * decoded once, then gated and rendered one time segment at a time directly
+	 * into the output buffer, so peak memory is bounded by the decoded input
+	 * and the WAV output rather than growing with the recording length — a long
+	 * recording is cleaned up in memory without the old "split first" detour.
 	 * @param file - Source audio file
 	 * @param config - Stages to apply
 	 * @returns Vault path of the written file
@@ -93,17 +145,85 @@ export class AudioProcessingService {
 			);
 		}
 		const data = await this.app.vault.readBinary(file);
-		const decoded = await this.decodeChannels(data);
-		const sampleRate = decoded.sampleRate;
-		let samples = decoded.data;
+		const { sampleRate, data: channels } = await this.decodeChannels(data);
+		const numChannels = channels.length;
+		const numFrames = channels[0].length;
 
-		// The gate runs first, on the decoded signal, so the whole pipeline
-		// is a single main-thread pass before the offline render. This keeps
-		// it to one OfflineAudioContext (peak memory) at the cost of the gate
-		// detecting on un-high-passed audio; if a future change needs the
-		// high-pass to precede the gate, split the offline render in two.
+		// Allocate the full interleaved 16-bit WAV output once and fill it a
+		// segment at a time. Only the decoded input and this output live at full
+		// length; each segment's gate/offline working set is released before the
+		// next iteration.
+		const pcmByteLength = numFrames * numChannels * 2;
+		const out = new ArrayBuffer(WAV_HEADER_SIZE + pcmByteLength);
+		new Uint8Array(out).set(
+			new Uint8Array(
+				createWavHeader(numChannels, sampleRate, pcmByteLength),
+			),
+			0,
+		);
+		const pcm = new DataView(out, WAV_HEADER_SIZE);
+
+		const segmentFrames = Math.max(
+			1,
+			Math.floor(sampleRate * this.segmentSeconds),
+		);
+		const warmupFrames = Math.floor(sampleRate * CLEANUP_WARMUP_SECONDS);
+		for (
+			let segStart = 0;
+			segStart < numFrames;
+			segStart += segmentFrames
+		) {
+			const segEnd = Math.min(numFrames, segStart + segmentFrames);
+			await this.processSegment(
+				channels,
+				sampleRate,
+				config,
+				segStart,
+				segEnd,
+				warmupFrames,
+				pcm,
+			);
+			// Yield to the UI between segments so a long file does not freeze it.
+			await delay(0);
+		}
+
+		const outputPath = await this.resolveOutputPath(file);
+		await this.app.vault.createBinary(outputPath, out);
+		return outputPath;
+	}
+
+	/**
+	 * Processes one time segment and writes its kept frames into the output. The
+	 * segment is read with a warm-up lead-in (discarded after processing) so the
+	 * stateful gate and offline stages reach the same envelope they would in a
+	 * continuous pass, leaving no boundary artifact. The gate runs first, on the
+	 * decoded signal, then the high-pass and leveling render offline — the same
+	 * order as a whole-file pass, just bounded to one segment.
+	 * @param channels - Full decoded per-channel samples (read as views)
+	 * @param sampleRate - Sample rate in Hz
+	 * @param config - Stages to apply
+	 * @param segStart - First frame of the kept region
+	 * @param segEnd - End frame (exclusive) of the kept region
+	 * @param warmupFrames - Lead-in frames to process and then discard
+	 * @param pcm - DataView over the output WAV PCM region
+	 */
+	private async processSegment(
+		channels: Float32Array[],
+		sampleRate: number,
+		config: AudioDspConfig,
+		segStart: number,
+		segEnd: number,
+		warmupFrames: number,
+		pcm: DataView,
+	): Promise<void> {
+		const inStart = Math.max(0, segStart - warmupFrames);
+		// Frames of warm-up at the front of the processed segment to drop.
+		const keepFrom = segStart - inStart;
+		let segment = channels.map((channel) =>
+			channel.subarray(inStart, segEnd),
+		);
 		if (config.gate.enabled) {
-			samples = samples.map((channel) =>
+			segment = segment.map((channel) =>
 				applyNoiseGateToChannel(
 					channel,
 					sampleRate,
@@ -112,13 +232,9 @@ export class AudioProcessingService {
 			);
 		}
 		if (config.highPass.enabled || config.leveling.enabled) {
-			samples = await this.renderOffline(samples, sampleRate, config);
+			segment = await this.renderOffline(segment, sampleRate, config);
 		}
-
-		const wav = encodeWavInterleaved(samples, sampleRate);
-		const outputPath = await this.resolveOutputPath(file);
-		await this.app.vault.createBinary(outputPath, wav);
-		return outputPath;
+		writeWavSegment(pcm, segment, keepFrom, segEnd - segStart, segStart);
 	}
 
 	/**

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -616,9 +616,28 @@ export const TRANSCRIBE_REQUEST_TIMEOUT_MS = 120_000;
  * Hard ceiling on a single transcription request timeout, in milliseconds
  * (30 minutes). A whole-file upload (e.g. a multi-hundred-MB Deepgram
  * request) scales its timeout with payload size up to this bound, so a
- * large but healthy upload is never aborted prematurely.
+ * large but healthy upload is never aborted prematurely. Used as the
+ * fallback ceiling when no per-request cap is supplied; the user-facing cap
+ * comes from {@link DEFAULT_TRANSCRIPTION_TIMEOUT_MINUTES} via settings.
  */
 export const TRANSCRIBE_MAX_REQUEST_TIMEOUT_MS = 30 * 60_000;
+
+/**
+ * Default per-request transcription timeout, in minutes. A single network
+ * request (one part of a multi-part job, or a whole-file upload) that runs
+ * longer than this is aborted and reported, so a hung endpoint or a stalled
+ * upload fails the part instead of stalling the whole run indefinitely. The
+ * size-scaled timeout still applies underneath; this value caps it. The
+ * default matches the Gemini generate floor so it is generous enough for a
+ * healthy long request yet bounds a genuine hang.
+ */
+export const DEFAULT_TRANSCRIPTION_TIMEOUT_MINUTES = 10;
+
+/** Smallest configurable per-request transcription timeout, in minutes. */
+export const MIN_TRANSCRIPTION_TIMEOUT_MINUTES = 1;
+
+/** Largest configurable per-request transcription timeout, in minutes. */
+export const MAX_TRANSCRIPTION_TIMEOUT_MINUTES = 60;
 
 /**
  * Assumed sustained upload throughput, in bytes per millisecond (~1 MB/s),
@@ -735,15 +754,36 @@ export const MAX_AUDIO_CLEANUP_SECONDS = 2 * 60 * 60;
 /**
  * Upper bound on the total decoded sample count (frames × channels) the
  * on-demand cleanup will process. Where {@link MAX_AUDIO_CLEANUP_BYTES}
- * bounds the on-disk size, this bounds the decoded working set: the
- * pipeline holds several full Float32 copies of the signal at once (the
- * gated input, the OfflineAudioContext buffer, and the rendered output),
- * so peak memory scales with this count rather than with the encoded
- * size. A heavily compressed file can be small on disk yet decode to a
- * multi-gigabyte buffer the byte guard alone would not catch; at 4 bytes
- * per sample and roughly three concurrent copies this caps the peak
- * working set near 1.5 GB. Checked right after decoding, before the
- * Float32 channels are materialized, so an oversized file is refused with
- * a clear message instead of failing with an out-of-memory error.
+ * bounds the on-disk size, this bounds the decoded working set. Cleanup now
+ * processes the signal in time segments (see {@link CLEANUP_SEGMENT_SECONDS}),
+ * so the gate and the OfflineAudioContext only ever hold one segment at a
+ * time; the lasting full-size allocations are just the decoded buffer (4
+ * bytes/sample) and the interleaved 16-bit WAV output (2 bytes/sample). At
+ * this cap that peak stays near ~1.6 GB regardless of how many DSP stages run,
+ * which lets a ~45-minute stereo recording be cleaned up in memory without the
+ * old "split into parts first" detour. A heavily compressed file can be small
+ * on disk yet decode to a multi-gigabyte buffer the byte guard alone would not
+ * catch, so the count is checked right after decoding, before the Float32
+ * channels are materialized, refusing an oversized file with a clear message
+ * instead of an out-of-memory error.
  */
-export const MAX_AUDIO_CLEANUP_DECODED_SAMPLES = 128 * 1024 * 1024;
+export const MAX_AUDIO_CLEANUP_DECODED_SAMPLES = 256 * 1024 * 1024;
+
+/**
+ * Length, in seconds, of one cleanup processing segment. The signal is gated
+ * and rendered one segment at a time so peak memory does not scale with the
+ * recording length. Long enough that the per-segment OfflineAudioContext setup
+ * cost is negligible, short enough that one segment's working set stays small.
+ */
+export const CLEANUP_SEGMENT_SECONDS = 120;
+
+/**
+ * Warm-up overlap, in seconds, prepended to each cleanup segment (except the
+ * first) and then discarded. The high-pass filter, compressor, and gate are
+ * stateful; processing a short lead-in lets their envelopes settle to the same
+ * place they would reach in a single continuous pass, so segment boundaries
+ * leave no audible click or level jump. Comfortably longer than the
+ * compressor's release time, so the dynamics fully re-converge before the kept
+ * region begins.
+ */
+export const CLEANUP_WARMUP_SECONDS = 3;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -459,6 +459,17 @@ export const GEMINI_GENERATE_MIN_TIMEOUT_MS = 10 * 60_000;
 export const GEMINI_MAX_WHOLE_FILE_SECONDS = 15 * 60;
 
 /**
+ * Smallest half an adaptive subdivision may produce when a part overruns a
+ * provider's output token limit. Output token count is not predictable from
+ * audio duration (a dense, diarized stretch yields far more text than a sparse
+ * one), so a part that truncates is retried as halves; this floor stops the
+ * recursion once the pieces are short enough that a further split would cost
+ * more requests than it saves, after which the part is reported as failed and
+ * the surrounding parts are still kept.
+ */
+export const MIN_SUBDIVIDE_SECONDS = 60;
+
+/**
  * LLM post-processing provider ids. The single source for the string values
  * used as the provider `id`, the settings discriminator, and the keys of the
  * provider label map, so the literals are never hand-typed across the codebase.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -486,9 +486,6 @@ export const ANTHROPIC_API_VERSION = '2023-06-01';
 /** Default Anthropic model for transcript post-processing. */
 export const DEFAULT_LLM_ANTHROPIC_MODEL = 'claude-opus-4-8';
 
-/** Default local Ollama base URL for LLM post-processing. */
-export const DEFAULT_LLM_OLLAMA_BASE_URL = 'http://localhost:11434/v1';
-
 /**
  * Default Gemini base URL for LLM post-processing. Like the transcription
  * base URL it carries no version segment; the provider appends
@@ -517,6 +514,82 @@ export const MIN_LLM_MAX_TOKENS = 512;
 
 /** Maximum configurable LLM output token budget. */
 export const MAX_LLM_MAX_TOKENS = 32000;
+
+/**
+ * Seed OpenAI chat model ids for the LLM model picker on first run; the list
+ * is user-editable. Chat/completions models suitable for transcript cleanup
+ * and summarization. See {@link OPENAI_MODELS_DOC_URL} for the current list.
+ */
+export const LLM_OPENAI_MODEL_SUGGESTIONS = [
+	'gpt-4o-mini',
+	'gpt-4o',
+	'gpt-4.1',
+	'gpt-4.1-mini',
+	'o4-mini',
+];
+
+/**
+ * Seed Anthropic model ids for the LLM model picker on first run; the list is
+ * user-editable. See {@link ANTHROPIC_MODELS_DOC_URL} for the current list.
+ */
+export const LLM_ANTHROPIC_MODEL_SUGGESTIONS = [
+	'claude-opus-4-8',
+	'claude-sonnet-4-6',
+	'claude-haiku-4-5',
+];
+
+/**
+ * Seed Gemini model ids for the LLM model picker on first run; the list is
+ * user-editable. See {@link GEMINI_MODELS_DOC_URL} for the current list.
+ */
+export const LLM_GEMINI_MODEL_SUGGESTIONS = [
+	'gemini-2.5-flash',
+	'gemini-2.5-pro',
+	'gemini-2.5-flash-lite',
+];
+
+/** Where to find the OpenAI model catalog. */
+export const OPENAI_MODELS_DOC_URL = 'https://platform.openai.com/docs/models';
+
+/** Where to find the Anthropic (Claude) model catalog. */
+export const ANTHROPIC_MODELS_DOC_URL =
+	'https://docs.anthropic.com/en/docs/about-claude/models';
+
+/**
+ * Default editable system prompt for the cleanup task. The language clause is
+ * appended automatically at request time (see {@link cleanupLanguageClause}),
+ * so this base text carries no language directive.
+ */
+export const DEFAULT_LLM_CLEANUP_PROMPT =
+	'You are an expert transcription editor. You are given a raw, ' +
+	'machine-generated transcript. Correct punctuation, capitalization, ' +
+	'and obvious speech-to-text errors; insert sensible paragraph breaks; ' +
+	'and remove filler artifacts only when they add no meaning. Do NOT ' +
+	'summarize, translate, paraphrase, add, or omit content — preserve ' +
+	'the speaker’s exact wording and meaning. Preserve any speaker labels ' +
+	'and timestamps exactly as they appear, keeping each on its original ' +
+	'line. Return only the corrected transcript with no preamble.';
+
+/**
+ * Default editable system prompt for the summary task. The language clause is
+ * appended automatically at request time (see {@link summaryLanguageClause}),
+ * so this base text carries no language directive.
+ */
+export const DEFAULT_LLM_SUMMARY_PROMPT =
+	'You are an expert analyst. Summarize the following transcript into a ' +
+	'concise set of key points and any action items, as Markdown bullet ' +
+	'lists under short headings. Be faithful to the content and do not ' +
+	'invent details. Return only the summary with no preamble.';
+
+/**
+ * Default editable instruction for the custom task. Unlike cleanup and
+ * summary, the custom instruction is sent verbatim with no language clause, so
+ * the user controls every directive including language.
+ */
+export const DEFAULT_LLM_CUSTOM_INSTRUCTION =
+	'Rewrite the following transcript as clean, well-structured Markdown ' +
+	'notes. Preserve the original language and meaning, and return only the ' +
+	'result with no preamble.';
 
 /**
  * Floor timeout, in milliseconds, for a transcription HTTP request.

--- a/src/main.ts
+++ b/src/main.ts
@@ -189,6 +189,15 @@ export default class AudioRecorderPlugin extends Plugin {
 			this,
 			() => this.settings,
 			() => this.createTranscriptionModalOptions(),
+			// Prime a freshly cleaned/converted file so the enhanced player
+			// applies immediately instead of after the note is reopened. The
+			// registrar is created just below; the closure resolves it lazily
+			// when a processing run finishes.
+			(paths, notePath) =>
+				this.playerRegistrar.primeSavedRecordingsForEnhancement(
+					paths,
+					notePath,
+				),
 		);
 		this.contextMenu.register();
 

--- a/src/player/AudioPlayer.ts
+++ b/src/player/AudioPlayer.ts
@@ -945,7 +945,14 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 	 */
 	private registerAudioEvents(): void {
 		this.registerDomEvent(this.audio, 'loadedmetadata', () => {
-			if (!Number.isFinite(this.audio.duration)) {
+			// Some plugin-produced mp4 files load with no usable duration: it
+			// reads as Infinity/NaN, or as a finite 0 (a multitrack mp4 whose
+			// container never got its real length stamped). Both leave the
+			// timeline stuck at 0:00, so probe for the true length in either case.
+			if (
+				!Number.isFinite(this.audio.duration) ||
+				this.audio.duration <= 0
+			) {
 				this.resolveInfiniteDuration();
 			} else {
 				this.renderMarkers();
@@ -970,9 +977,12 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 	}
 
 	/**
-	 * Resolves a duration that the browser initially reports as Infinity
-	 * (common for MediaRecorder WebM) by probing a far seek position and
-	 * waiting for the corrected value, then restoring the start.
+	 * Resolves a duration the browser does not report up front — Infinity/NaN
+	 * (common for MediaRecorder WebM) or a finite 0 (some multitrack mp4 whose
+	 * container lacks a stamped length) — by probing a far seek position and
+	 * waiting for a real, positive value, then restoring the start. When the
+	 * seek yields no usable length the watchdog gives up and the bar stays
+	 * unseekable, so a truly length-less file degrades rather than hangs.
 	 */
 	private resolveInfiniteDuration(): void {
 		if (this.durationProbeActive) {
@@ -993,7 +1003,13 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 			this.updateProgress();
 		};
 		const onDurationChange = (): void => {
-			if (Number.isFinite(this.audio.duration)) {
+			// Wait for a real, positive length: a file that loaded at 0 reports a
+			// finite-but-useless 0, so finishing on "finite" alone would lock in
+			// the bogus zero instead of the corrected duration.
+			if (
+				Number.isFinite(this.audio.duration) &&
+				this.audio.duration > 0
+			) {
 				finish();
 			}
 		};
@@ -1227,9 +1243,10 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 				'--aar-progress': `${String(fraction * 100)}%`,
 			});
 		}
-		const total = Number.isFinite(this.audio.duration)
-			? this.audio.duration
-			: 0;
+		const total =
+			Number.isFinite(this.audio.duration) && this.audio.duration > 0
+				? this.audio.duration
+				: 0;
 		if (this.timeEl) {
 			// Format elapsed against the total so both sides share one width
 			this.timeEl.setText(

--- a/src/recording/ConversionService.ts
+++ b/src/recording/ConversionService.ts
@@ -34,7 +34,7 @@ export interface ConversionRequest {
  * the user via Notices by the pipeline.
  */
 export type ConversionOutcome =
-	| { status: 'completed'; newFileName: string }
+	| { status: 'completed'; newFileName: string; newPath: string }
 	| { status: 'aborted' }
 	| { status: 'partial' };
 
@@ -139,7 +139,7 @@ export class ConversionService {
 			return { status: 'partial' };
 		}
 
-		return { status: 'completed', newFileName };
+		return { status: 'completed', newFileName, newPath };
 	}
 
 	/**

--- a/src/recording/NoteInserter.ts
+++ b/src/recording/NoteInserter.ts
@@ -5,7 +5,7 @@
  * @module recording/NoteInserter
  */
 
-import { MarkdownView } from 'obsidian';
+import { MarkdownView, TFile, getLinkpath } from 'obsidian';
 import type { App } from 'obsidian';
 import type { InsertionContext } from '../types';
 import type { DebugLogger } from '../utils/DebugLogger';
@@ -93,4 +93,57 @@ export function insertFileLinks(
 		return activeView?.file?.path ?? null;
 	}
 	return null;
+}
+
+/**
+ * Links a processed (cleaned/converted) audio file into the note that embeds
+ * the source, mirroring how a freshly recorded file is linked. When the source
+ * is being removed its embed is replaced (so no broken link is left behind);
+ * otherwise the new embed is inserted on the line right after it, keeping both.
+ * Edits the note content atomically via `vault.process`, matching the source
+ * embed by its exact original text, so a stale cursor or offset cannot misplace
+ * the insert. Returns the note path the embed landed in, or null when the active
+ * note does not embed the source (e.g. cleanup invoked from the file explorer),
+ * so the caller can skip the enhanced-player priming.
+ * @param app - Obsidian App instance
+ * @param sourceFile - The original audio file that was processed
+ * @param processedPath - Vault path of the processed output
+ * @param replaceSource - Replace the source embed instead of inserting after it
+ * @returns The note path the embed was inserted into, or null when none matched
+ */
+export async function insertProcessedAudioEmbed(
+	app: App,
+	sourceFile: TFile,
+	processedPath: string,
+	replaceSource: boolean,
+): Promise<string | null> {
+	const note = app.workspace.getActiveFile();
+	if (!note || note.extension !== 'md') {
+		return null;
+	}
+	const embeds = app.metadataCache.getFileCache(note)?.embeds ?? [];
+	const target = embeds.find(
+		(embed) =>
+			app.metadataCache.getFirstLinkpathDest(
+				getLinkpath(embed.link),
+				note.path,
+			)?.path === sourceFile.path,
+	);
+	if (!target) {
+		return null;
+	}
+	const processedFile = app.vault.getAbstractFileByPath(processedPath);
+	const link =
+		processedFile instanceof TFile
+			? app.fileManager.generateMarkdownLink(processedFile, note.path)
+			: `[[${processedPath.split('/').pop() ?? processedPath}]]`;
+	const newEmbed = `!${link}`;
+	const original = target.original;
+	await app.vault.process(note, (content) =>
+		content.replace(
+			original,
+			replaceSource ? newEmbed : `${original}\n${newEmbed}`,
+		),
+	);
+	return note.path;
 }

--- a/src/recording/NoteInserter.ts
+++ b/src/recording/NoteInserter.ts
@@ -6,7 +6,7 @@
  */
 
 import { MarkdownView, TFile, getLinkpath } from 'obsidian';
-import type { App } from 'obsidian';
+import type { App, EmbedCache } from 'obsidian';
 import type { InsertionContext } from '../types';
 import type { DebugLogger } from '../utils/DebugLogger';
 
@@ -98,17 +98,18 @@ export function insertFileLinks(
 /**
  * Links a processed (cleaned/converted) audio file into the note that embeds
  * the source, mirroring how a freshly recorded file is linked. When the source
- * is being removed its embed is replaced (so no broken link is left behind);
- * otherwise the new embed is inserted on the line right after it, keeping both.
- * Edits the note content atomically via `vault.process`, matching the source
- * embed by its exact original text, so a stale cursor or offset cannot misplace
- * the insert. Returns the note path the embed landed in, or null when the active
+ * is being removed every one of its embeds is replaced (so no broken link is
+ * left behind, even if the note embeds it more than once); otherwise the new
+ * embed is inserted on the line right after the first one, keeping both. Edits
+ * the note content atomically via `vault.process`, matching the source embeds by
+ * their exact original text, so a stale cursor or offset cannot misplace the
+ * insert. Returns the note path the embed landed in, or null when the active
  * note does not embed the source (e.g. cleanup invoked from the file explorer),
  * so the caller can skip the enhanced-player priming.
  * @param app - Obsidian App instance
  * @param sourceFile - The original audio file that was processed
  * @param processedPath - Vault path of the processed output
- * @param replaceSource - Replace the source embed instead of inserting after it
+ * @param replaceSource - Replace the source embeds instead of inserting after
  * @returns The note path the embed was inserted into, or null when none matched
  */
 export async function insertProcessedAudioEmbed(
@@ -122,14 +123,14 @@ export async function insertProcessedAudioEmbed(
 		return null;
 	}
 	const embeds = app.metadataCache.getFileCache(note)?.embeds ?? [];
-	const target = embeds.find(
+	const matches = embeds.filter(
 		(embed) =>
 			app.metadataCache.getFirstLinkpathDest(
 				getLinkpath(embed.link),
 				note.path,
 			)?.path === sourceFile.path,
 	);
-	if (!target) {
+	if (matches.length === 0) {
 		return null;
 	}
 	const processedFile = app.vault.getAbstractFileByPath(processedPath);
@@ -138,12 +139,58 @@ export async function insertProcessedAudioEmbed(
 			? app.fileManager.generateMarkdownLink(processedFile, note.path)
 			: `[[${processedPath.split('/').pop() ?? processedPath}]]`;
 	const newEmbed = `!${link}`;
-	const original = target.original;
 	await app.vault.process(note, (content) =>
-		content.replace(
-			original,
-			replaceSource ? newEmbed : `${original}\n${newEmbed}`,
-		),
+		replaceSource
+			? replaceSourceEmbeds(content, matches, newEmbed)
+			: insertEmbedAfterSource(content, matches[0].original, newEmbed),
 	);
 	return note.path;
+}
+
+/**
+ * Replaces every embed of the source file with the processed embed, so trashing
+ * the source afterwards leaves no broken link even when the note embeds it more
+ * than once. Uses split/join rather than `String.prototype.replace`, whose
+ * string replacement reinterprets `$` substitution patterns such as `$&` and
+ * `$$` — a filename or alias containing `$` would otherwise corrupt the
+ * rewritten note.
+ * @param content - Current note body
+ * @param matches - Embeds that resolve to the source file
+ * @param newEmbed - The processed file's embed text
+ * @returns The note body with every source embed replaced
+ */
+function replaceSourceEmbeds(
+	content: string,
+	matches: EmbedCache[],
+	newEmbed: string,
+): string {
+	let next = content;
+	// Distinct embed texts only: identical occurrences are all handled by a
+	// single split/join, so a duplicate would otherwise replace nothing new.
+	for (const original of new Set(matches.map((match) => match.original))) {
+		next = next.split(original).join(newEmbed);
+	}
+	return next;
+}
+
+/**
+ * Inserts the processed embed on the line right after the first source embed,
+ * keeping the source. Plain string slicing avoids the `$` reinterpretation a
+ * `String.prototype.replace` string replacement would apply to the embed text.
+ * @param content - Current note body
+ * @param original - The source embed's exact original text
+ * @param newEmbed - The processed file's embed text
+ * @returns The note body with the processed embed inserted after the source
+ */
+function insertEmbedAfterSource(
+	content: string,
+	original: string,
+	newEmbed: string,
+): string {
+	const index = content.indexOf(original);
+	if (index === -1) {
+		return content;
+	}
+	const end = index + original.length;
+	return `${content.slice(0, end)}\n${newEmbed}${content.slice(end)}`;
 }

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -30,10 +30,15 @@ import {
 	DEFAULT_LLM_OPENAI_MODEL,
 	DEFAULT_LLM_ANTHROPIC_BASE_URL,
 	DEFAULT_LLM_ANTHROPIC_MODEL,
-	DEFAULT_LLM_OLLAMA_BASE_URL,
 	DEFAULT_LLM_GEMINI_BASE_URL,
 	DEFAULT_LLM_GEMINI_MODEL,
 	DEFAULT_LLM_MAX_TOKENS,
+	LLM_OPENAI_MODEL_SUGGESTIONS,
+	LLM_ANTHROPIC_MODEL_SUGGESTIONS,
+	LLM_GEMINI_MODEL_SUGGESTIONS,
+	DEFAULT_LLM_CLEANUP_PROMPT,
+	DEFAULT_LLM_SUMMARY_PROMPT,
+	DEFAULT_LLM_CUSTOM_INSTRUCTION,
 	DEFAULT_CLEANUP_HIGHPASS_HZ,
 	DEFAULT_CLEANUP_GATE_THRESHOLD_DB,
 	DEFAULT_CLEANUP_LEVELING_MAKEUP_DB,
@@ -150,7 +155,7 @@ export interface AudioRecorderSettings {
 	transcriptionChunkMb: number;
 	/** Whisper API base URL (OpenAI-compatible) */
 	whisperApiBaseUrl: string;
-	/** Whisper API key */
+	/** Whisper API key. Shared with the OpenAI LLM provider as the OpenAI vendor key. */
 	whisperApiKey: string;
 	/** Whisper API model id (the selected one) */
 	whisperApiModel: string;
@@ -166,7 +171,7 @@ export interface AudioRecorderSettings {
 	deepgramModels: string[];
 	/** Gemini API base URL */
 	geminiBaseUrl: string;
-	/** Gemini API key */
+	/** Gemini API key. Shared between Gemini transcription and the Gemini LLM provider. */
 	geminiApiKey: string;
 	/** Gemini model id (the selected one) */
 	geminiModel: string;
@@ -202,16 +207,34 @@ export interface AudioRecorderSettings {
 	llmPostProcessEnabled: boolean;
 	/** LLM post-processing task */
 	llmPostProcessTask: LlmTask;
-	/** Custom instruction for the 'custom' task */
+	/** Editable system prompt for the cleanup task (language clause auto-appended) */
+	llmCleanupPrompt: string;
+	/** Editable system prompt for the summary task (language clause auto-appended) */
+	llmSummaryPrompt: string;
+	/** Editable instruction for the 'custom' task (sent verbatim) */
 	llmCustomInstruction: string;
-	/** LLM provider: OpenAI-compatible or Anthropic */
+	/** LLM provider: OpenAI, Anthropic, or Google Gemini */
 	llmProvider: LlmProviderId;
 	/** LLM base URL */
 	llmBaseUrl: string;
-	/** LLM API key */
-	llmApiKey: string;
-	/** LLM model id */
-	llmModel: string;
+	/**
+	 * Anthropic API key. OpenAI and Gemini LLM reuse the transcription keys
+	 * (whisperApiKey, geminiApiKey) so a vendor token is entered once; Anthropic
+	 * has no transcription counterpart, so it keeps its own key here.
+	 */
+	anthropicApiKey: string;
+	/** Selected OpenAI LLM model id */
+	llmOpenAiModel: string;
+	/** Known OpenAI LLM model ids offered in the picker (user-editable) */
+	llmOpenAiModels: string[];
+	/** Selected Anthropic LLM model id */
+	llmAnthropicModel: string;
+	/** Known Anthropic LLM model ids offered in the picker (user-editable) */
+	llmAnthropicModels: string[];
+	/** Selected Gemini LLM model id */
+	llmGeminiModel: string;
+	/** Known Gemini LLM model ids offered in the picker (user-editable) */
+	llmGeminiModels: string[];
 	/** Maximum output tokens for LLM post-processing */
 	llmMaxTokens: number;
 	/** Apply browser noise suppression to the input */
@@ -290,7 +313,7 @@ export type LlmProviderId =
 
 /** Display labels for each LLM provider (single source for the UI). */
 export const LLM_PROVIDER_LABELS: Record<LlmProviderId, string> = {
-	[LLM_PROVIDER_IDS.OPENAI_COMPATIBLE]: 'OpenAI / Groq / Ollama',
+	[LLM_PROVIDER_IDS.OPENAI_COMPATIBLE]: 'OpenAI',
 	[LLM_PROVIDER_IDS.ANTHROPIC]: 'Anthropic (Claude)',
 	[LLM_PROVIDER_IDS.GEMINI]: 'Google Gemini',
 };
@@ -403,11 +426,18 @@ export const DEFAULT_SETTINGS: AudioRecorderSettings = {
 	transcriptHeading: '## Transcript',
 	llmPostProcessEnabled: false,
 	llmPostProcessTask: 'cleanup',
-	llmCustomInstruction: '',
+	llmCleanupPrompt: DEFAULT_LLM_CLEANUP_PROMPT,
+	llmSummaryPrompt: DEFAULT_LLM_SUMMARY_PROMPT,
+	llmCustomInstruction: DEFAULT_LLM_CUSTOM_INSTRUCTION,
 	llmProvider: LLM_PROVIDER_IDS.OPENAI_COMPATIBLE,
 	llmBaseUrl: DEFAULT_LLM_OPENAI_BASE_URL,
-	llmApiKey: '',
-	llmModel: DEFAULT_LLM_OPENAI_MODEL,
+	anthropicApiKey: '',
+	llmOpenAiModel: DEFAULT_LLM_OPENAI_MODEL,
+	llmOpenAiModels: [...LLM_OPENAI_MODEL_SUGGESTIONS],
+	llmAnthropicModel: DEFAULT_LLM_ANTHROPIC_MODEL,
+	llmAnthropicModels: [...LLM_ANTHROPIC_MODEL_SUGGESTIONS],
+	llmGeminiModel: DEFAULT_LLM_GEMINI_MODEL,
+	llmGeminiModels: [...LLM_GEMINI_MODEL_SUGGESTIONS],
 	llmMaxTokens: DEFAULT_LLM_MAX_TOKENS,
 	inputNoiseSuppression: true,
 	inputEchoCancellation: true,
@@ -431,22 +461,15 @@ export const DEFAULT_SETTINGS: AudioRecorderSettings = {
 const DEFAULT_LLM_BASE_URLS: ReadonlySet<string> = new Set([
 	DEFAULT_LLM_OPENAI_BASE_URL,
 	DEFAULT_LLM_ANTHROPIC_BASE_URL,
-	DEFAULT_LLM_OLLAMA_BASE_URL,
 	DEFAULT_LLM_GEMINI_BASE_URL,
 ]);
 
-/** Model ids that ship as provider defaults (same auto-switch guard). */
-const DEFAULT_LLM_MODELS: ReadonlySet<string> = new Set([
-	DEFAULT_LLM_OPENAI_MODEL,
-	DEFAULT_LLM_ANTHROPIC_MODEL,
-	DEFAULT_LLM_GEMINI_MODEL,
-]);
-
 /**
- * Aligns the LLM base URL and model with the target provider's defaults when
- * the current values are still provider defaults; a custom URL or model the
- * user entered is preserved. Mutates and returns `settings` so the settings
- * tab can switch the dependent fields in one step when the provider changes.
+ * Aligns the LLM base URL with the target provider's default when the current
+ * value is still a provider default; a custom URL the user entered is
+ * preserved. The model is not switched here — each provider keeps its own
+ * selected model in a dedicated field. Mutates and returns `settings` so the
+ * settings tab can switch the base URL in one step when the provider changes.
  * @param settings - Settings to adjust in place
  * @param provider - The provider being switched to
  * @returns The same settings object, adjusted
@@ -459,34 +482,22 @@ export function applyLlmProviderDefaults(
 		if (DEFAULT_LLM_BASE_URLS.has(settings.llmBaseUrl)) {
 			settings.llmBaseUrl = DEFAULT_LLM_ANTHROPIC_BASE_URL;
 		}
-		if (DEFAULT_LLM_MODELS.has(settings.llmModel)) {
-			settings.llmModel = DEFAULT_LLM_ANTHROPIC_MODEL;
-		}
 		return settings;
 	}
 	if (provider === LLM_PROVIDER_IDS.GEMINI) {
 		if (DEFAULT_LLM_BASE_URLS.has(settings.llmBaseUrl)) {
 			settings.llmBaseUrl = DEFAULT_LLM_GEMINI_BASE_URL;
 		}
-		if (DEFAULT_LLM_MODELS.has(settings.llmModel)) {
-			settings.llmModel = DEFAULT_LLM_GEMINI_MODEL;
-		}
 		return settings;
 	}
-	// OpenAI-compatible (OpenAI / Groq / Ollama): only move off another
-	// provider's shipped default (Anthropic or Gemini), leaving any other
-	// OpenAI-compatible endpoint or model the user entered intact.
+	// OpenAI: only move off another provider's shipped default base URL
+	// (Anthropic or Gemini), leaving any other OpenAI-compatible endpoint the
+	// user entered intact.
 	if (
 		settings.llmBaseUrl === DEFAULT_LLM_ANTHROPIC_BASE_URL ||
 		settings.llmBaseUrl === DEFAULT_LLM_GEMINI_BASE_URL
 	) {
 		settings.llmBaseUrl = DEFAULT_LLM_OPENAI_BASE_URL;
-	}
-	if (
-		settings.llmModel === DEFAULT_LLM_ANTHROPIC_MODEL ||
-		settings.llmModel === DEFAULT_LLM_GEMINI_MODEL
-	) {
-		settings.llmModel = DEFAULT_LLM_OPENAI_MODEL;
 	}
 	return settings;
 }
@@ -573,13 +584,68 @@ export function serializeSettings(
 export function mergeSettings(
 	userSettings: AudioRecorderSettingsInput = {},
 ): AudioRecorderSettings {
-	return {
+	const merged: AudioRecorderSettings = {
 		...DEFAULT_SETTINGS,
 		...userSettings,
 		trackAudioSources: normalizeTrackAudioSources(
 			userSettings.trackAudioSources,
 		),
 	};
+	migrateLegacyLlmSettings(merged, userSettings);
+	return merged;
+}
+
+/**
+ * Carries forward settings saved under the pre-rework LLM schema. The old
+ * single `llmApiKey` maps onto the new per-vendor key (OpenAI reuses
+ * `whisperApiKey`, Gemini reuses `geminiApiKey`, Anthropic uses its own
+ * `anthropicApiKey`), and the old single `llmModel` maps onto the selected
+ * model of the stored provider. The superseded flat fields are then dropped so
+ * a later save does not persist them. A vendor key already set is never
+ * overwritten, so the migration cannot clobber a freshly entered token.
+ * @param merged - The merged settings to migrate in place
+ * @param raw - The raw user settings as loaded from disk
+ */
+function migrateLegacyLlmSettings(
+	merged: AudioRecorderSettings,
+	raw: AudioRecorderSettingsInput,
+): void {
+	const legacy = raw as unknown as Record<string, unknown>;
+	const legacyKey =
+		typeof legacy.llmApiKey === 'string' ? legacy.llmApiKey : '';
+	if (legacyKey) {
+		if (
+			merged.llmProvider === LLM_PROVIDER_IDS.ANTHROPIC &&
+			!merged.anthropicApiKey
+		) {
+			merged.anthropicApiKey = legacyKey;
+		} else if (
+			merged.llmProvider === LLM_PROVIDER_IDS.GEMINI &&
+			!merged.geminiApiKey
+		) {
+			merged.geminiApiKey = legacyKey;
+		} else if (
+			merged.llmProvider === LLM_PROVIDER_IDS.OPENAI_COMPATIBLE &&
+			!merged.whisperApiKey
+		) {
+			merged.whisperApiKey = legacyKey;
+		}
+	}
+	const legacyModel =
+		typeof legacy.llmModel === 'string' ? legacy.llmModel.trim() : '';
+	if (legacyModel) {
+		if (merged.llmProvider === LLM_PROVIDER_IDS.ANTHROPIC) {
+			merged.llmAnthropicModel = legacyModel;
+		} else if (merged.llmProvider === LLM_PROVIDER_IDS.GEMINI) {
+			merged.llmGeminiModel = legacyModel;
+		} else {
+			merged.llmOpenAiModel = legacyModel;
+		}
+	}
+	// Drop the superseded flat fields so a later save does not persist them.
+	const mergedRecord = merged as unknown as Record<string, unknown>;
+	delete mergedRecord.llmApiKey;
+	delete mergedRecord.llmModel;
 }
 
 /**

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -24,6 +24,7 @@ import {
 	DEFAULT_GEMINI_BASE_URL,
 	DEFAULT_GEMINI_MODEL,
 	GEMINI_MODEL_SUGGESTIONS,
+	DEFAULT_TRANSCRIPTION_TIMEOUT_MINUTES,
 	TRANSCRIPTION_PROVIDER_IDS,
 	LLM_PROVIDER_IDS,
 	DEFAULT_LLM_OPENAI_BASE_URL,
@@ -153,6 +154,8 @@ export interface AudioRecorderSettings {
 	transcriptionWordTimestamps: boolean;
 	/** Upload size limit per chunk, in megabytes (Whisper API) */
 	transcriptionChunkMb: number;
+	/** Per-request transcription timeout, in minutes (a hung request fails after this) */
+	transcriptionTimeoutMinutes: number;
 	/** Whisper API base URL (OpenAI-compatible) */
 	whisperApiBaseUrl: string;
 	/** Whisper API key. Shared with the OpenAI LLM provider as the OpenAI vendor key. */
@@ -399,6 +402,7 @@ export const DEFAULT_SETTINGS: AudioRecorderSettings = {
 	transcriptionDiarize: false,
 	transcriptionWordTimestamps: false,
 	transcriptionChunkMb: DEFAULT_TRANSCRIBE_CHUNK_MB,
+	transcriptionTimeoutMinutes: DEFAULT_TRANSCRIPTION_TIMEOUT_MINUTES,
 	whisperApiBaseUrl: DEFAULT_WHISPER_API_BASE_URL,
 	whisperApiKey: '',
 	whisperApiModel: DEFAULT_WHISPER_API_MODEL,

--- a/src/settings/sections/transcriptionSettingsSection.ts
+++ b/src/settings/sections/transcriptionSettingsSection.ts
@@ -12,9 +12,12 @@ import {
 	MIN_LLM_MAX_TOKENS,
 	MAX_LLM_MAX_TOKENS,
 	TRANSCRIPTION_PROVIDER_IDS,
+	LLM_PROVIDER_IDS,
 	WHISPER_API_MODELS_DOC_URL,
 	DEEPGRAM_MODELS_DOC_URL,
 	GEMINI_MODELS_DOC_URL,
+	OPENAI_MODELS_DOC_URL,
+	ANTHROPIC_MODELS_DOC_URL,
 	LOCAL_WHISPER_MODEL_NAMES,
 	LOCAL_WHISPER_MODELS_DOC_URL,
 } from '../../constants';
@@ -33,6 +36,7 @@ import {
 	addModelPicker,
 	addSlider,
 	addText,
+	addTextArea,
 	addToggle,
 	type SettingsSectionContext,
 } from '../settingControls';
@@ -374,23 +378,55 @@ function renderLlmSection(ctx: SettingsSectionContext): void {
 		rerender: true,
 	});
 
-	if (s.llmPostProcessTask === 'custom') {
-		addText(ctx, {
-			name: 'Custom instruction',
-			desc: 'System instruction applied to the transcript text.',
-			get: () => s.llmCustomInstruction,
-			set: (v) => (s.llmCustomInstruction = v),
-		});
-	}
+	renderLlmPromptField(ctx);
+	renderLlmProviderFields(ctx);
+}
 
+/**
+ * Editable prompt for the selected task. Cleanup and summary expose their
+ * (language-agnostic) base prompt with the language clause appended at request
+ * time; custom is sent verbatim and gets a larger field.
+ */
+function renderLlmPromptField(ctx: SettingsSectionContext): void {
+	const s = ctx.settings;
+	if (s.llmPostProcessTask === 'cleanup') {
+		addTextArea(ctx, {
+			name: 'Cleanup prompt',
+			desc: 'System instruction for the cleanup pass. The transcript language is appended automatically.',
+			get: () => s.llmCleanupPrompt,
+			set: (v) => (s.llmCleanupPrompt = v),
+		});
+		return;
+	}
+	if (s.llmPostProcessTask === 'summary') {
+		addTextArea(ctx, {
+			name: 'Summary prompt',
+			desc: 'System instruction for the summary pass. The transcript language is appended automatically.',
+			get: () => s.llmSummaryPrompt,
+			set: (v) => (s.llmSummaryPrompt = v),
+		});
+		return;
+	}
+	addTextArea(ctx, {
+		name: 'Custom instruction',
+		desc: 'System instruction applied to the transcript text. Sent verbatim — include any language directive yourself.',
+		get: () => s.llmCustomInstruction,
+		set: (v) => (s.llmCustomInstruction = v),
+		rows: 8,
+	});
+}
+
+/** Provider dropdown, shared vendor key, base URL, model picker, token budget. */
+function renderLlmProviderFields(ctx: SettingsSectionContext): void {
+	const s = ctx.settings;
 	addDropdown(ctx, {
 		name: 'LLM provider',
 		options: LLM_PROVIDER_OPTIONS,
 		get: () => s.llmProvider,
 		set: (v) => {
-			// Move the base URL and model to the picked provider's defaults
-			// when they are still defaults, so choosing Anthropic does not
-			// leave an OpenAI URL/model behind (and vice versa).
+			// Move the base URL to the picked provider's default when it is still
+			// a default, so choosing Anthropic does not leave an OpenAI URL behind
+			// (and vice versa). The model is per-provider and switches on its own.
 			const provider = v as typeof s.llmProvider;
 			applyLlmProviderDefaults(s, provider);
 			s.llmProvider = provider;
@@ -399,23 +435,12 @@ function renderLlmSection(ctx: SettingsSectionContext): void {
 	});
 	addText(ctx, {
 		name: 'LLM base URL',
-		desc: 'API base URL (e.g. https://api.openai.com/v1, http://localhost:11434/v1, https://api.anthropic.com/v1, or https://generativelanguage.googleapis.com).',
+		desc: 'API base URL (e.g. https://api.openai.com/v1, https://api.anthropic.com/v1, or https://generativelanguage.googleapis.com).',
 		get: () => s.llmBaseUrl,
 		set: (v) => (s.llmBaseUrl = v),
 	});
-	addText(ctx, {
-		name: 'LLM API key',
-		desc: 'Leave empty for a local Ollama server. Stored in plugin data on this device.',
-		get: () => s.llmApiKey,
-		set: (v) => (s.llmApiKey = v),
-		secret: true,
-	});
-	addText(ctx, {
-		name: 'LLM model',
-		desc: 'Model id (e.g. gpt-4o-mini, llama3.1, claude-opus-4-8, gemini-2.5-flash).',
-		get: () => s.llmModel,
-		set: (v) => (s.llmModel = v),
-	});
+	renderLlmKeyField(ctx);
+	renderLlmModelPicker(ctx);
 	addSlider(ctx, {
 		name: 'Max output tokens',
 		desc: 'Upper bound on the LLM response length.',
@@ -424,5 +449,88 @@ function renderLlmSection(ctx: SettingsSectionContext): void {
 		step: 512,
 		get: () => s.llmMaxTokens,
 		set: (v) => (s.llmMaxTokens = v),
+	});
+}
+
+/**
+ * API-key field bound to the shared per-vendor key. OpenAI and Gemini reuse the
+ * transcription key (so a vendor token is entered once); Anthropic keeps its
+ * own.
+ */
+function renderLlmKeyField(ctx: SettingsSectionContext): void {
+	const s = ctx.settings;
+	if (s.llmProvider === LLM_PROVIDER_IDS.ANTHROPIC) {
+		addText(ctx, {
+			name: 'Anthropic API key',
+			desc: 'Stored in plugin data on this device.',
+			get: () => s.anthropicApiKey,
+			set: (v) => (s.anthropicApiKey = v),
+			secret: true,
+		});
+		return;
+	}
+	if (s.llmProvider === LLM_PROVIDER_IDS.GEMINI) {
+		addText(ctx, {
+			name: 'Google Gemini API key',
+			desc: 'Shared with the Gemini transcription engine — set it in either place.',
+			get: () => s.geminiApiKey,
+			set: (v) => (s.geminiApiKey = v),
+			secret: true,
+		});
+		return;
+	}
+	addText(ctx, {
+		name: 'OpenAI API key',
+		desc: 'Shared with the Whisper API transcription engine — set it in either place.',
+		get: () => s.whisperApiKey,
+		set: (v) => (s.whisperApiKey = v),
+		secret: true,
+	});
+}
+
+/** Model picker bound to the selected provider's saved, user-editable list. */
+function renderLlmModelPicker(ctx: SettingsSectionContext): void {
+	const s = ctx.settings;
+	if (s.llmProvider === LLM_PROVIDER_IDS.ANTHROPIC) {
+		addModelPicker(ctx, {
+			name: 'LLM model',
+			desc: 'Pick an Anthropic model (e.g. claude-opus-4-8, claude-sonnet-4-6).',
+			helpLink: {
+				label: 'Anthropic models',
+				url: ANTHROPIC_MODELS_DOC_URL,
+			},
+			getModels: () => s.llmAnthropicModels,
+			setModels: (models) => (s.llmAnthropicModels = models),
+			getSelected: () => s.llmAnthropicModel,
+			setSelected: (id) => (s.llmAnthropicModel = id),
+		});
+		return;
+	}
+	if (s.llmProvider === LLM_PROVIDER_IDS.GEMINI) {
+		addModelPicker(ctx, {
+			name: 'LLM model',
+			desc: 'Pick a Gemini model (e.g. gemini-2.5-flash, gemini-2.5-pro).',
+			helpLink: {
+				label: 'Gemini model list',
+				url: GEMINI_MODELS_DOC_URL,
+			},
+			getModels: () => s.llmGeminiModels,
+			setModels: (models) => (s.llmGeminiModels = models),
+			getSelected: () => s.llmGeminiModel,
+			setSelected: (id) => (s.llmGeminiModel = id),
+		});
+		return;
+	}
+	addModelPicker(ctx, {
+		name: 'LLM model',
+		desc: 'Pick an OpenAI model (e.g. gpt-4o-mini, gpt-4o).',
+		helpLink: {
+			label: 'OpenAI models',
+			url: OPENAI_MODELS_DOC_URL,
+		},
+		getModels: () => s.llmOpenAiModels,
+		setModels: (models) => (s.llmOpenAiModels = models),
+		getSelected: () => s.llmOpenAiModel,
+		setSelected: (id) => (s.llmOpenAiModel = id),
 	});
 }

--- a/src/settings/sections/transcriptionSettingsSection.ts
+++ b/src/settings/sections/transcriptionSettingsSection.ts
@@ -9,6 +9,8 @@
 import {
 	MIN_TRANSCRIBE_CHUNK_MB,
 	MAX_TRANSCRIBE_CHUNK_MB,
+	MIN_TRANSCRIPTION_TIMEOUT_MINUTES,
+	MAX_TRANSCRIPTION_TIMEOUT_MINUTES,
 	MIN_LLM_MAX_TOKENS,
 	MAX_LLM_MAX_TOKENS,
 	TRANSCRIPTION_PROVIDER_IDS,
@@ -110,6 +112,20 @@ export function renderTranscriptionSection(ctx: SettingsSectionContext): void {
 		get: () => s.transcriptionWordTimestamps,
 		set: (v) => (s.transcriptionWordTimestamps = v),
 	});
+
+	// Cloud engines only: a hung network request is bounded by this limit. Local
+	// whisper.cpp runs no HTTP request, so the timeout does not apply to it.
+	if (s.transcriptionProvider !== TRANSCRIPTION_PROVIDER_IDS.LOCAL_WHISPER) {
+		addSlider(ctx, {
+			name: 'Request timeout',
+			desc: 'Minutes before a single transcription request (one part of a long recording) is aborted and reported as failed, so a stalled request cannot hang the run indefinitely.',
+			min: MIN_TRANSCRIPTION_TIMEOUT_MINUTES,
+			max: MAX_TRANSCRIPTION_TIMEOUT_MINUTES,
+			step: 1,
+			get: () => s.transcriptionTimeoutMinutes,
+			set: (v) => (s.transcriptionTimeoutMinutes = v),
+		});
+	}
 
 	if (s.transcriptionProvider === TRANSCRIPTION_PROVIDER_IDS.WHISPER_API) {
 		renderWhisperApiSettings(ctx);
@@ -392,7 +408,7 @@ function renderLlmPromptField(ctx: SettingsSectionContext): void {
 	if (s.llmPostProcessTask === 'cleanup') {
 		addTextArea(ctx, {
 			name: 'Cleanup prompt',
-			desc: 'System instruction for the cleanup pass. The transcript language is appended automatically.',
+			desc: 'System instruction for the cleanup pass. The transcript language is appended automatically. Leave empty to use the built-in default.',
 			get: () => s.llmCleanupPrompt,
 			set: (v) => (s.llmCleanupPrompt = v),
 		});
@@ -401,7 +417,7 @@ function renderLlmPromptField(ctx: SettingsSectionContext): void {
 	if (s.llmPostProcessTask === 'summary') {
 		addTextArea(ctx, {
 			name: 'Summary prompt',
-			desc: 'System instruction for the summary pass. The transcript language is appended automatically.',
+			desc: 'System instruction for the summary pass. The transcript language is appended automatically. Leave empty to use the built-in default.',
 			get: () => s.llmSummaryPrompt,
 			set: (v) => (s.llmSummaryPrompt = v),
 		});

--- a/src/settings/settingControls.ts
+++ b/src/settings/settingControls.ts
@@ -21,6 +21,12 @@ export const SETTING_DISABLED_CLASS = 'aar-setting-disabled';
 /** Class applied to a "learn more" link appended to a setting description. */
 export const SETTING_DOC_LINK_CLASS = 'aar-doc-link';
 
+/** Class applied to a setting whose control is a full-width, stacked text area. */
+export const SETTING_STACKED_CLASS = 'aar-setting-stacked';
+
+/** Default visible row count for a multi-line text-area control. */
+const DEFAULT_TEXTAREA_ROWS = 6;
+
 /** A "learn more" link appended to a setting's description. */
 export interface HelpLink {
 	label: string;
@@ -110,6 +116,56 @@ export function addText(
 	if (config.disabled) {
 		// Dim the whole row so a non-interactive input reads as unavailable, not
 		// merely empty — mirrors the disabled rendering used by addToggle.
+		setting.settingEl.addClass(SETTING_DISABLED_CLASS);
+	}
+}
+
+/** Configuration for a debounced multi-line text-area control. */
+export interface TextAreaControlConfig {
+	name: string;
+	desc?: string;
+	get: () => string;
+	set: (value: string) => void;
+	/** Optional "learn more" link appended to the description. */
+	helpLink?: HelpLink;
+	/** Visible row count (defaults to {@link DEFAULT_TEXTAREA_ROWS}). */
+	rows?: number;
+	/** Render the input non-interactive and dim the row. */
+	disabled?: boolean;
+}
+
+/**
+ * Adds a full-width, stacked multi-line text area bound to a getter/setter with
+ * a debounced save. Used for the editable LLM prompts, where a single-line text
+ * field is too cramped to read or edit a multi-sentence instruction.
+ * @param ctx - Section context
+ * @param config - Text-area bindings
+ */
+export function addTextArea(
+	ctx: SettingsSectionContext,
+	config: TextAreaControlConfig,
+): void {
+	const setting = new Setting(ctx.containerEl).setName(config.name);
+	if (config.desc) {
+		setting.setDesc(config.desc);
+	}
+	if (config.helpLink) {
+		appendHelpLink(setting, config.helpLink);
+	}
+	setting.addTextArea((text) => {
+		// rows is a textarea attribute (not a style), so it is allowed; width
+		// and height come from the stacked-layout CSS class on the row.
+		text.inputEl.rows = config.rows ?? DEFAULT_TEXTAREA_ROWS;
+		text.setValue(config.get()).onChange((value) => {
+			config.set(value);
+			ctx.saveDebounced();
+		});
+		if (config.disabled) {
+			text.setDisabled(true);
+		}
+	});
+	setting.settingEl.addClass(SETTING_STACKED_CLASS);
+	if (config.disabled) {
 		setting.settingEl.addClass(SETTING_DISABLED_CLASS);
 	}
 }

--- a/src/transcription/TranscriptionService.ts
+++ b/src/transcription/TranscriptionService.ts
@@ -181,7 +181,7 @@ export class TranscriptionService {
 			this.throwIfCancelled(token);
 			const partLabel =
 				partCount > 1
-					? `part ${String(i + 1)} of ${String(partCount)}`
+					? this.describePart(payloads[i], i, partCount)
 					: '';
 			options.onProgress?.(
 				(i / partCount) * TRANSCRIBE_CHUNK_PROGRESS_CEILING,
@@ -392,6 +392,29 @@ export class TranscriptionService {
 			return `the segment at ${start}`;
 		}
 		return `the ${start}–${formatTimecode(part.endSeconds, reference)} segment`;
+	}
+
+	/**
+	 * Labels a top-level part for progress and salvage messages. A part whose
+	 * span is known (the decode path stamps {@link PreparedPayload.endSeconds})
+	 * is named by its timeline range, matching how a subdivided part is named so
+	 * the incomplete-transcription warning never mixes a "part N of M" label with
+	 * a timecode span. Only when the span was never measured (no endSeconds) does
+	 * it fall back to the ordinal position.
+	 * @param part - The prepared top-level part
+	 * @param index - Zero-based position of the part
+	 * @param count - Total number of top-level parts
+	 * @returns A human label for the part
+	 */
+	private describePart(
+		part: PreparedPayload,
+		index: number,
+		count: number,
+	): string {
+		if (part.endSeconds !== undefined) {
+			return this.partTimeLabel(part);
+		}
+		return `part ${String(index + 1)} of ${String(count)}`;
 	}
 
 	/**

--- a/src/transcription/TranscriptionService.ts
+++ b/src/transcription/TranscriptionService.ts
@@ -172,6 +172,7 @@ export class TranscriptionService {
 		const payloads = prepared.payloads;
 		const partCount = payloads.length;
 		const results: { offsetSeconds: number; transcript: Transcript }[] = [];
+		const failedParts: { label: string; message: string }[] = [];
 		for (let i = 0; i < partCount; i++) {
 			this.throwIfCancelled(token);
 			const prepPayload = payloads[i];
@@ -191,28 +192,45 @@ export class TranscriptionService {
 				filename: prepPayload.filename,
 				offsetSeconds: prepPayload.offsetSeconds,
 			};
-			let chunkResult;
 			try {
-				chunkResult = await provider.transcribe(
+				const chunkResult = await provider.transcribe(
 					payload,
 					transcribeOptions,
 				);
+				results.push({
+					offsetSeconds: payload.offsetSeconds,
+					transcript: buildTranscript(chunkResult.segments, {
+						language: chunkResult.language,
+					}),
+				});
 			} catch (error) {
-				// Single-part jobs need no extra context; for multi-part,
-				// name which part failed so the error is actionable.
-				if (!partLabel) {
+				// A cancel aborts the whole run; never salvage past it.
+				if (error instanceof TranscriptionCancelledError) {
 					throw error;
 				}
 				const detail =
 					error instanceof Error ? error.message : String(error);
-				throw new Error(`${detail} (while transcribing ${partLabel})`);
+				// A single-part job has nothing to keep, so fail as before. For
+				// a multi-part job, record the failure and carry on: discarding
+				// a completed (and, on a paid API, already-billed) part because
+				// a later part hit a provider limit would throw away good work.
+				if (!partLabel) {
+					throw error;
+				}
+				failedParts.push({ label: partLabel, message: detail });
 			}
-			results.push({
-				offsetSeconds: payload.offsetSeconds,
-				transcript: buildTranscript(chunkResult.segments, {
-					language: chunkResult.language,
-				}),
-			});
+		}
+
+		// Every part failed: there is no transcript to keep, so surface the
+		// first failure (named like the per-part error) rather than writing
+		// nothing and reporting a hollow success.
+		if (results.length === 0) {
+			const first = failedParts[0];
+			throw new Error(
+				first
+					? `${first.message} (while transcribing ${first.label})`
+					: 'Transcription produced no output.',
+			);
 		}
 
 		// Honor a cancel pressed during the final (or only) request: requestUrl
@@ -240,6 +258,23 @@ export class TranscriptionService {
 			markdownOptions,
 			this.linkBuilder(file, options.notePathForLinks),
 		);
+
+		// Some parts failed but others succeeded: keep the good parts, flag the
+		// gap at the top of the note so the transcript is not mistaken for
+		// complete, and warn — rather than failing the whole run and discarding
+		// a transcript the user already paid for.
+		if (failedParts.length > 0) {
+			const labels = failedParts.map((part) => part.label).join(', ');
+			const verb = failedParts.length > 1 ? 'are' : 'is';
+			markdown =
+				`> [!warning] Transcription incomplete: ${labels} could not be ` +
+				`transcribed and ${verb} missing below.\n\n${markdown}`;
+			new Notice(
+				`Some audio could not be transcribed (${labels}) and is missing ` +
+					'from the transcript; saving the parts that succeeded. ' +
+					failedParts[0].message,
+			);
+		}
 
 		if (settings.llmPostProcessEnabled) {
 			this.throwIfCancelled(token);

--- a/src/transcription/TranscriptionService.ts
+++ b/src/transcription/TranscriptionService.ts
@@ -346,10 +346,18 @@ export class TranscriptionService {
 			}
 			// The part overran the provider's output token budget. Retrying it as
 			// smaller pieces keeps each piece's output under the cap, so a dense
-			// stretch is recovered rather than discarded.
+			// stretch is recovered rather than discarded. Each retry is a real
+			// (and, on a paid API, billed) request, so the subdivision is logged:
+			// the recursion is bounded only by the MIN_SUBDIVIDE_SECONDS floor, so
+			// a consistently dense part can fan out into several extra requests.
 			if (error instanceof TranscriptTruncatedError) {
 				const halves = prepared.subdivide?.() ?? [];
 				if (halves.length > 0) {
+					console.debug(
+						`${PLUGIN_LOG_PREFIX} ${label || 'The audio'} overran ` +
+							'the output token limit; retrying as ' +
+							`${String(halves.length)} smaller pieces.`,
+					);
 					for (const half of halves) {
 						await this.transcribePart(
 							provider,
@@ -363,6 +371,14 @@ export class TranscriptionService {
 					}
 					return;
 				}
+				// At the minimum subdividable length a further split would cost
+				// more requests than it saves, so stop here and let the part be
+				// reported (or fail the run, for a single indivisible job).
+				console.debug(
+					`${PLUGIN_LOG_PREFIX} ${label || 'The audio'} still ` +
+						'overran the output token limit at the minimum segment ' +
+						'length; reporting it without subdividing further.',
+				);
 			}
 			const detail =
 				error instanceof Error ? error.message : String(error);

--- a/src/transcription/TranscriptionService.ts
+++ b/src/transcription/TranscriptionService.ts
@@ -21,11 +21,15 @@ import {
 	audioMimeFromExtension,
 	audioPrepOptions,
 	prepareAudio,
+	type PreparedPayload,
 } from './audioPrep';
 import type {
 	AudioPayload,
+	TranscribeOptions,
 	TranscriptionProvider,
 } from './providers/TranscriptionProvider';
+import { TranscriptTruncatedError } from './transcriptionErrors';
+import { formatTimecode } from '../utils/TimeUtils';
 import {
 	buildTranscript,
 	plainText,
@@ -175,7 +179,6 @@ export class TranscriptionService {
 		const failedParts: { label: string; message: string }[] = [];
 		for (let i = 0; i < partCount; i++) {
 			this.throwIfCancelled(token);
-			const prepPayload = payloads[i];
 			const partLabel =
 				partCount > 1
 					? `part ${String(i + 1)} of ${String(partCount)}`
@@ -184,41 +187,15 @@ export class TranscriptionService {
 				(i / partCount) * TRANSCRIBE_CHUNK_PROGRESS_CEILING,
 				partLabel ? `Transcribing ${partLabel}...` : 'Transcribing...',
 			);
-			// Materialize this payload's bytes only now, so a multi-chunk job
-			// never holds more than one chunk's WAV in memory at a time.
-			const payload: AudioPayload = {
-				data: prepPayload.createData(),
-				contentType: prepPayload.contentType,
-				filename: prepPayload.filename,
-				offsetSeconds: prepPayload.offsetSeconds,
-			};
-			try {
-				const chunkResult = await provider.transcribe(
-					payload,
-					transcribeOptions,
-				);
-				results.push({
-					offsetSeconds: payload.offsetSeconds,
-					transcript: buildTranscript(chunkResult.segments, {
-						language: chunkResult.language,
-					}),
-				});
-			} catch (error) {
-				// A cancel aborts the whole run; never salvage past it.
-				if (error instanceof TranscriptionCancelledError) {
-					throw error;
-				}
-				const detail =
-					error instanceof Error ? error.message : String(error);
-				// A single-part job has nothing to keep, so fail as before. For
-				// a multi-part job, record the failure and carry on: discarding
-				// a completed (and, on a paid API, already-billed) part because
-				// a later part hit a provider limit would throw away good work.
-				if (!partLabel) {
-					throw error;
-				}
-				failedParts.push({ label: partLabel, message: detail });
-			}
+			await this.transcribePart(
+				provider,
+				payloads[i],
+				transcribeOptions,
+				token,
+				partLabel,
+				results,
+				failedParts,
+			);
 		}
 
 		// Every part failed: there is no transcript to keep, so surface the
@@ -259,16 +236,18 @@ export class TranscriptionService {
 			this.linkBuilder(file, options.notePathForLinks),
 		);
 
-		// Some parts failed but others succeeded: keep the good parts, flag the
-		// gap at the top of the note so the transcript is not mistaken for
-		// complete, and warn — rather than failing the whole run and discarding
-		// a transcript the user already paid for.
+		// Some parts failed but others succeeded: keep the good parts and warn,
+		// rather than failing the whole run and discarding a transcript the user
+		// already paid for. The gap is flagged with a callout prepended only
+		// after post-processing (below), because an LLM cleanup/custom pass
+		// replaces the whole body and would otherwise strip the warning.
+		let incompleteWarning = '';
 		if (failedParts.length > 0) {
 			const labels = failedParts.map((part) => part.label).join(', ');
 			const verb = failedParts.length > 1 ? 'are' : 'is';
-			markdown =
-				`> [!warning] Transcription incomplete: ${labels} could not be ` +
-				`transcribed and ${verb} missing below.\n\n${markdown}`;
+			incompleteWarning =
+				`> [!warning] Transcription incomplete: ${labels} could not ` +
+				`be transcribed and ${verb} missing below.\n\n`;
 			new Notice(
 				`Some audio could not be transcribed (${labels}) and is missing ` +
 					'from the transcript; saving the parts that succeeded. ' +
@@ -305,8 +284,114 @@ export class TranscriptionService {
 			}
 		}
 
+		// Flag any gap last, so the callout survives an LLM cleanup/custom pass
+		// that would otherwise replace the body and drop it.
+		markdown = incompleteWarning + markdown;
+
 		options.onProgress?.(1, 'Done');
 		return { transcript, markdown };
+	}
+
+	/**
+	 * Transcribes one prepared part, pushing its stitched result or, on failure,
+	 * recording the failure so the surrounding parts are still kept. When a
+	 * provider truncates the part because its output token budget was exhausted
+	 * ({@link TranscriptTruncatedError}), the part is split into smaller pieces
+	 * and each is transcribed in turn, recovering a dense stretch that overran
+	 * the cap instead of losing it; only when the part is already at the minimum
+	 * length (subdivision yields nothing) does it count as a failure. A part with
+	 * an empty label is a single indivisible job and fails the whole run as
+	 * before.
+	 * @param provider - The active transcription provider
+	 * @param prepared - The prepared part to transcribe
+	 * @param providerOptions - Per-request provider options (language, diarize)
+	 * @param token - Cancellation token
+	 * @param label - Human label for the part ('' for a single indivisible job)
+	 * @param results - Accumulates successful per-part transcripts (mutated)
+	 * @param failedParts - Accumulates recoverable per-part failures (mutated)
+	 */
+	private async transcribePart(
+		provider: TranscriptionProvider,
+		prepared: PreparedPayload,
+		providerOptions: TranscribeOptions,
+		token: CancellationToken,
+		label: string,
+		results: { offsetSeconds: number; transcript: Transcript }[],
+		failedParts: { label: string; message: string }[],
+	): Promise<void> {
+		this.throwIfCancelled(token);
+		// Materialize this payload's bytes only now, so a multi-chunk job never
+		// holds more than one chunk's WAV in memory at a time.
+		const payload: AudioPayload = {
+			data: prepared.createData(),
+			contentType: prepared.contentType,
+			filename: prepared.filename,
+			offsetSeconds: prepared.offsetSeconds,
+		};
+		try {
+			const chunkResult = await provider.transcribe(
+				payload,
+				providerOptions,
+			);
+			results.push({
+				offsetSeconds: payload.offsetSeconds,
+				transcript: buildTranscript(chunkResult.segments, {
+					language: chunkResult.language,
+				}),
+			});
+		} catch (error) {
+			// A cancel aborts the whole run; never salvage past it.
+			if (error instanceof TranscriptionCancelledError) {
+				throw error;
+			}
+			// The part overran the provider's output token budget. Retrying it as
+			// smaller pieces keeps each piece's output under the cap, so a dense
+			// stretch is recovered rather than discarded.
+			if (error instanceof TranscriptTruncatedError) {
+				const halves = prepared.subdivide?.() ?? [];
+				if (halves.length > 0) {
+					for (const half of halves) {
+						await this.transcribePart(
+							provider,
+							half,
+							providerOptions,
+							token,
+							this.partTimeLabel(half),
+							results,
+							failedParts,
+						);
+					}
+					return;
+				}
+			}
+			const detail =
+				error instanceof Error ? error.message : String(error);
+			// A single indivisible job has nothing to keep, so fail as before. A
+			// labelled part (one of several, or a subdivision) records the failure
+			// and carries on: discarding a completed — and, on a paid API, already
+			// billed — part because another part hit a provider limit would throw
+			// away good work.
+			if (!label) {
+				throw error;
+			}
+			failedParts.push({ label, message: detail });
+		}
+	}
+
+	/**
+	 * Labels a subdivided part by its span on the timeline, e.g. "the
+	 * 7:30–15:00 segment", so a salvage warning names which stretch is missing
+	 * rather than an opaque part number that no longer maps to the split.
+	 * @param part - The prepared sub-part
+	 * @returns A human label for the part's time range
+	 */
+	private partTimeLabel(part: PreparedPayload): string {
+		const reference = part.endSeconds ?? part.offsetSeconds;
+		const start = formatTimecode(part.offsetSeconds, reference);
+		if (part.endSeconds === undefined) {
+			return `the segment at ${start}`;
+		}
+		return `the ${start}–${formatTimecode(part.endSeconds, reference)} segment`;
 	}
 
 	/**

--- a/src/transcription/TranscriptionService.ts
+++ b/src/transcription/TranscriptionService.ts
@@ -291,6 +291,8 @@ export class TranscriptionService {
 			{
 				task: settings.llmPostProcessTask,
 				language: transcript.language,
+				cleanupPrompt: settings.llmCleanupPrompt,
+				summaryPrompt: settings.llmSummaryPrompt,
 				customInstruction: settings.llmCustomInstruction,
 			},
 		);

--- a/src/transcription/audioChunks.ts
+++ b/src/transcription/audioChunks.ts
@@ -75,6 +75,40 @@ export function planChunks(
 }
 
 /**
+ * Splits a chunk plan into two halves at its midpoint, for retrying a part
+ * that overran a provider's output token limit as smaller pieces. The shared
+ * midpoint boundary tiles exactly because {@link extractChunkWav} rounds both
+ * ends to the same frame. Returns an empty array when the chunk is too short to
+ * divide into two halves that each stay at or above `minSeconds`, signalling
+ * the caller to stop subdividing.
+ * @param chunk - The chunk plan to split
+ * @param minSeconds - Smallest half a split may produce
+ * @returns Two half-length plans, or [] when the chunk is at the floor
+ */
+export function splitChunkPlan(
+	chunk: ChunkPlan,
+	minSeconds: number,
+): ChunkPlan[] {
+	const duration = chunk.endSeconds - chunk.startSeconds;
+	if (duration < 2 * minSeconds) {
+		return [];
+	}
+	const midSeconds = chunk.startSeconds + duration / 2;
+	return [
+		{
+			index: chunk.index * 2,
+			startSeconds: chunk.startSeconds,
+			endSeconds: midSeconds,
+		},
+		{
+			index: chunk.index * 2 + 1,
+			startSeconds: midSeconds,
+			endSeconds: chunk.endSeconds,
+		},
+	];
+}
+
+/**
  * Decodes an audio file and resamples it to a single 16 kHz mono PCM
  * channel via an OfflineAudioContext. This is the canonical Whisper input
  * and makes every source format chunk identically.

--- a/src/transcription/audioPrep.ts
+++ b/src/transcription/audioPrep.ts
@@ -20,10 +20,17 @@ import {
 	FORMAT_FLAC,
 	MIME_TYPE_AUDIO_PREFIX,
 	MIN_AUDIO_BYTES_PER_SEC,
+	MIN_SUBDIVIDE_SECONDS,
 	TRANSCRIBE_BYTES_PER_SEC,
 	TRANSCRIBE_SAMPLE_RATE,
 } from '../constants';
-import { decodeToMono16k, extractChunkWav, planChunks } from './audioChunks';
+import {
+	decodeToMono16k,
+	extractChunkWav,
+	planChunks,
+	splitChunkPlan,
+	type ChunkPlan,
+} from './audioChunks';
 import type { ProviderCapabilities } from './providers/TranscriptionProvider';
 
 /** Maps a lowercased file extension to its upload container MIME type. */
@@ -84,8 +91,22 @@ export interface PreparedPayload {
 	filename: string;
 	/** Offset of this payload from the start of the recording, in seconds. */
 	offsetSeconds: number;
+	/**
+	 * End of this payload on the recording timeline, in seconds. Present on the
+	 * decode path (so a part can be labelled and subdivided by its time range);
+	 * absent on the whole-file path, whose true duration is never measured.
+	 */
+	endSeconds?: number;
 	/** Builds the upload bytes; invoked once, right before uploading. */
 	createData(): ArrayBuffer;
+	/**
+	 * Splits this payload into smaller payloads covering the same audio, for a
+	 * provider that overran its output token budget on this part. Present only on
+	 * the decode path (the decoded samples are still in memory); returns the
+	 * smaller payloads, or [] when the part is already at the minimum
+	 * subdividable length.
+	 */
+	subdivide?: () => PreparedPayload[];
 }
 
 /** Prepared payloads ready to transcribe. */
@@ -200,12 +221,28 @@ export async function prepareAudio(
 	const totalSeconds = samples.length / TRANSCRIBE_SAMPLE_RATE;
 	const plans = planChunks(totalSeconds, options.chunkBytes);
 	const multiChunk = plans.length > 1;
-	const payloads: PreparedPayload[] = plans.map((plan) => ({
+	// Build a payload for a plan, retaining the decoded samples so the part can
+	// be re-split on demand when a provider overruns its output token budget.
+	const buildPayload = (
+		plan: ChunkPlan,
+		filename: string,
+	): PreparedPayload => ({
 		contentType: `${MIME_TYPE_AUDIO_PREFIX}wav`,
-		filename: multiChunk ? `audio-${String(plan.index)}.wav` : 'audio.wav',
+		filename,
 		offsetSeconds: plan.startSeconds,
+		endSeconds: plan.endSeconds,
 		createData: () => extractChunkWav(samples, plan),
-	}));
+		subdivide: () =>
+			splitChunkPlan(plan, MIN_SUBDIVIDE_SECONDS).map((half) =>
+				buildPayload(half, `audio-${String(half.index)}.wav`),
+			),
+	});
+	const payloads: PreparedPayload[] = plans.map((plan) =>
+		buildPayload(
+			plan,
+			multiChunk ? `audio-${String(plan.index)}.wav` : 'audio.wav',
+		),
+	);
 	return {
 		payloads,
 		diarizationSplitWarning: shouldWarnDiarizationSplit(

--- a/src/transcription/factories.ts
+++ b/src/transcription/factories.ts
@@ -97,35 +97,49 @@ export function createTranscriptionProvider(
 }
 
 /**
- * Builds the configured LLM post-processing provider.
+ * Builds the configured LLM post-processing provider. The API key is the
+ * shared per-vendor key (OpenAI reuses the Whisper API key, Gemini reuses the
+ * Gemini transcription key, Anthropic uses its own), and the model is the
+ * provider's own selected id. Every provider requires a key.
  * @param settings - Plugin settings
  */
 export function createLlmProvider(
 	settings: AudioRecorderSettings,
 ): LlmProvider {
-	const config = {
-		baseUrl: settings.llmBaseUrl,
-		apiKey: settings.llmApiKey,
-		model: settings.llmModel,
-	};
+	const baseUrl = settings.llmBaseUrl;
 	if (settings.llmProvider === LLM_PROVIDER_IDS.ANTHROPIC) {
-		if (!config.apiKey) {
+		if (!settings.anthropicApiKey) {
 			throw new ProviderConfigError(
 				'Set the Anthropic API key in settings.',
 			);
 		}
-		return new AnthropicLlmProvider(config);
+		return new AnthropicLlmProvider({
+			baseUrl,
+			apiKey: settings.anthropicApiKey,
+			model: settings.llmAnthropicModel,
+		});
 	}
 	if (settings.llmProvider === LLM_PROVIDER_IDS.GEMINI) {
-		if (!config.apiKey) {
+		if (!settings.geminiApiKey) {
 			throw new ProviderConfigError(
 				'Set the Google Gemini API key in settings.',
 			);
 		}
-		return new GeminiLlmProvider(config);
+		return new GeminiLlmProvider({
+			baseUrl,
+			apiKey: settings.geminiApiKey,
+			model: settings.llmGeminiModel,
+		});
 	}
-	// OpenAI-compatible: a local Ollama server needs no key, hosted APIs do.
-	return new OpenAiCompatibleLlmProvider(config);
+	// OpenAI reuses the Whisper API key as the shared OpenAI vendor key.
+	if (!settings.whisperApiKey) {
+		throw new ProviderConfigError('Set the OpenAI API key in settings.');
+	}
+	return new OpenAiCompatibleLlmProvider({
+		baseUrl,
+		apiKey: settings.whisperApiKey,
+		model: settings.llmOpenAiModel,
+	});
 }
 
 /**

--- a/src/transcription/factories.ts
+++ b/src/transcription/factories.ts
@@ -4,7 +4,11 @@
  * @module transcription/factories
  */
 
-import { LLM_PROVIDER_IDS, TRANSCRIPTION_PROVIDER_IDS } from '../constants';
+import {
+	LLM_PROVIDER_IDS,
+	MS_PER_MINUTE,
+	TRANSCRIPTION_PROVIDER_IDS,
+} from '../constants';
 import type { AudioRecorderSettings } from '../settings/Settings';
 import { WhisperApiProvider } from './providers/WhisperApiProvider';
 import { LocalWhisperProvider } from './providers/LocalWhisperProvider';
@@ -34,6 +38,11 @@ export class ProviderConfigError extends Error {
 export function createTranscriptionProvider(
 	settings: AudioRecorderSettings,
 ): TranscriptionProvider {
+	// Per-request timeout cap shared by every network provider, from the
+	// user-configured limit (minutes). Local whisper.cpp makes no HTTP request,
+	// so it ignores this.
+	const requestTimeoutMs =
+		settings.transcriptionTimeoutMinutes * MS_PER_MINUTE;
 	if (
 		settings.transcriptionProvider ===
 		TRANSCRIPTION_PROVIDER_IDS.LOCAL_WHISPER
@@ -70,6 +79,7 @@ export function createTranscriptionProvider(
 			baseUrl: settings.deepgramBaseUrl,
 			apiKey: settings.deepgramApiKey,
 			model: settings.deepgramModel,
+			requestTimeoutMs,
 		});
 	}
 	if (settings.transcriptionProvider === TRANSCRIPTION_PROVIDER_IDS.GEMINI) {
@@ -82,6 +92,7 @@ export function createTranscriptionProvider(
 			baseUrl: settings.geminiBaseUrl,
 			apiKey: settings.geminiApiKey,
 			model: settings.geminiModel,
+			requestTimeoutMs,
 		});
 	}
 	if (!settings.whisperApiKey) {
@@ -93,6 +104,7 @@ export function createTranscriptionProvider(
 		baseUrl: settings.whisperApiBaseUrl,
 		apiKey: settings.whisperApiKey,
 		model: settings.whisperApiModel,
+		requestTimeoutMs,
 	});
 }
 

--- a/src/transcription/httpClient.ts
+++ b/src/transcription/httpClient.ts
@@ -84,15 +84,20 @@ export function trimTrailingSlash(url: string): string {
  * Scales a request timeout with the upload size so a large but healthy
  * upload (e.g. a whole-file Deepgram request) is not aborted prematurely.
  * Starts at the floor and adds time proportional to the payload at a
- * conservative assumed throughput, capped at the hard ceiling.
+ * conservative assumed throughput, capped at `maxMs`.
  * @param byteLength - Size of the request body in bytes
+ * @param maxMs - Hard cap for the timeout (the user-configured per-request
+ *   limit); defaults to {@link TRANSCRIBE_MAX_REQUEST_TIMEOUT_MS}
  * @returns Timeout in milliseconds
  */
-export function uploadTimeoutMs(byteLength: number): number {
+export function uploadTimeoutMs(
+	byteLength: number,
+	maxMs: number = TRANSCRIBE_MAX_REQUEST_TIMEOUT_MS,
+): number {
 	const scaled =
 		TRANSCRIBE_REQUEST_TIMEOUT_MS +
 		Math.ceil(byteLength / TRANSCRIBE_UPLOAD_BYTES_PER_MS);
-	return Math.min(scaled, TRANSCRIBE_MAX_REQUEST_TIMEOUT_MS);
+	return Math.min(scaled, maxMs);
 }
 
 /** Status used for errors that never reached an HTTP response (transport/timeout). */

--- a/src/transcription/llm/LlmProvider.ts
+++ b/src/transcription/llm/LlmProvider.ts
@@ -1,7 +1,7 @@
 /**
- * LLM provider abstraction for transcript post-processing, plus the
- * OpenAI-compatible (OpenAI / Groq / Ollama) and Anthropic
- * implementations. All calls go through Obsidian's `requestUrl`.
+ * LLM provider abstraction for transcript post-processing, plus the OpenAI,
+ * Anthropic, and Google Gemini implementations. The OpenAI provider speaks the
+ * OpenAI Chat Completions API. All calls go through Obsidian's `requestUrl`.
  * @module transcription/llm/LlmProvider
  */
 
@@ -45,12 +45,13 @@ export interface LlmConfig {
 }
 
 /**
- * OpenAI-compatible chat-completions provider. Works with OpenAI, Groq,
- * and a local Ollama server (which accepts an empty API key).
+ * OpenAI chat-completions provider, using the OpenAI Chat Completions API.
+ * The implementation stays OpenAI-compatible, but only OpenAI is offered as a
+ * configured vendor.
  */
 export class OpenAiCompatibleLlmProvider implements LlmProvider {
 	readonly id = LLM_PROVIDER_IDS.OPENAI_COMPATIBLE;
-	readonly label = 'OpenAI-compatible (OpenAI / Groq / Ollama)';
+	readonly label = 'OpenAI';
 
 	constructor(private readonly config: LlmConfig) {}
 

--- a/src/transcription/llm/llmResponse.ts
+++ b/src/transcription/llm/llmResponse.ts
@@ -9,8 +9,8 @@ import { isRecord } from '../providers/responseUtils';
 import { geminiCandidateText } from '../providers/geminiShared';
 
 /**
- * Extracts the assistant message text from an OpenAI-compatible
- * `chat/completions` response (also used by Groq and Ollama).
+ * Extracts the assistant message text from an OpenAI Chat Completions
+ * (`chat/completions`) response.
  * @param body - Parsed JSON response
  * @returns The message content, or empty string when absent
  */

--- a/src/transcription/llmPostProcess.ts
+++ b/src/transcription/llmPostProcess.ts
@@ -1,9 +1,16 @@
 /**
  * Pure prompt construction for LLM post-processing of a transcript.
  * Building the prompts is separated from the network call so the prompt
- * shape can be unit tested and reused across providers.
+ * shape can be unit tested and reused across providers. The cleanup and
+ * summary system prompts are editable in settings; the language clause is
+ * appended here so the user-facing base text stays language-agnostic.
  * @module transcription/llmPostProcess
  */
+
+import {
+	DEFAULT_LLM_CLEANUP_PROMPT,
+	DEFAULT_LLM_SUMMARY_PROMPT,
+} from '../constants';
 
 /** What the LLM should do with the transcript text. */
 export type LlmTask = 'cleanup' | 'summary' | 'custom';
@@ -20,53 +27,48 @@ export interface PostProcessOptions {
 	task: LlmTask;
 	/** Detected/declared language name or code, when known. */
 	language?: string;
-	/** Custom instruction, used when task is 'custom'. */
+	/**
+	 * Editable cleanup system prompt (base text, before the language clause).
+	 * Falls back to {@link DEFAULT_LLM_CLEANUP_PROMPT} when empty.
+	 */
+	cleanupPrompt?: string;
+	/**
+	 * Editable summary system prompt (base text, before the language clause).
+	 * Falls back to {@link DEFAULT_LLM_SUMMARY_PROMPT} when empty.
+	 */
+	summaryPrompt?: string;
+	/** Custom instruction, sent verbatim, used when task is 'custom'. */
 	customInstruction?: string;
 }
 
 /**
- * Builds the system instruction for a cleanup pass: fix punctuation,
- * capitalization, and obvious transcription slips, add paragraph breaks,
- * and keep the speaker's words and meaning intact — in the original
- * language.
+ * Builds the language clause appended to the cleanup prompt: keep the answer in
+ * the transcript's language.
+ * @param language - Detected/declared language, when known
  */
-function cleanupSystemPrompt(language?: string): string {
-	const langClause = language
+function cleanupLanguageClause(language?: string): string {
+	return language
 		? ` The transcript language is ${language}; respond in that same language.`
 		: ' Respond in the same language as the transcript.';
-	return (
-		'You are an expert transcription editor. You are given a raw, ' +
-		'machine-generated transcript. Correct punctuation, capitalization, ' +
-		'and obvious speech-to-text errors; insert sensible paragraph breaks; ' +
-		'and remove filler artifacts only when they add no meaning. Do NOT ' +
-		'summarize, translate, paraphrase, add, or omit content — preserve ' +
-		'the speaker’s exact wording and meaning. Preserve any speaker labels ' +
-		'and timestamps exactly as they appear, keeping each on its original ' +
-		'line. Return only the corrected transcript with no preamble.' +
-		langClause
-	);
 }
 
 /**
- * Builds the system instruction for a summary pass.
+ * Builds the language clause appended to the summary prompt.
+ * @param language - Detected/declared language, when known
  */
-function summarySystemPrompt(language?: string): string {
-	const langClause = language
+function summaryLanguageClause(language?: string): string {
+	return language
 		? ` Write the summary in ${language}.`
 		: ' Write the summary in the same language as the transcript.';
-	return (
-		'You are an expert analyst. Summarize the following transcript into a ' +
-		'concise set of key points and any action items, as Markdown bullet ' +
-		'lists under short headings. Be faithful to the content and do not ' +
-		'invent details. Return only the summary with no preamble.' +
-		langClause
-	);
 }
 
 /**
  * Builds a provider-neutral prompt for the requested post-processing task.
+ * The cleanup and summary base prompts come from settings (falling back to the
+ * shipped defaults) and get the language clause appended; the custom
+ * instruction is sent verbatim so the user controls every directive.
  * @param text - The transcript text to process
- * @param options - Task and language options
+ * @param options - Task, language, and editable prompt templates
  * @returns System + user prompt
  */
 export function buildPostProcessPrompt(
@@ -76,12 +78,18 @@ export function buildPostProcessPrompt(
 	switch (options.task) {
 		case 'cleanup':
 			return {
-				system: cleanupSystemPrompt(options.language),
+				system:
+					(options.cleanupPrompt?.trim() ||
+						DEFAULT_LLM_CLEANUP_PROMPT) +
+					cleanupLanguageClause(options.language),
 				user: text,
 			};
 		case 'summary':
 			return {
-				system: summarySystemPrompt(options.language),
+				system:
+					(options.summaryPrompt?.trim() ||
+						DEFAULT_LLM_SUMMARY_PROMPT) +
+					summaryLanguageClause(options.language),
 				user: text,
 			};
 		case 'custom':

--- a/src/transcription/providers/DeepgramProvider.ts
+++ b/src/transcription/providers/DeepgramProvider.ts
@@ -25,6 +25,8 @@ export interface DeepgramConfig {
 	baseUrl: string;
 	apiKey: string;
 	model: string;
+	/** Per-request timeout cap (ms); the user-configured transcription limit. */
+	requestTimeoutMs?: number;
 }
 
 /**
@@ -65,7 +67,10 @@ export class DeepgramProvider implements TranscriptionProvider {
 			headers: { Authorization: `Token ${this.config.apiKey}` },
 			contentType: payload.contentType,
 			body: payload.data,
-			timeoutMs: uploadTimeoutMs(payload.data.byteLength),
+			timeoutMs: uploadTimeoutMs(
+				payload.data.byteLength,
+				this.config.requestTimeoutMs,
+			),
 		});
 		return mapDeepgramResponse(json, options.diarize);
 	}

--- a/src/transcription/providers/GeminiProvider.ts
+++ b/src/transcription/providers/GeminiProvider.ts
@@ -13,6 +13,7 @@ import {
 	GEMINI_AUDIO_MIME_TYPES,
 	GEMINI_GENERATE_MIN_TIMEOUT_MS,
 	MIME_TYPE_AUDIO_PREFIX,
+	TRANSCRIBE_MAX_REQUEST_TIMEOUT_MS,
 	TRANSCRIBE_SAMPLE_RATE,
 	TRANSCRIPTION_PROVIDER_IDS,
 } from '../../constants';
@@ -45,6 +46,8 @@ export interface GeminiConfig {
 	baseUrl: string;
 	apiKey: string;
 	model: string;
+	/** Per-request timeout cap (ms); the user-configured transcription limit. */
+	requestTimeoutMs?: number;
 }
 
 /** WAV MIME type used when a container is decoded before upload. */
@@ -97,15 +100,22 @@ const TRUNCATION_REMEDY =
  * audio duration, not byte size, and a compressed accepted container (mp3, aac,
  * ogg, flac) has far fewer bytes than its duration implies, so the upload-size
  * proxy alone can abort a healthy long transcription. Take the larger of the
- * size-scaled upload budget and a generous floor.
+ * size-scaled upload budget and a generous floor, then cap by the
+ * user-configured per-request limit so the floor cannot exceed it.
  * @param byteLength - Size of the uploaded audio bytes
+ * @param maxMs - Per-request timeout cap; defaults to
+ *   {@link TRANSCRIBE_MAX_REQUEST_TIMEOUT_MS}
  * @returns Timeout in milliseconds
  */
-export function geminiGenerateTimeoutMs(byteLength: number): number {
-	return Math.max(
-		uploadTimeoutMs(byteLength),
+export function geminiGenerateTimeoutMs(
+	byteLength: number,
+	maxMs: number = TRANSCRIBE_MAX_REQUEST_TIMEOUT_MS,
+): number {
+	const base = Math.max(
+		uploadTimeoutMs(byteLength, maxMs),
 		GEMINI_GENERATE_MIN_TIMEOUT_MS,
 	);
+	return Math.min(base, maxMs);
 }
 
 /** Builds the per-run instruction text sent alongside the audio. */
@@ -152,6 +162,7 @@ export class GeminiProvider implements TranscriptionProvider {
 			data,
 			mimeType,
 			payload.filename,
+			this.config.requestTimeoutMs,
 		);
 		try {
 			await waitUntilActive(
@@ -192,7 +203,10 @@ export class GeminiProvider implements TranscriptionProvider {
 						...(thinkingConfig ? { thinkingConfig } : {}),
 					},
 				}),
-				timeoutMs: geminiGenerateTimeoutMs(data.byteLength),
+				timeoutMs: geminiGenerateTimeoutMs(
+					data.byteLength,
+					this.config.requestTimeoutMs,
+				),
 			});
 			// A truncated (MAX_TOKENS) response yields invalid JSON, and a
 			// safety/policy block yields no candidate; both would otherwise map

--- a/src/transcription/providers/WhisperApiProvider.ts
+++ b/src/transcription/providers/WhisperApiProvider.ts
@@ -30,6 +30,8 @@ export interface WhisperApiConfig {
 	baseUrl: string;
 	apiKey: string;
 	model: string;
+	/** Per-request timeout cap (ms); the user-configured transcription limit. */
+	requestTimeoutMs?: number;
 }
 
 /**
@@ -88,7 +90,10 @@ export class WhisperApiProvider implements TranscriptionProvider {
 			headers: { Authorization: `Bearer ${this.config.apiKey}` },
 			contentType,
 			body,
-			timeoutMs: uploadTimeoutMs(body.byteLength),
+			timeoutMs: uploadTimeoutMs(
+				body.byteLength,
+				this.config.requestTimeoutMs,
+			),
 		});
 		return mapWhisperResponse(json);
 	}

--- a/src/transcription/providers/geminiFileApi.ts
+++ b/src/transcription/providers/geminiFileApi.ts
@@ -104,6 +104,7 @@ function parseFile(body: unknown): GeminiFile {
  * @param data - Encoded audio bytes
  * @param mimeType - MIME type of the bytes
  * @param displayName - Human-readable name stored with the file
+ * @param maxTimeoutMs - Per-request timeout cap for the byte-upload step
  */
 export async function uploadFile(
 	baseUrl: string,
@@ -111,6 +112,7 @@ export async function uploadFile(
 	data: ArrayBuffer,
 	mimeType: string,
 	displayName: string,
+	maxTimeoutMs?: number,
 ): Promise<GeminiFile> {
 	const base = trimTrailingSlash(baseUrl);
 	const numBytes = String(data.byteLength);
@@ -145,7 +147,7 @@ export async function uploadFile(
 			'X-Goog-Upload-Command': 'upload, finalize',
 		},
 		body: data,
-		timeoutMs: uploadTimeoutMs(data.byteLength),
+		timeoutMs: uploadTimeoutMs(data.byteLength, maxTimeoutMs),
 	});
 	return parseFile(finalized);
 }

--- a/src/transcription/providers/geminiShared.ts
+++ b/src/transcription/providers/geminiShared.ts
@@ -13,6 +13,7 @@ import {
 	GEMINI_PRO_MIN_THINKING_BUDGET,
 	GEMINI_THINKING_BUDGET_OFF,
 } from '../../constants';
+import { TranscriptTruncatedError } from '../transcriptionErrors';
 
 /** Finish reason set when the model stops because it hit the output token cap. */
 export const GEMINI_FINISH_MAX_TOKENS = 'MAX_TOKENS';
@@ -205,7 +206,7 @@ function geminiUsageDetail(body: unknown): string {
  */
 export function assertGeminiNotTruncated(body: unknown, remedy: string): void {
 	if (geminiFinishReason(body) === GEMINI_FINISH_MAX_TOKENS) {
-		throw new Error(
+		throw new TranscriptTruncatedError(
 			'Gemini stopped because it reached its output token limit' +
 				`${geminiUsageDetail(body)}, so the response is incomplete. ` +
 				remedy,

--- a/src/transcription/providers/geminiShared.ts
+++ b/src/transcription/providers/geminiShared.ts
@@ -129,12 +129,75 @@ export function geminiFinishReason(body: unknown): string | undefined {
 }
 
 /**
+ * Token counts Gemini reports in `usageMetadata`. Every field is optional: a
+ * response may omit usage data, and only a thinking model reports
+ * `thoughtsTokenCount`, so callers treat a missing count as "unknown" rather
+ * than zero.
+ */
+export interface GeminiUsage {
+	promptTokenCount?: number;
+	candidatesTokenCount?: number;
+	totalTokenCount?: number;
+	thoughtsTokenCount?: number;
+}
+
+/**
+ * Reads the `usageMetadata` token counts from a `generateContent` response,
+ * keeping only finite numbers. Returns an empty object when usage is absent so
+ * a caller can distinguish "not reported" from a real zero.
+ * @param body - Parsed JSON `generateContent` response
+ * @returns The reported token counts (absent fields stay undefined)
+ */
+export function geminiUsage(body: unknown): GeminiUsage {
+	if (!isRecord(body) || !isRecord(body.usageMetadata)) {
+		return {};
+	}
+	const meta = body.usageMetadata;
+	const finite = (value: unknown): number | undefined =>
+		typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+	return {
+		promptTokenCount: finite(meta.promptTokenCount),
+		candidatesTokenCount: finite(meta.candidatesTokenCount),
+		totalTokenCount: finite(meta.totalTokenCount),
+		thoughtsTokenCount: finite(meta.thoughtsTokenCount),
+	};
+}
+
+/**
+ * Formats the reported token usage as a parenthetical for the truncation error,
+ * e.g. ` (generated 65536 output tokens, 78000 total)`. Returns '' when the
+ * response carried no usable counts, so the message degrades cleanly when the
+ * provider omits usage data.
+ * @param body - Parsed JSON `generateContent` response
+ * @returns A leading-space parenthetical, or '' when no counts are present
+ */
+function geminiUsageDetail(body: unknown): string {
+	const usage = geminiUsage(body);
+	const parts: string[] = [];
+	if (usage.candidatesTokenCount !== undefined) {
+		const thinking =
+			usage.thoughtsTokenCount && usage.thoughtsTokenCount > 0
+				? ` including ${String(usage.thoughtsTokenCount)} on thinking`
+				: '';
+		parts.push(
+			`generated ${String(usage.candidatesTokenCount)} output tokens${thinking}`,
+		);
+	}
+	if (usage.totalTokenCount !== undefined) {
+		parts.push(`${String(usage.totalTokenCount)} total`);
+	}
+	return parts.length > 0 ? ` (${parts.join(', ')})` : '';
+}
+
+/**
  * Throws a clear, actionable error when a Gemini response was cut off because
  * it reached the output token limit. Gemini 2.5 models also spend part of the
  * output budget on internal "thinking", so a low limit can truncate or empty
  * the usable text; surfacing this beats silently returning a partial transcript
- * or an empty post-processing result. The caller supplies the `remedy` because
- * the actionable advice differs by task: the LLM path can raise the max-tokens
+ * or an empty post-processing result. The message embeds the reported token
+ * usage (output and total counts) so the user sees how far the response ran
+ * before hitting the cap. The caller supplies the `remedy` because the
+ * actionable advice differs by task: the LLM path can raise the max-tokens
  * setting, whereas transcription has no such control and must shorten the input
  * or change model.
  * @param body - Parsed JSON `generateContent` response
@@ -143,8 +206,9 @@ export function geminiFinishReason(body: unknown): string | undefined {
 export function assertGeminiNotTruncated(body: unknown, remedy: string): void {
 	if (geminiFinishReason(body) === GEMINI_FINISH_MAX_TOKENS) {
 		throw new Error(
-			'Gemini stopped because it reached its output token limit, so the ' +
-				`response is incomplete. ${remedy}`,
+			'Gemini stopped because it reached its output token limit' +
+				`${geminiUsageDetail(body)}, so the response is incomplete. ` +
+				remedy,
 		);
 	}
 }

--- a/src/transcription/providers/geminiShared.ts
+++ b/src/transcription/providers/geminiShared.ts
@@ -176,9 +176,12 @@ function geminiUsageDetail(body: unknown): string {
 	const usage = geminiUsage(body);
 	const parts: string[] = [];
 	if (usage.candidatesTokenCount !== undefined) {
+		// Gemini reports thinking tokens separately from candidatesTokenCount
+		// (billing is the sum of the two), so they are added to, not contained
+		// within, the output-token count — hence "plus", not "including".
 		const thinking =
 			usage.thoughtsTokenCount && usage.thoughtsTokenCount > 0
-				? ` including ${String(usage.thoughtsTokenCount)} on thinking`
+				? ` plus ${String(usage.thoughtsTokenCount)} on thinking`
 				: '';
 		parts.push(
 			`generated ${String(usage.candidatesTokenCount)} output tokens${thinking}`,

--- a/src/transcription/transcriptionErrors.ts
+++ b/src/transcription/transcriptionErrors.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared transcription error types that the pipeline reacts to by type rather
+ * than by matching message text. Kept provider-neutral so both the provider
+ * implementations that throw them and the orchestrating service that catches
+ * them depend on this module, not on each other.
+ * @module transcription/transcriptionErrors
+ */
+
+/**
+ * Thrown when a provider stopped because it hit its output token limit, so the
+ * returned transcript is incomplete. The orchestrator treats this as
+ * recoverable: transcribing the same audio in smaller pieces keeps each part's
+ * output under the cap. The message is provider-supplied and already names the
+ * reported token usage, so it can be surfaced unchanged when subdivision is no
+ * longer possible.
+ */
+export class TranscriptTruncatedError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'TranscriptTruncatedError';
+	}
+}

--- a/src/ui/ContextMenu.ts
+++ b/src/ui/ContextMenu.ts
@@ -25,7 +25,18 @@ import { SplitModal } from './SplitModal';
 import { TranscriptionModal } from './TranscriptionModal';
 import type { TranscriptionModalOptions } from './TranscriptionModal';
 import { AudioProcessingModal } from '../cleanup/AudioProcessingModal';
+import { insertProcessedAudioEmbed } from '../recording/NoteInserter';
 import type { AudioRecorderSettings } from '../settings/Settings';
+
+/**
+ * Primes freshly written files for the enhanced player so a cleaned/converted
+ * file is upgraded immediately instead of after the note is reopened. Injected
+ * so the context menu stays decoupled from the player registrar.
+ */
+export type EnhancementPrimer = (
+	paths: string[],
+	notePath: string | null,
+) => void;
 
 /** CodeMirror view attached to Editor (internal Obsidian API). */
 interface EditorCodeMirrorView {
@@ -66,6 +77,7 @@ export class ContextMenu {
 		private plugin: Plugin,
 		private getSettings: () => AudioRecorderSettings,
 		private createTranscriptionModalOptions: () => TranscriptionModalOptions = () => ({}),
+		private primeForEnhancement: EnhancementPrimer = () => {},
 	) {}
 
 	/**
@@ -339,6 +351,20 @@ export class ContextMenu {
 						this.app,
 						file,
 						this.getSettings(),
+						async ({ outputPath, replaceSource }) => {
+							// Link the result into the note (replace the source
+							// embed when it is being deleted, else insert after),
+							// then prime it so the enhanced player applies at once.
+							const notePath = await insertProcessedAudioEmbed(
+								this.app,
+								file,
+								outputPath,
+								replaceSource,
+							);
+							if (notePath) {
+								this.primeForEnhancement([outputPath], notePath);
+							}
+						},
 					).open();
 				});
 		});
@@ -518,6 +544,15 @@ export class ContextMenu {
 						this.app,
 						file,
 						this.getSettings(),
+						(convertedPath) => {
+							// The note link is already rewritten by the
+							// conversion's linkAction; prime the active note so the
+							// new embed becomes the enhanced player at once.
+							this.primeForEnhancement(
+								[convertedPath],
+								this.app.workspace.getActiveFile()?.path ?? null,
+							);
+						},
 					).open();
 				});
 		});

--- a/src/ui/ConversionModal.ts
+++ b/src/ui/ConversionModal.ts
@@ -36,7 +36,19 @@ export class ConversionModal extends Modal {
 	/** Conversion pipeline behind the form. */
 	private readonly conversionService: ConversionService;
 
-	constructor(app: App, sourceFile: TFile, settings: AudioRecorderSettings) {
+	/**
+	 * @param app - Obsidian app handle
+	 * @param sourceFile - Audio file to convert
+	 * @param settings - Plugin settings (seed format/bitrate/link defaults)
+	 * @param onConverted - Called with the converted file's path after a
+	 *   successful run, so a caller can prime it for the enhanced player.
+	 */
+	constructor(
+		app: App,
+		sourceFile: TFile,
+		settings: AudioRecorderSettings,
+		private readonly onConverted?: (convertedPath: string) => void,
+	) {
 		super(app);
 		this.sourceFile = sourceFile;
 		this.deleteSource = settings.deleteSourceAfterConversion;
@@ -168,6 +180,9 @@ export class ConversionModal extends Modal {
 			}
 
 			this.setProgress(progressEl, '');
+			// Conversion already rewrote the note's link (linkAction); prime the
+			// new file so the enhanced player applies without reopening the note.
+			this.onConverted?.(outcome.newPath);
 			const action = this.deleteSource ? 'Replaced with' : 'Converted to';
 			new Notice(`${action} ${outcome.newFileName}`);
 			// Cleared before close() so onClose does not start a

--- a/src/ui/TranscriptionModal.ts
+++ b/src/ui/TranscriptionModal.ts
@@ -31,6 +31,7 @@ import {
 	type SettingsSectionContext,
 } from '../settings/settingControls';
 import { transcribeFile } from '../transcription/runTranscription';
+import { formatTimecode } from '../utils/TimeUtils';
 import {
 	effectiveDiarize,
 	providerSupportsDiarization,
@@ -71,6 +72,11 @@ export class TranscriptionModal extends Modal {
 	private cancelled = false;
 	private running = false;
 	private statusEl: HTMLElement | null = null;
+	private elapsedEl: HTMLElement | null = null;
+	/** Interval handle for the live elapsed-time counter (null when stopped). */
+	private elapsedTimer: number | null = null;
+	/** Wall-clock start of the current run, in ms, for the elapsed counter. */
+	private runStartedAt = 0;
 	private progressFillEl: HTMLElement | null = null;
 	private configEl: HTMLElement | null = null;
 	private runButton: ButtonComponent | null = null;
@@ -142,6 +148,9 @@ export class TranscriptionModal extends Modal {
 		this.progressFillEl = progress.createDiv({
 			cls: 'aar-transcribe-progress-bar',
 		});
+		// Live elapsed-time counter; hidden until a run starts so an idle dialog
+		// shows no stray "0:00".
+		this.elapsedEl = contentEl.createDiv({ cls: 'aar-transcribe-elapsed' });
 
 		new Setting(contentEl)
 			.addButton((button) => {
@@ -375,11 +384,47 @@ export class TranscriptionModal extends Modal {
 		this.running = running;
 		if (running) {
 			this.cancelled = false;
+			this.startElapsedTimer();
+		} else {
+			this.stopElapsedTimer();
 		}
 		this.runButton?.setDisabled(running);
 		this.minimizeButton?.setDisabled(!running);
 		this.secondaryButton?.setButtonText(running ? 'Cancel' : 'Close');
 		this.configEl?.toggleClass('aar-transcribe-options-disabled', running);
+	}
+
+	/**
+	 * Starts the live elapsed-time counter, ticking once a second. The same
+	 * element is reused across minimize/restore, so the counter keeps running
+	 * visually while the job continues.
+	 */
+	private startElapsedTimer(): void {
+		this.runStartedAt = Date.now();
+		this.renderElapsed();
+		if (this.elapsedTimer !== null) {
+			window.clearInterval(this.elapsedTimer);
+		}
+		this.elapsedTimer = window.setInterval(() => {
+			this.renderElapsed();
+		}, 1000);
+	}
+
+	/** Stops the elapsed-time counter, leaving the final value on screen. */
+	private stopElapsedTimer(): void {
+		if (this.elapsedTimer !== null) {
+			window.clearInterval(this.elapsedTimer);
+			this.elapsedTimer = null;
+		}
+	}
+
+	/** Writes the elapsed time since the run started as mm:ss (or h:mm:ss). */
+	private renderElapsed(): void {
+		if (!this.elapsedEl) {
+			return;
+		}
+		const seconds = Math.floor((Date.now() - this.runStartedAt) / 1000);
+		this.elapsedEl.setText(`Elapsed ${formatTimecode(seconds)}`);
 	}
 
 	/**
@@ -449,6 +494,7 @@ export class TranscriptionModal extends Modal {
 		if (this.running) {
 			this.cancelled = true;
 		}
+		this.stopElapsedTimer();
 		this.clearBackgroundProgress();
 		this.contentEl.empty();
 		this.rendered = false;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -669,3 +669,22 @@ input.aar-input-invalid {
 .aar-doc-link {
     font-size: 0.85em;
 }
+
+/* Multi-line prompt editor: stack the control under the label and let the
+   text area fill the row so long editable prompts have room to breathe. */
+.aar-setting-stacked {
+    display: block;
+}
+
+.aar-setting-stacked .setting-item-control {
+    width: 100%;
+    padding-top: var(--size-4-2);
+    justify-content: flex-start;
+}
+
+.aar-setting-stacked .setting-item-control textarea {
+    width: 100%;
+    min-height: 6em;
+    resize: vertical;
+    font-family: var(--font-monospace);
+}

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -655,6 +655,13 @@ input.aar-input-invalid {
     transition: width 0.3s ease;
 }
 
+.aar-transcribe-elapsed {
+    margin-top: 4px;
+    font-size: 0.8em;
+    color: var(--text-muted);
+    font-variant-numeric: tabular-nums;
+}
+
 /* A setting rendered disabled: dimmed and non-interactive so an option the
    current selection cannot use reads clearly as off, not merely unset. */
 .aar-setting-disabled {

--- a/tests/unit/AudioProcessingService.test.ts
+++ b/tests/unit/AudioProcessingService.test.ts
@@ -188,6 +188,31 @@ describe('AudioProcessingService.process (e2e pipeline)', () => {
 		);
 	});
 
+	it('segments a recording longer than one segment, writing the full length', async () => {
+		// Force a 1-second segment so this 3.5s clip is processed across four
+		// segments; the output must still cover every frame.
+		const sampleRate = 1000;
+		const numFrames = 3500;
+		const loud = new Float32Array(numFrames).fill(0.5);
+		decodeAudioData.mockResolvedValue(fakeBuffer([loud], sampleRate));
+		const { app, written } = makeApp();
+		const service = new AudioProcessingService(app, 1);
+		const path = await service.process(fakeFile('voice/long.wav'), {
+			highPass: { enabled: false, hz: 80 },
+			gate: { enabled: true, thresholdDb: -50 },
+			leveling: { enabled: false, makeupDb: 0 },
+		});
+		const buffer = written.get(path) as ArrayBuffer;
+		expect(readWavHeader(buffer).dataBytes).toBe(numFrames * 2);
+		// A frame in the final segment carries real audio (the loud input opens
+		// the gate), proving every segment's output landed in the buffer rather
+		// than leaving the tail as the initial zeros.
+		const pcm = new DataView(buffer, 44);
+		expect(
+			Math.abs(pcm.getInt16((numFrames - 1) * 2, true)),
+		).toBeGreaterThan(0);
+	});
+
 	it('rejects files larger than the byte limit before decoding', async () => {
 		const { app } = makeApp();
 		await expect(

--- a/tests/unit/AudioProcessingService.test.ts
+++ b/tests/unit/AudioProcessingService.test.ts
@@ -11,7 +11,7 @@
 import type { App, TFile } from 'obsidian';
 import {
 	AudioProcessingService,
-	encodeWavInterleaved,
+	floatToInt16,
 } from 'src/cleanup/AudioProcessingService';
 import type { AudioDspConfig } from 'src/cleanup/audioDsp';
 import {
@@ -285,36 +285,19 @@ describe('AudioProcessingService.process (e2e pipeline)', () => {
 	});
 });
 
-describe('encodeWavInterleaved', () => {
-	it('writes a header and interleaves channels, round-tripping samples', () => {
-		const left = new Float32Array([1, 0, -1]);
-		const right = new Float32Array([0, 0.5, -0.5]);
-		const wav = encodeWavInterleaved([left, right], 48000);
-		const header = readWavHeader(wav);
-		expect(header.channels).toBe(2);
-		expect(header.sampleRate).toBe(48000);
-		expect(header.dataBytes).toBe(3 * 2 * 2);
-
-		const view = new DataView(wav, 44);
-		// Frame 0: left=1 -> 32767, right=0 -> 0
-		expect(view.getInt16(0, true)).toBe(32767);
-		expect(view.getInt16(2, true)).toBe(0);
-		// Frame 1: left=0 -> 0, right=0.5 -> ~16384
-		expect(view.getInt16(6, true)).toBeCloseTo(16384, -1);
-		// Full negative range: -1 -> -32768
-		expect(view.getInt16(8, true)).toBe(-32768);
+describe('floatToInt16', () => {
+	it('maps the rails asymmetrically (-1 -> -32768, +1 -> 32767)', () => {
+		expect(floatToInt16(1)).toBe(32767);
+		expect(floatToInt16(-1)).toBe(-32768);
+		expect(floatToInt16(0)).toBe(0);
+		// 0.5 scales by the positive rail (0x7fff).
+		expect(floatToInt16(0.5)).toBeCloseTo(16384, -1);
+		// Negatives scale by the full negative rail (0x8000).
+		expect(floatToInt16(-0.5)).toBe(-16384);
 	});
 
-	it('produces a header-only file for empty channels', () => {
-		const wav = encodeWavInterleaved([], 16000);
-		expect(readWavHeader(wav).dataBytes).toBe(0);
-	});
-
-	it('throws when channels have mismatched lengths', () => {
-		const left = new Float32Array([1, 0, -1]);
-		const right = new Float32Array([0, 0.5]);
-		expect(() => encodeWavInterleaved([left, right], 48000)).toThrow(
-			/same length/i,
-		);
+	it('clamps samples outside the -1..1 range', () => {
+		expect(floatToInt16(2)).toBe(32767);
+		expect(floatToInt16(-2)).toBe(-32768);
 	});
 });

--- a/tests/unit/ContextMenu.test.ts
+++ b/tests/unit/ContextMenu.test.ts
@@ -411,6 +411,7 @@ describe('ContextMenu', () => {
 				mockApp,
 				mockFile,
 				expect.any(Object),
+				expect.any(Function),
 			);
 		});
 

--- a/tests/unit/ConversionService.test.ts
+++ b/tests/unit/ConversionService.test.ts
@@ -112,6 +112,7 @@ describe('ConversionService', () => {
 		expect(outcome).toEqual({
 			status: 'completed',
 			newFileName: 'recording.webm',
+			newPath: 'Audio/recording.webm',
 		});
 		expect(mockApp.vault.createBinary).toHaveBeenCalledWith(
 			'Audio/recording.webm',

--- a/tests/unit/GeminiProvider.test.ts
+++ b/tests/unit/GeminiProvider.test.ts
@@ -279,4 +279,12 @@ describe('geminiGenerateTimeoutMs', () => {
 		expect(scaled).toBeGreaterThan(GEMINI_GENERATE_MIN_TIMEOUT_MS);
 		expect(geminiGenerateTimeoutMs(bigBytes)).toBe(scaled);
 	});
+
+	it('clamps to the configured cap even below the inference floor', () => {
+		// A user who sets a 5-minute limit overrides the 10-minute floor: the
+		// per-request cap wins so the run cannot wait longer than configured.
+		const cap = 5 * 60_000;
+		expect(geminiGenerateTimeoutMs(8, cap)).toBe(cap);
+		expect(geminiGenerateTimeoutMs(600 * 1024 * 1024, cap)).toBe(cap);
+	});
 });

--- a/tests/unit/NoteInserter.test.ts
+++ b/tests/unit/NoteInserter.test.ts
@@ -413,9 +413,12 @@ describe('NoteInserter', () => {
 			resolves?: Record<string, string>;
 			content: string;
 		}): { app: App; getContent: () => string } {
-			const note = opts.noteActive === false
-				? null
-				: new MockTFile(`notes/daily.${opts.noteExtension ?? 'md'}`);
+			const note =
+				opts.noteActive === false
+					? null
+					: new MockTFile(
+							`notes/daily.${opts.noteExtension ?? 'md'}`,
+						);
 			let content = opts.content;
 			const app = {
 				workspace: {
@@ -471,9 +474,7 @@ describe('NoteInserter', () => {
 			);
 
 			expect(notePath).toBe('notes/daily.md');
-			expect(getContent()).toBe(
-				'intro\n![[recording-clean.wav]]\noutro',
-			);
+			expect(getContent()).toBe('intro\n![[recording-clean.wav]]\noutro');
 		});
 
 		it('inserts the new embed after the source when it is kept', async () => {
@@ -500,9 +501,7 @@ describe('NoteInserter', () => {
 
 		it('returns null when the active note does not embed the source', async () => {
 			const { app, getContent } = buildEmbedApp({
-				embeds: [
-					{ link: 'other.mp4', original: '![[other.mp4]]' },
-				],
+				embeds: [{ link: 'other.mp4', original: '![[other.mp4]]' }],
 				resolves: { 'other.mp4': 'Audio/other.mp4' },
 				content: 'intro\n![[other.mp4]]\noutro',
 			});
@@ -549,6 +548,104 @@ describe('NoteInserter', () => {
 			);
 
 			expect(notePath).toBeNull();
+		});
+
+		it('writes a processed filename containing $ verbatim', async () => {
+			// A `$&`/`$$` in the replacement would be reinterpreted by
+			// String.prototype.replace, corrupting the note. The link text must
+			// land in the note exactly as generated.
+			const { app, getContent } = buildEmbedApp({
+				embeds: [
+					{ link: 'recording.mp4', original: '![[recording.mp4]]' },
+				],
+				resolves: { 'recording.mp4': 'Audio/recording.mp4' },
+				content: 'intro\n![[recording.mp4]]\noutro',
+			});
+
+			const notePath = await insertProcessedAudioEmbed(
+				app,
+				source(),
+				'Audio/clean $& $$.wav',
+				true,
+			);
+
+			expect(notePath).toBe('notes/daily.md');
+			expect(getContent()).toBe('intro\n![[clean $& $$.wav]]\noutro');
+		});
+
+		it('replaces every embed of the source when it is being deleted', async () => {
+			// The source embedded twice must leave no occurrence behind, or
+			// trashing it would orphan the un-rewritten embed.
+			const { app, getContent } = buildEmbedApp({
+				embeds: [
+					{ link: 'recording.mp4', original: '![[recording.mp4]]' },
+					{ link: 'recording.mp4', original: '![[recording.mp4]]' },
+				],
+				resolves: { 'recording.mp4': 'Audio/recording.mp4' },
+				content: 'a\n![[recording.mp4]]\nb\n![[recording.mp4]]\nc',
+			});
+
+			const notePath = await insertProcessedAudioEmbed(
+				app,
+				source(),
+				'Audio/recording-clean.wav',
+				true,
+			);
+
+			expect(notePath).toBe('notes/daily.md');
+			expect(getContent()).toBe(
+				'a\n![[recording-clean.wav]]\nb\n![[recording-clean.wav]]\nc',
+			);
+		});
+
+		it('replaces distinct source embeds (plain and aliased) alike', async () => {
+			const { app, getContent } = buildEmbedApp({
+				embeds: [
+					{ link: 'recording.mp4', original: '![[recording.mp4]]' },
+					{
+						link: 'recording.mp4',
+						original: '![[recording.mp4|My audio]]',
+					},
+				],
+				resolves: { 'recording.mp4': 'Audio/recording.mp4' },
+				content:
+					'a\n![[recording.mp4]]\nb\n![[recording.mp4|My audio]]\nc',
+			});
+
+			await insertProcessedAudioEmbed(
+				app,
+				source(),
+				'Audio/recording-clean.wav',
+				true,
+			);
+
+			expect(getContent()).toBe(
+				'a\n![[recording-clean.wav]]\nb\n![[recording-clean.wav]]\nc',
+			);
+		});
+
+		it('inserts after the first embed only when the source is kept', async () => {
+			// Keeping a twice-embedded source must add the processed embed once,
+			// after the first occurrence, not once per occurrence.
+			const { app, getContent } = buildEmbedApp({
+				embeds: [
+					{ link: 'recording.mp4', original: '![[recording.mp4]]' },
+					{ link: 'recording.mp4', original: '![[recording.mp4]]' },
+				],
+				resolves: { 'recording.mp4': 'Audio/recording.mp4' },
+				content: 'a\n![[recording.mp4]]\nb\n![[recording.mp4]]\nc',
+			});
+
+			await insertProcessedAudioEmbed(
+				app,
+				source(),
+				'Audio/recording-clean.wav',
+				false,
+			);
+
+			expect(getContent()).toBe(
+				'a\n![[recording.mp4]]\n![[recording-clean.wav]]\nb\n![[recording.mp4]]\nc',
+			);
 		});
 	});
 });

--- a/tests/unit/NoteInserter.test.ts
+++ b/tests/unit/NoteInserter.test.ts
@@ -18,14 +18,29 @@ class MockMarkdownView {
 	} | null = null;
 }
 
+/** Mock TFile for the instanceof check in insertProcessedAudioEmbed. */
+class MockTFile {
+	path: string;
+	extension: string;
+	constructor(path: string) {
+		this.path = path;
+		this.extension = path.split('.').pop() ?? '';
+	}
+}
+
 jest.mock('obsidian', () => ({
 	MarkdownView: MockMarkdownView,
+	TFile: MockTFile,
+	getLinkpath: (link: string): string =>
+		link.split('#')[0].split('|')[0].trim(),
 }));
 
 import {
 	captureInsertionContext,
 	insertFileLinks,
+	insertProcessedAudioEmbed,
 } from '../../src/recording/NoteInserter';
+import type { TFile } from 'obsidian';
 
 // DebugLogger mock
 function createMockDebugLogger(): { log: jest.Mock } {
@@ -382,6 +397,155 @@ describe('NoteInserter', () => {
 				['recordings/audio.webm'],
 				null,
 				app,
+			);
+
+			expect(notePath).toBeNull();
+		});
+	});
+
+	describe('insertProcessedAudioEmbed', () => {
+		// Builds an app whose active note embeds a single source file, with
+		// the note body editable through a captured vault.process callback.
+		function buildEmbedApp(opts: {
+			noteExtension?: string;
+			noteActive?: boolean;
+			embeds?: Array<{ link: string; original: string }>;
+			resolves?: Record<string, string>;
+			content: string;
+		}): { app: App; getContent: () => string } {
+			const note = opts.noteActive === false
+				? null
+				: new MockTFile(`notes/daily.${opts.noteExtension ?? 'md'}`);
+			let content = opts.content;
+			const app = {
+				workspace: {
+					getActiveFile: (): MockTFile | null => note,
+				},
+				metadataCache: {
+					getFileCache: (): { embeds: typeof opts.embeds } => ({
+						embeds: opts.embeds ?? [],
+					}),
+					getFirstLinkpathDest: (
+						linkpath: string,
+					): { path: string } | null => {
+						const dest = opts.resolves?.[linkpath];
+						return dest ? { path: dest } : null;
+					},
+				},
+				vault: {
+					getAbstractFileByPath: (path: string): MockTFile =>
+						new MockTFile(path),
+					process: (
+						_note: unknown,
+						fn: (current: string) => string,
+					): Promise<string> => {
+						content = fn(content);
+						return Promise.resolve(content);
+					},
+				},
+				fileManager: {
+					generateMarkdownLink: (file: MockTFile): string =>
+						`[[${file.path.split('/').pop() ?? file.path}]]`,
+				},
+			} as unknown as App;
+			return { app, getContent: (): string => content };
+		}
+
+		const source = (): TFile =>
+			new MockTFile('Audio/recording.mp4') as unknown as TFile;
+
+		it('replaces the source embed when the source is being deleted', async () => {
+			const { app, getContent } = buildEmbedApp({
+				embeds: [
+					{ link: 'recording.mp4', original: '![[recording.mp4]]' },
+				],
+				resolves: { 'recording.mp4': 'Audio/recording.mp4' },
+				content: 'intro\n![[recording.mp4]]\noutro',
+			});
+
+			const notePath = await insertProcessedAudioEmbed(
+				app,
+				source(),
+				'Audio/recording-clean.wav',
+				true,
+			);
+
+			expect(notePath).toBe('notes/daily.md');
+			expect(getContent()).toBe(
+				'intro\n![[recording-clean.wav]]\noutro',
+			);
+		});
+
+		it('inserts the new embed after the source when it is kept', async () => {
+			const { app, getContent } = buildEmbedApp({
+				embeds: [
+					{ link: 'recording.mp4', original: '![[recording.mp4]]' },
+				],
+				resolves: { 'recording.mp4': 'Audio/recording.mp4' },
+				content: 'intro\n![[recording.mp4]]\noutro',
+			});
+
+			const notePath = await insertProcessedAudioEmbed(
+				app,
+				source(),
+				'Audio/recording-clean.wav',
+				false,
+			);
+
+			expect(notePath).toBe('notes/daily.md');
+			expect(getContent()).toBe(
+				'intro\n![[recording.mp4]]\n![[recording-clean.wav]]\noutro',
+			);
+		});
+
+		it('returns null when the active note does not embed the source', async () => {
+			const { app, getContent } = buildEmbedApp({
+				embeds: [
+					{ link: 'other.mp4', original: '![[other.mp4]]' },
+				],
+				resolves: { 'other.mp4': 'Audio/other.mp4' },
+				content: 'intro\n![[other.mp4]]\noutro',
+			});
+
+			const notePath = await insertProcessedAudioEmbed(
+				app,
+				source(),
+				'Audio/recording-clean.wav',
+				true,
+			);
+
+			expect(notePath).toBeNull();
+			// The note body must stay untouched when no embed matched
+			expect(getContent()).toBe('intro\n![[other.mp4]]\noutro');
+		});
+
+		it('returns null when there is no active markdown note', async () => {
+			const { app } = buildEmbedApp({
+				noteActive: false,
+				content: '',
+			});
+
+			const notePath = await insertProcessedAudioEmbed(
+				app,
+				source(),
+				'Audio/recording-clean.wav',
+				true,
+			);
+
+			expect(notePath).toBeNull();
+		});
+
+		it('returns null when the active file is not a markdown note', async () => {
+			const { app } = buildEmbedApp({
+				noteExtension: 'canvas',
+				content: '',
+			});
+
+			const notePath = await insertProcessedAudioEmbed(
+				app,
+				source(),
+				'Audio/recording-clean.wav',
+				true,
 			);
 
 			expect(notePath).toBeNull();

--- a/tests/unit/Settings.test.ts
+++ b/tests/unit/Settings.test.ts
@@ -234,6 +234,7 @@ describe('Settings', () => {
 				transcriptionDiarize: true,
 				transcriptionWordTimestamps: true,
 				transcriptionChunkMb: 10,
+				transcriptionTimeoutMinutes: 15,
 				whisperApiBaseUrl: 'https://api.groq.com/openai/v1',
 				whisperApiKey: 'sk-test',
 				whisperApiModel: 'whisper-large-v3',

--- a/tests/unit/Settings.test.ts
+++ b/tests/unit/Settings.test.ts
@@ -9,6 +9,7 @@
 
 import {
 	AudioRecorderSettings,
+	AudioRecorderSettingsInput,
 	DEFAULT_SETTINGS,
 	mergeSettings,
 	mergeSettingsAsync,
@@ -260,11 +261,18 @@ describe('Settings', () => {
 				transcriptHeading: '# T',
 				llmPostProcessEnabled: true,
 				llmPostProcessTask: 'summary',
+				llmCleanupPrompt: 'cleanup base',
+				llmSummaryPrompt: 'summary base',
 				llmCustomInstruction: 'do it',
 				llmProvider: 'anthropic',
 				llmBaseUrl: 'https://api.anthropic.com/v1',
-				llmApiKey: 'ak-test',
-				llmModel: 'claude-opus-4-8',
+				anthropicApiKey: 'ak-test',
+				llmOpenAiModel: 'gpt-4o',
+				llmOpenAiModels: ['gpt-4o', 'gpt-4o-mini'],
+				llmAnthropicModel: 'claude-opus-4-8',
+				llmAnthropicModels: ['claude-opus-4-8', 'claude-sonnet-4-6'],
+				llmGeminiModel: 'gemini-2.5-flash',
+				llmGeminiModels: ['gemini-2.5-flash', 'gemini-2.5-pro'],
 				llmMaxTokens: 2048,
 				inputNoiseSuppression: false,
 				inputEchoCancellation: false,
@@ -291,6 +299,45 @@ describe('Settings', () => {
 			mergeSettings({ recordingFormat: 'wav' });
 
 			expect(DEFAULT_SETTINGS).toEqual(originalDefaults);
+		});
+
+		it('migrates a legacy llmApiKey/llmModel onto the Anthropic vendor fields', () => {
+			// Pre-rework data held one flat key and model for the stored provider.
+			const legacy = {
+				llmProvider: 'anthropic',
+				llmApiKey: 'ak-legacy',
+				llmModel: 'claude-legacy',
+			} as unknown as AudioRecorderSettingsInput;
+
+			const result = mergeSettings(legacy);
+
+			expect(result.anthropicApiKey).toBe('ak-legacy');
+			expect(result.llmAnthropicModel).toBe('claude-legacy');
+			// The superseded flat fields must not linger in the merged object.
+			const record = result as unknown as Record<string, unknown>;
+			expect(record.llmApiKey).toBeUndefined();
+			expect(record.llmModel).toBeUndefined();
+		});
+
+		it('maps a legacy OpenAI llmApiKey onto the shared Whisper/OpenAI key', () => {
+			const result = mergeSettings({
+				llmProvider: 'openai-compatible',
+				llmApiKey: 'sk-legacy',
+				llmModel: 'gpt-legacy',
+			} as unknown as AudioRecorderSettingsInput);
+
+			expect(result.whisperApiKey).toBe('sk-legacy');
+			expect(result.llmOpenAiModel).toBe('gpt-legacy');
+		});
+
+		it('does not overwrite a vendor key that is already set', () => {
+			const result = mergeSettings({
+				llmProvider: 'gemini',
+				geminiApiKey: 'gm-current',
+				llmApiKey: 'gm-legacy',
+			} as unknown as AudioRecorderSettingsInput);
+
+			expect(result.geminiApiKey).toBe('gm-current');
 		});
 
 		it('should handle boolean settings correctly', () => {

--- a/tests/unit/audioChunks.test.ts
+++ b/tests/unit/audioChunks.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Tests for splitChunkPlan: halving a chunk plan so a part that overran a
+ * provider's output token limit can be retried as smaller pieces. The split
+ * must tile the original span exactly (no gap or overlap at the midpoint) and
+ * must stop once the halves would fall below the minimum length.
+ * @module tests/unit/audioChunks.test
+ */
+
+import { splitChunkPlan, type ChunkPlan } from 'src/transcription/audioChunks';
+
+const MIN_SECONDS = 60;
+
+describe('splitChunkPlan', () => {
+	it('halves a chunk at its midpoint, tiling the span exactly', () => {
+		const chunk: ChunkPlan = { index: 1, startSeconds: 0, endSeconds: 900 };
+		const halves = splitChunkPlan(chunk, MIN_SECONDS);
+		expect(halves).toHaveLength(2);
+		expect(halves[0].startSeconds).toBe(0);
+		expect(halves[0].endSeconds).toBe(450);
+		// The second half starts exactly where the first ends: no gap, no overlap.
+		expect(halves[1].startSeconds).toBe(450);
+		expect(halves[1].endSeconds).toBe(900);
+	});
+
+	it('carries the offset so an inner part keeps its place on the timeline', () => {
+		const chunk: ChunkPlan = {
+			index: 0,
+			startSeconds: 600,
+			endSeconds: 1200,
+		};
+		const halves = splitChunkPlan(chunk, MIN_SECONDS);
+		expect(halves[0]).toMatchObject({ startSeconds: 600, endSeconds: 900 });
+		expect(halves[1]).toMatchObject({
+			startSeconds: 900,
+			endSeconds: 1200,
+		});
+	});
+
+	it('still splits a chunk exactly twice the minimum', () => {
+		const chunk: ChunkPlan = {
+			index: 0,
+			startSeconds: 0,
+			endSeconds: 2 * MIN_SECONDS,
+		};
+		expect(splitChunkPlan(chunk, MIN_SECONDS)).toHaveLength(2);
+	});
+
+	it('returns no halves once a chunk is below twice the minimum (the floor)', () => {
+		const chunk: ChunkPlan = {
+			index: 0,
+			startSeconds: 0,
+			endSeconds: 2 * MIN_SECONDS - 1,
+		};
+		expect(splitChunkPlan(chunk, MIN_SECONDS)).toEqual([]);
+	});
+});

--- a/tests/unit/geminiShared.test.ts
+++ b/tests/unit/geminiShared.test.ts
@@ -13,6 +13,7 @@ import {
 	geminiFinishReason,
 	geminiGenerateContentUrl,
 	geminiThinkingConfig,
+	geminiUsage,
 	GEMINI_FINISH_MAX_TOKENS,
 } from 'src/transcription/providers/geminiShared';
 
@@ -83,6 +84,82 @@ describe('assertGeminiNotTruncated', () => {
 			),
 		).not.toThrow();
 		expect(() => assertGeminiNotTruncated({}, REMEDY)).not.toThrow();
+	});
+
+	it('embeds the reported output and total token counts in the message', () => {
+		// The user needs to know how far the response ran before the cap.
+		expect(() =>
+			assertGeminiNotTruncated(
+				{
+					candidates: [{ finishReason: GEMINI_FINISH_MAX_TOKENS }],
+					usageMetadata: {
+						candidatesTokenCount: 65536,
+						totalTokenCount: 78000,
+					},
+				},
+				REMEDY,
+			),
+		).toThrow(/65536 output tokens, 78000 total/);
+	});
+
+	it('notes the thinking-token share when the model reports it', () => {
+		expect(() =>
+			assertGeminiNotTruncated(
+				{
+					candidates: [{ finishReason: GEMINI_FINISH_MAX_TOKENS }],
+					usageMetadata: {
+						candidatesTokenCount: 4096,
+						thoughtsTokenCount: 4000,
+						totalTokenCount: 9000,
+					},
+				},
+				REMEDY,
+			),
+		).toThrow(/4096 output tokens including 4000 on thinking/);
+	});
+
+	it('omits the usage parenthetical when no counts are reported', () => {
+		// A response without usageMetadata must still read as a clean sentence.
+		let message = '';
+		try {
+			assertGeminiNotTruncated(
+				{ candidates: [{ finishReason: GEMINI_FINISH_MAX_TOKENS }] },
+				REMEDY,
+			);
+		} catch (error) {
+			message = error instanceof Error ? error.message : String(error);
+		}
+		expect(message).toContain('output token limit, so the response');
+		expect(message).not.toContain('(');
+	});
+});
+
+describe('geminiUsage', () => {
+	it('reads the finite token counts from usageMetadata', () => {
+		expect(
+			geminiUsage({
+				usageMetadata: {
+					promptTokenCount: 10,
+					candidatesTokenCount: 20,
+					totalTokenCount: 30,
+					thoughtsTokenCount: 5,
+				},
+			}),
+		).toEqual({
+			promptTokenCount: 10,
+			candidatesTokenCount: 20,
+			totalTokenCount: 30,
+			thoughtsTokenCount: 5,
+		});
+	});
+
+	it('returns an empty object when usageMetadata is absent or malformed', () => {
+		expect(geminiUsage({})).toEqual({});
+		expect(geminiUsage(null)).toEqual({});
+		// A non-numeric count is dropped rather than coerced to a number.
+		expect(
+			geminiUsage({ usageMetadata: { candidatesTokenCount: 'lots' } }),
+		).toEqual({});
 	});
 });
 

--- a/tests/unit/geminiShared.test.ts
+++ b/tests/unit/geminiShared.test.ts
@@ -16,6 +16,7 @@ import {
 	geminiUsage,
 	GEMINI_FINISH_MAX_TOKENS,
 } from 'src/transcription/providers/geminiShared';
+import { TranscriptTruncatedError } from 'src/transcription/transcriptionErrors';
 
 describe('geminiCandidateText', () => {
 	it('concatenates the text parts of the first candidate without trimming', () => {
@@ -63,6 +64,17 @@ describe('assertGeminiNotTruncated', () => {
 				REMEDY,
 			),
 		).toThrow(/output token limit/i);
+	});
+
+	it('throws a TranscriptTruncatedError so callers can subdivide on it', () => {
+		// The transcription orchestrator branches on this exact type to retry a
+		// part as smaller pieces, so the thrown class is part of the contract.
+		expect(() =>
+			assertGeminiNotTruncated(
+				{ candidates: [{ finishReason: GEMINI_FINISH_MAX_TOKENS }] },
+				REMEDY,
+			),
+		).toThrow(TranscriptTruncatedError);
 	});
 
 	it('appends the caller-supplied remedy to the message', () => {

--- a/tests/unit/geminiShared.test.ts
+++ b/tests/unit/geminiShared.test.ts
@@ -127,7 +127,7 @@ describe('assertGeminiNotTruncated', () => {
 				},
 				REMEDY,
 			),
-		).toThrow(/4096 output tokens including 4000 on thinking/);
+		).toThrow(/4096 output tokens plus 4000 on thinking/);
 	});
 
 	it('omits the usage parenthetical when no counts are reported', () => {

--- a/tests/unit/httpClient.test.ts
+++ b/tests/unit/httpClient.test.ts
@@ -96,6 +96,13 @@ describe('uploadTimeoutMs', () => {
 		);
 	});
 
+	it('honors a caller-supplied cap below the default ceiling', () => {
+		// The user-configured per-request limit lowers the cap; a large payload
+		// that would otherwise scale higher is clamped to it.
+		const cap = 5 * 60_000;
+		expect(uploadTimeoutMs(8 * 1024 * 1024 * 1024, cap)).toBe(cap);
+	});
+
 	it('is monotonic in payload size', () => {
 		expect(uploadTimeoutMs(10 * 1024 * 1024)).toBeLessThanOrEqual(
 			uploadTimeoutMs(20 * 1024 * 1024),

--- a/tests/unit/llmProviderDefaults.test.ts
+++ b/tests/unit/llmProviderDefaults.test.ts
@@ -1,67 +1,65 @@
 /**
  * Tests for applyLlmProviderDefaults: switching the LLM provider should move
- * the base URL and model to the new provider's defaults when they are still
- * defaults, and must never clobber a custom endpoint or model the user typed.
+ * the base URL to the new provider's default when it is still a default, and
+ * must never clobber a custom endpoint the user typed. The model is no longer
+ * switched here — each provider keeps its own selected model.
  */
 
 import { applyLlmProviderDefaults, mergeSettings } from 'src/settings/Settings';
 import {
 	DEFAULT_LLM_OPENAI_BASE_URL,
-	DEFAULT_LLM_OPENAI_MODEL,
 	DEFAULT_LLM_ANTHROPIC_BASE_URL,
-	DEFAULT_LLM_ANTHROPIC_MODEL,
 	DEFAULT_LLM_GEMINI_BASE_URL,
-	DEFAULT_LLM_GEMINI_MODEL,
 } from 'src/constants';
 
 describe('applyLlmProviderDefaults', () => {
-	it('switches OpenAI defaults to Anthropic defaults when choosing Anthropic', () => {
+	it('switches the OpenAI base URL to Anthropic when choosing Anthropic', () => {
 		const settings = mergeSettings({
 			llmBaseUrl: DEFAULT_LLM_OPENAI_BASE_URL,
-			llmModel: DEFAULT_LLM_OPENAI_MODEL,
 		});
 		applyLlmProviderDefaults(settings, 'anthropic');
 		expect(settings.llmBaseUrl).toBe(DEFAULT_LLM_ANTHROPIC_BASE_URL);
-		expect(settings.llmModel).toBe(DEFAULT_LLM_ANTHROPIC_MODEL);
 	});
 
-	it('moves Anthropic defaults back to OpenAI defaults when choosing OpenAI-compatible', () => {
+	it('moves the Anthropic base URL back to OpenAI when choosing OpenAI', () => {
 		const settings = mergeSettings({
 			llmBaseUrl: DEFAULT_LLM_ANTHROPIC_BASE_URL,
-			llmModel: DEFAULT_LLM_ANTHROPIC_MODEL,
 		});
 		applyLlmProviderDefaults(settings, 'openai-compatible');
 		expect(settings.llmBaseUrl).toBe(DEFAULT_LLM_OPENAI_BASE_URL);
-		expect(settings.llmModel).toBe(DEFAULT_LLM_OPENAI_MODEL);
 	});
 
-	it('switches OpenAI defaults to Gemini defaults when choosing Gemini', () => {
+	it('switches the OpenAI base URL to Gemini when choosing Gemini', () => {
 		const settings = mergeSettings({
 			llmBaseUrl: DEFAULT_LLM_OPENAI_BASE_URL,
-			llmModel: DEFAULT_LLM_OPENAI_MODEL,
 		});
 		applyLlmProviderDefaults(settings, 'gemini');
 		expect(settings.llmBaseUrl).toBe(DEFAULT_LLM_GEMINI_BASE_URL);
-		expect(settings.llmModel).toBe(DEFAULT_LLM_GEMINI_MODEL);
 	});
 
-	it('moves Gemini defaults back to OpenAI defaults when choosing OpenAI-compatible', () => {
+	it('moves the Gemini base URL back to OpenAI when choosing OpenAI', () => {
 		const settings = mergeSettings({
 			llmBaseUrl: DEFAULT_LLM_GEMINI_BASE_URL,
-			llmModel: DEFAULT_LLM_GEMINI_MODEL,
 		});
 		applyLlmProviderDefaults(settings, 'openai-compatible');
 		expect(settings.llmBaseUrl).toBe(DEFAULT_LLM_OPENAI_BASE_URL);
-		expect(settings.llmModel).toBe(DEFAULT_LLM_OPENAI_MODEL);
 	});
 
-	it('preserves a custom base URL and model', () => {
+	it('preserves a custom base URL', () => {
 		const settings = mergeSettings({
 			llmBaseUrl: 'https://my-proxy.example/v1',
-			llmModel: 'my-custom-model',
 		});
 		applyLlmProviderDefaults(settings, 'anthropic');
 		expect(settings.llmBaseUrl).toBe('https://my-proxy.example/v1');
-		expect(settings.llmModel).toBe('my-custom-model');
+	});
+
+	it('leaves each provider model untouched (model is per-provider now)', () => {
+		const settings = mergeSettings({
+			llmOpenAiModel: 'gpt-custom',
+			llmAnthropicModel: 'claude-custom',
+		});
+		applyLlmProviderDefaults(settings, 'anthropic');
+		expect(settings.llmOpenAiModel).toBe('gpt-custom');
+		expect(settings.llmAnthropicModel).toBe('claude-custom');
 	});
 });

--- a/tests/unit/llmProviderOptions.test.ts
+++ b/tests/unit/llmProviderOptions.test.ts
@@ -40,7 +40,11 @@ describe('LLM provider options (single source of truth)', () => {
 		for (const option of LLM_PROVIDER_OPTIONS) {
 			const settings = mergeSettings({
 				llmProvider: option.value as LlmProviderId,
-				llmApiKey: 'test-key',
+				// Each provider reads its own vendor key (OpenAI reuses the
+				// Whisper key, Gemini its transcription key, Anthropic its own).
+				whisperApiKey: 'sk-test',
+				anthropicApiKey: 'ak-test',
+				geminiApiKey: 'gm-test',
 			});
 			expect(() => createLlmProvider(settings)).not.toThrow();
 		}

--- a/tests/unit/transcriptionCore.test.ts
+++ b/tests/unit/transcriptionCore.test.ts
@@ -143,6 +143,24 @@ describe('buildPostProcessPrompt', () => {
 		});
 		expect(prompt.system).toBe('Bullet it');
 	});
+
+	it('uses the provided cleanup template and appends the language', () => {
+		const prompt = buildPostProcessPrompt('t', {
+			task: 'cleanup',
+			language: 'es',
+			cleanupPrompt: 'MY CLEANUP BASE',
+		});
+		expect(prompt.system).toContain('MY CLEANUP BASE');
+		expect(prompt.system).toContain('es');
+	});
+
+	it('uses the provided summary template', () => {
+		const prompt = buildPostProcessPrompt('t', {
+			task: 'summary',
+			summaryPrompt: 'MY SUMMARY BASE',
+		});
+		expect(prompt.system).toContain('MY SUMMARY BASE');
+	});
 });
 
 describe('buildTranscriptFilePath', () => {
@@ -210,19 +228,54 @@ describe('provider factories', () => {
 		expect(provider.capabilities.supportsDiarization).toBe(true);
 	});
 
-	it('requires an Anthropic key but not an Ollama key', () => {
+	it('requires a key for every LLM provider', () => {
 		expect(() =>
 			createLlmProvider(
-				mergeSettings({ llmProvider: 'anthropic', llmApiKey: '' }),
+				mergeSettings({
+					llmProvider: 'anthropic',
+					anthropicApiKey: '',
+				}),
 			),
 		).toThrow(ProviderConfigError);
+		expect(() =>
+			createLlmProvider(
+				mergeSettings({ llmProvider: 'gemini', geminiApiKey: '' }),
+			),
+		).toThrow(ProviderConfigError);
+		expect(() =>
+			createLlmProvider(
+				mergeSettings({
+					llmProvider: 'openai-compatible',
+					whisperApiKey: '',
+				}),
+			),
+		).toThrow(ProviderConfigError);
+	});
+
+	it('builds each LLM provider from its shared vendor key', () => {
 		expect(
 			createLlmProvider(
 				mergeSettings({
 					llmProvider: 'openai-compatible',
-					llmApiKey: '',
+					whisperApiKey: 'sk-test',
 				}),
 			).id,
 		).toBe('openai-compatible');
+		expect(
+			createLlmProvider(
+				mergeSettings({
+					llmProvider: 'anthropic',
+					anthropicApiKey: 'ak-test',
+				}),
+			).id,
+		).toBe('anthropic');
+		expect(
+			createLlmProvider(
+				mergeSettings({
+					llmProvider: 'gemini',
+					geminiApiKey: 'gm-test',
+				}),
+			).id,
+		).toBe('gemini');
 	});
 });

--- a/tests/unit/transcriptionCore.test.ts
+++ b/tests/unit/transcriptionCore.test.ts
@@ -20,7 +20,11 @@ import {
 	ProviderConfigError,
 } from 'src/transcription/factories';
 import { mergeSettings } from 'src/settings/Settings';
-import { TRANSCRIBE_BYTES_PER_SEC } from 'src/constants';
+import {
+	TRANSCRIBE_BYTES_PER_SEC,
+	DEFAULT_LLM_CLEANUP_PROMPT,
+	DEFAULT_LLM_SUMMARY_PROMPT,
+} from 'src/constants';
 import { WAV_HEADER_SIZE } from 'src/recording/WavEncoder';
 
 describe('planChunks', () => {
@@ -160,6 +164,21 @@ describe('buildPostProcessPrompt', () => {
 			summaryPrompt: 'MY SUMMARY BASE',
 		});
 		expect(prompt.system).toContain('MY SUMMARY BASE');
+	});
+
+	it('falls back to the shipped default when a template is empty', () => {
+		// Clearing the field in settings leaves an empty string; the request must
+		// still carry a usable system prompt rather than sending none.
+		const cleanup = buildPostProcessPrompt('t', {
+			task: 'cleanup',
+			cleanupPrompt: '',
+		});
+		expect(cleanup.system).toContain(DEFAULT_LLM_CLEANUP_PROMPT);
+		const summary = buildPostProcessPrompt('t', {
+			task: 'summary',
+			summaryPrompt: '   ',
+		});
+		expect(summary.system).toContain(DEFAULT_LLM_SUMMARY_PROMPT);
 	});
 });
 

--- a/tests/unit/transcriptionServicePartFailure.test.ts
+++ b/tests/unit/transcriptionServicePartFailure.test.ts
@@ -19,6 +19,8 @@ import {
 } from 'src/transcription/TranscriptionService';
 import type { TranscriptionProvider } from 'src/transcription/providers/TranscriptionProvider';
 import { prepareAudio } from 'src/transcription/audioPrep';
+import { TranscriptTruncatedError } from 'src/transcription/transcriptionErrors';
+import type { LlmProvider } from 'src/transcription/llm/LlmProvider';
 import { mergeSettings } from 'src/settings/Settings';
 
 jest.mock('obsidian', () => {
@@ -77,6 +79,51 @@ function prepareTwoParts(): void {
 		],
 		diarizationSplitWarning: false,
 	});
+}
+
+/**
+ * One prepared part spanning 0..900s that, on demand, subdivides into two
+ * halves; each half declares it cannot split further (subdivide -> []), so a
+ * test can drive both the recovery path and the at-the-floor failure path.
+ */
+function prepareSubdividingPart(): void {
+	const half = (
+		offsetSeconds: number,
+		endSeconds: number,
+		filename: string,
+	) => ({
+		contentType: 'audio/wav',
+		filename,
+		offsetSeconds,
+		endSeconds,
+		createData: () => new ArrayBuffer(4),
+		subdivide: () => [],
+	});
+	mockPrepareAudio.mockResolvedValue({
+		payloads: [
+			{
+				contentType: 'audio/wav',
+				filename: 'audio.wav',
+				offsetSeconds: 0,
+				endSeconds: 900,
+				createData: () => new ArrayBuffer(4),
+				subdivide: () => [
+					half(0, 450, 'audio-0.wav'),
+					half(450, 900, 'audio-1.wav'),
+				],
+			},
+		],
+		diarizationSplitWarning: false,
+	});
+}
+
+/** A stub LLM provider whose cleanup output deliberately carries no callout. */
+function makeLlm(output: string): LlmProvider {
+	return {
+		id: 'fake-llm',
+		label: 'Fake LLM',
+		complete: jest.fn(async () => output),
+	};
 }
 
 function makeProvider(transcribe: jest.Mock): TranscriptionProvider {
@@ -161,5 +208,108 @@ describe('TranscriptionService multi-part salvage', () => {
 			}),
 		).rejects.toThrow(/first failed \(while transcribing part 1 of 2\)/);
 		expect(mockNotice).not.toHaveBeenCalled();
+	});
+
+	it('subdivides a truncated part and keeps both halves', async () => {
+		prepareSubdividingPart();
+		const transcribe = jest
+			.fn()
+			// The whole part overruns the output token cap...
+			.mockRejectedValueOnce(
+				new TranscriptTruncatedError(
+					'Gemini stopped because it reached its output token limit',
+				),
+			)
+			// ...so it is retried as two halves, both of which now fit.
+			.mockResolvedValueOnce({
+				segments: [{ start: 0, end: 1, text: 'first half' }],
+			})
+			.mockResolvedValueOnce({
+				segments: [{ start: 0, end: 1, text: 'second half' }],
+			});
+		const service = new TranscriptionService(
+			makeApp(),
+			() => mergeSettings(baseSettings),
+			{ createProvider: () => makeProvider(transcribe) },
+		);
+
+		const result = await service.run(audioFile, {
+			notePathForLinks: 'note.md',
+			token: NEVER_CANCELLED,
+		});
+
+		// One truncated attempt on the whole part plus the two halves.
+		expect(transcribe).toHaveBeenCalledTimes(3);
+		expect(result.transcript.segments.map((s) => s.text)).toEqual([
+			'first half',
+			'second half',
+		]);
+		// Both halves succeeded, so there is no gap to flag and no warning.
+		expect(result.markdown).not.toContain('Transcription incomplete');
+		expect(mockNotice).not.toHaveBeenCalled();
+	});
+
+	it('fails, naming the timeline span, when every subdivision still truncates', async () => {
+		prepareSubdividingPart();
+		const truncated = (): TranscriptTruncatedError =>
+			new TranscriptTruncatedError(
+				'Gemini stopped because it reached its output token limit',
+			);
+		const transcribe = jest
+			.fn()
+			.mockRejectedValueOnce(truncated()) // whole part
+			.mockRejectedValueOnce(truncated()) // first half (at the floor)
+			.mockRejectedValueOnce(truncated()); // second half (at the floor)
+		const service = new TranscriptionService(
+			makeApp(),
+			() => mergeSettings(baseSettings),
+			{ createProvider: () => makeProvider(transcribe) },
+		);
+
+		// Every leaf failed: nothing to keep, so the run surfaces the first
+		// failure named by the timeline span that could not be salvaged.
+		await expect(
+			service.run(audioFile, {
+				notePathForLinks: 'note.md',
+				token: NEVER_CANCELLED,
+			}),
+		).rejects.toThrow(
+			/output token limit \(while transcribing the .* segment\)/,
+		);
+		expect(transcribe).toHaveBeenCalledTimes(3);
+	});
+
+	it('keeps the incompleteness warning after LLM post-processing replaces the body', async () => {
+		const transcribe = jest
+			.fn()
+			.mockRejectedValueOnce(new Error('boom'))
+			.mockResolvedValueOnce({
+				segments: [{ start: 0, end: 1, text: 'good part' }],
+			});
+		const service = new TranscriptionService(
+			makeApp(),
+			() =>
+				mergeSettings({
+					...baseSettings,
+					llmPostProcessEnabled: true,
+					llmPostProcessTask: 'cleanup',
+				}),
+			{
+				createProvider: () => makeProvider(transcribe),
+				// Cleanup replaces the whole body and drops any callout it was
+				// handed, so the gap warning must be re-applied after it returns.
+				createLlm: () => makeLlm('LLM CLEANED OUTPUT'),
+			},
+		);
+
+		const result = await service.run(audioFile, {
+			notePathForLinks: 'note.md',
+			token: NEVER_CANCELLED,
+		});
+
+		// The cleaned body is used, and the gap warning still survives above it.
+		expect(result.markdown).toContain('LLM CLEANED OUTPUT');
+		expect(result.markdown).toContain('Transcription incomplete');
+		expect(result.markdown).toContain('part 1 of 2');
 	});
 });

--- a/tests/unit/transcriptionServicePartFailure.test.ts
+++ b/tests/unit/transcriptionServicePartFailure.test.ts
@@ -1,0 +1,165 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Tests that a multi-part transcription keeps the parts that succeeded when a
+ * later part fails (e.g. a Gemini MAX_TOKENS truncation), instead of discarding
+ * a completed — and, on a paid API, already-billed — transcript. The note flags
+ * the gap, the user is warned, and only when every part fails does the run
+ * surface an error.
+ * @module tests/unit/transcriptionServicePartFailure.test
+ */
+
+import type { App, TFile } from 'obsidian';
+import { Notice } from 'obsidian';
+import {
+	NEVER_CANCELLED,
+	TranscriptionService,
+} from 'src/transcription/TranscriptionService';
+import type { TranscriptionProvider } from 'src/transcription/providers/TranscriptionProvider';
+import { prepareAudio } from 'src/transcription/audioPrep';
+import { mergeSettings } from 'src/settings/Settings';
+
+jest.mock('obsidian', () => {
+	const actual = jest.requireActual('../mocks/obsidian');
+	return { ...actual, Notice: jest.fn() };
+});
+
+// Replace audio preparation so the test drives the part count directly without
+// decoding real audio (the Web Audio path is unavailable under jsdom).
+jest.mock('src/transcription/audioPrep', () => ({
+	prepareAudio: jest.fn(),
+	audioMimeFromExtension: jest.fn(() => 'audio/webm'),
+	audioPrepOptions: jest.fn(() => ({})),
+}));
+
+const mockPrepareAudio = prepareAudio as jest.Mock;
+const mockNotice = Notice as unknown as jest.Mock;
+
+const audioFile = {
+	name: 'rec.webm',
+	extension: 'webm',
+	path: 'rec.webm',
+} as unknown as TFile;
+
+/** Minimal App with just the surface the transcription pipeline touches. */
+function makeApp(): App {
+	return {
+		vault: {
+			readBinary: jest.fn(async () => new ArrayBuffer(4)),
+			create: jest.fn(),
+			adapter: { exists: jest.fn(async () => false) },
+		},
+		fileManager: {
+			generateMarkdownLink: jest.fn(() => '[[rec#t=0|0:00]]'),
+		},
+		workspace: { getLeavesOfType: jest.fn(() => []) },
+	} as unknown as App;
+}
+
+/** Two prepared parts on the timeline (0s and 60s), each a tiny WAV payload. */
+function prepareTwoParts(): void {
+	mockPrepareAudio.mockResolvedValue({
+		payloads: [
+			{
+				contentType: 'audio/wav',
+				filename: 'audio-0.wav',
+				offsetSeconds: 0,
+				createData: () => new ArrayBuffer(4),
+			},
+			{
+				contentType: 'audio/wav',
+				filename: 'audio-1.wav',
+				offsetSeconds: 60,
+				createData: () => new ArrayBuffer(4),
+			},
+		],
+		diarizationSplitWarning: false,
+	});
+}
+
+function makeProvider(transcribe: jest.Mock): TranscriptionProvider {
+	return {
+		id: 'fake',
+		label: 'Fake',
+		requiresNetwork: false,
+		capabilities: {
+			maxRequestBytes: Number.POSITIVE_INFINITY,
+			maxRequestSeconds: Number.POSITIVE_INFINITY,
+			acceptsOriginalContainer: true,
+			supportsDiarization: false,
+		},
+		transcribe,
+	};
+}
+
+const baseSettings = {
+	transcriptionProvider: 'gemini' as const,
+	geminiApiKey: 'gm-test',
+};
+
+describe('TranscriptionService multi-part salvage', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		prepareTwoParts();
+	});
+
+	it('keeps the successful part when a later part hits the token limit', async () => {
+		const transcribe = jest
+			.fn()
+			.mockResolvedValueOnce({
+				segments: [{ start: 0, end: 1, text: 'part one' }],
+			})
+			.mockRejectedValueOnce(
+				new Error(
+					'Gemini stopped because it reached its output token limit',
+				),
+			);
+		const service = new TranscriptionService(
+			makeApp(),
+			() => mergeSettings(baseSettings),
+			{ createProvider: () => makeProvider(transcribe) },
+		);
+
+		const result = await service.run(audioFile, {
+			notePathForLinks: 'note.md',
+			token: NEVER_CANCELLED,
+		});
+
+		expect(transcribe).toHaveBeenCalledTimes(2);
+		// The completed part survives rather than being discarded.
+		expect(result.transcript.segments.map((s) => s.text)).toEqual([
+			'part one',
+		]);
+		// The note flags the gap so a partial transcript is not read as whole.
+		expect(result.markdown).toContain('Transcription incomplete');
+		expect(result.markdown).toContain('part 2 of 2');
+		expect(result.markdown).toContain('part one');
+		// The user is warned, carrying the underlying provider message.
+		expect(mockNotice).toHaveBeenCalledTimes(1);
+		expect(mockNotice).toHaveBeenCalledWith(
+			expect.stringContaining('output token limit'),
+		);
+	});
+
+	it('throws only when every part fails, naming the first failure', async () => {
+		const transcribe = jest
+			.fn()
+			.mockRejectedValueOnce(new Error('first failed'))
+			.mockRejectedValueOnce(new Error('second failed'));
+		const service = new TranscriptionService(
+			makeApp(),
+			() => mergeSettings(baseSettings),
+			{ createProvider: () => makeProvider(transcribe) },
+		);
+
+		await expect(
+			service.run(audioFile, {
+				notePathForLinks: 'note.md',
+				token: NEVER_CANCELLED,
+			}),
+		).rejects.toThrow(/first failed \(while transcribing part 1 of 2\)/);
+		expect(mockNotice).not.toHaveBeenCalled();
+	});
+});

--- a/tests/unit/transcriptionServicePartFailure.test.ts
+++ b/tests/unit/transcriptionServicePartFailure.test.ts
@@ -82,6 +82,33 @@ function prepareTwoParts(): void {
 }
 
 /**
+ * Two prepared parts that carry their timeline spans (endSeconds), exactly as
+ * the decode path stamps them, so a salvage label reads as a time range rather
+ * than the "part N of M" fallback the span-less payloads above produce.
+ */
+function prepareTwoPartsWithSpans(): void {
+	mockPrepareAudio.mockResolvedValue({
+		payloads: [
+			{
+				contentType: 'audio/wav',
+				filename: 'audio-0.wav',
+				offsetSeconds: 0,
+				endSeconds: 450,
+				createData: () => new ArrayBuffer(4),
+			},
+			{
+				contentType: 'audio/wav',
+				filename: 'audio-1.wav',
+				offsetSeconds: 450,
+				endSeconds: 900,
+				createData: () => new ArrayBuffer(4),
+			},
+		],
+		diarizationSplitWarning: false,
+	});
+}
+
+/**
  * One prepared part spanning 0..900s that, on demand, subdivides into two
  * halves; each half declares it cannot split further (subdivide -> []), so a
  * test can drive both the recovery path and the at-the-floor failure path.
@@ -311,5 +338,34 @@ describe('TranscriptionService multi-part salvage', () => {
 		expect(result.markdown).toContain('LLM CLEANED OUTPUT');
 		expect(result.markdown).toContain('Transcription incomplete');
 		expect(result.markdown).toContain('part 1 of 2');
+	});
+
+	it('labels a salvaged part by its timeline span when the span is known', async () => {
+		// The decode path stamps endSeconds on every part, so in production the
+		// salvage label is a time range, never the ordinal fallback. Exercise
+		// that path so the wording the user actually sees is covered.
+		prepareTwoPartsWithSpans();
+		const transcribe = jest
+			.fn()
+			.mockResolvedValueOnce({
+				segments: [{ start: 0, end: 1, text: 'first part' }],
+			})
+			.mockRejectedValueOnce(new Error('boom'));
+		const service = new TranscriptionService(
+			makeApp(),
+			() => mergeSettings(baseSettings),
+			{ createProvider: () => makeProvider(transcribe) },
+		);
+
+		const result = await service.run(audioFile, {
+			notePathForLinks: 'note.md',
+			token: NEVER_CANCELLED,
+		});
+
+		expect(result.markdown).toContain('the 7:30–15:00 segment');
+		expect(result.markdown).not.toContain('part 2 of 2');
+		expect(mockNotice).toHaveBeenCalledWith(
+			expect.stringContaining('the 7:30–15:00 segment'),
+		);
 	});
 });


### PR DESCRIPTION
## Summary

Reworks **LLM post-processing** settings and bundles several related transcription/cleanup/player improvements landed on this branch: per-vendor API keys and a model picker, a salvage path for partial transcriptions, adaptive subdivision on token-limit overruns, an mp4 zero-duration player fix, a configurable per-request timeout with an elapsed-time counter, segmented in-memory audio cleanup for long recordings, and linking the processed file back into the note with immediate enhanced-player rendering.

## LLM post-processing rework

- **Three separate providers.** The single `OpenAI / Groq / Ollama` item is split into **OpenAI**, **Anthropic (Claude)**, and **Google Gemini**. Grok and Ollama are dropped; OpenAI now requires a key.
- **Shared per-vendor API keys.** OpenAI LLM reuses the Whisper API key and Gemini LLM reuses the Gemini transcription key, so a vendor token is entered once; Anthropic keeps its own `anthropicApiKey`. The standalone `llmApiKey` is removed. `whisperApiKey` is intentionally not renamed (the Whisper API engine is OpenAI-compatible).
- **Model picker for the LLM model.** The free-text field is replaced by the managed picker used for transcription models (saved per-provider list + add/remove + docs link). `llmModel` is removed; `applyLlmProviderDefaults` now switches only the base URL.
- **Editable prompts.** Cleanup and summary prompts are editable (defaults in constants, transcript-language clause still appended automatically); leaving one empty falls back to the shipped default. The custom instruction gets a larger, full-width editor via a new `addTextArea` control.
- **Migration.** `mergeSettings` carries forward legacy `llmApiKey`/`llmModel` onto the new per-vendor fields without overwriting a key already set.

## Transcription robustness

- **Partial-transcription salvage.** When some parts of a multi-part job succeed and a later part fails (e.g. a Gemini `MAX_TOKENS` truncation), the completed (and, on a paid API, already-billed) parts are kept with a `> [!warning]` callout and a Notice instead of discarding the whole run; the run errors only when every part fails. The callout is re-applied after LLM post-processing so a cleanup/custom pass cannot strip it.
- **Adaptive subdivision.** A part that overruns the provider's output-token budget is retried as smaller pieces via `TranscriptTruncatedError`, recovering a dense stretch rather than losing it, down to a minimum length.
- **Configurable per-request timeout.** A new **Request timeout** setting (default 10 min, 1-60) caps every network transcription request — threaded through Whisper API, Deepgram, and Gemini (generate + File API upload). The configured value overrides even the Gemini inference floor, so a stalled request fails that part instead of hanging the run.
- **Elapsed-time counter.** The transcription dialog shows a live elapsed timer that survives minimize/restore.

## Audio cleanup

- **Segmented in-memory processing.** Cleanup now gates and renders the signal one time segment at a time (with a discarded warm-up lead-in longer than the compressor release, so segment boundaries leave no click or level jump), writing each segment straight into the output WAV. Peak memory is bounded by the decoded input plus the WAV output regardless of length, so the decoded-sample guard is raised 128M -> 256M (~45 min stereo) and such recordings clean up in memory without the old "split into parts first" detour.

## Note linking & player priming

- **Processed files land back in the note.** After a cleanup or conversion run, the resulting file is linked into the active note the same way a fresh recording is: the source embed is replaced when the source is being deleted (so no broken link is left behind), or the new embed is inserted on the line right after it when the source is kept. The insert matches the source embed by its exact original text and edits the note atomically via `vault.process`, so a stale cursor cannot misplace it; when the active note does not embed the source (e.g. cleanup invoked from the file explorer) nothing is inserted.
- **Immediate enhanced player.** The processed file is primed for the enhanced player, so a cleaned `.wav` or a converted file renders with the waveform UI right away instead of showing Obsidian's default player until the note is reopened.

## Player

- **mp4 zero-duration fix.** Some plugin-produced multitrack mp4 files load with a finite-but-zero duration; the player now probes for the true length in that case too, so the timeline is no longer stuck at 0:00.

## Tests & docs

- Updated/added unit tests across settings/migration, provider factories, timeout caps, prompt templates, part-failure salvage, chunk subdivision, the segmented cleanup pipeline, and the new processed-file note insertion (replace/insert-after/no-match cases).
- WebAudio is mocked in jest, so cleanup tests cover orchestration (segment count, output length, guards); audio fidelity at segment boundaries should be confirmed by listening.
- Updated the README LLM post-processing, request-timeout, and progress sections, and `docs/audio-cleanup.md` for the in-memory processing change.

```bash
anatolk@dev:~/obsidian-advanced-audio-recorder$ npm run lint && npm run build && npx jest --no-coverage
Test Suites: 90 passed, 90 total
Tests:       1339 passed, 1339 total
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
