### PR TITLE
Per-embed independent playback for distinct audio embeds

### DIFF
--- a/src/player/AudioPlayer.ts
+++ b/src/player/AudioPlayer.ts
@@ -40,6 +40,7 @@ import {
 	WaveformPeakCache,
 	type AudioDecoder,
 } from './WaveformData';
+import { playbackKey } from './AudioPlayerRegistry';
 import type {
 	AudioPlayerRegistry,
 	SeekablePlayer,
@@ -113,15 +114,24 @@ export interface AudioPlayerOptions {
  * Renders and drives a single enhanced audio player instance.
  */
 export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
-	/** Shared per-file audio element, acquired from the registry on render so
-	 * every view mode controls the same playback. */
+	/** Shared audio element for this embed's playback key, acquired from the
+	 * registry on render so the same embed across view modes controls one
+	 * playback while distinct embeds of the file stay independent. */
 	private audio!: HTMLAudioElement;
 	/**
+	 * Identity key of this embed's shared audio element: the file path plus
+	 * the #t= start (see playbackKey). Distinct embeds of one file get
+	 * different keys and so independent playback; the same embed re-created
+	 * across a view-mode switch re-acquires its element under this key.
+	 */
+	private readonly audioKey: string;
+	/**
 	 * The #t= start position to show for THIS embed until its playback engages.
-	 * The audio element is shared per file, so moving its currentTime would drag
-	 * every other embed of the same file; instead each embed shows its own start
-	 * here (display only) and seeks the shared element to it just-in-time when
-	 * the user plays or skips this embed. Null when the embed has no #t= offset.
+	 * The audio element can be shared with the same embed in another view/pane,
+	 * so moving its currentTime eagerly would drag that copy; instead the embed
+	 * shows its start here (display only) and seeks the shared element to it
+	 * just-in-time when the user plays or skips this embed. Null when the embed
+	 * has no #t= offset.
 	 */
 	private startHint: number | null = null;
 	private playButton!: HTMLElement;
@@ -192,6 +202,7 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 		private readonly options: AudioPlayerOptions,
 	) {
 		super(containerEl);
+		this.audioKey = playbackKey(file.path, options.startSeconds);
 	}
 
 	/**
@@ -345,11 +356,12 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 			this.runRenderCleanups();
 		});
 
-		// Bind to the file's shared audio element so every view mode controls
-		// the same playback; the registry releases it once the last player
-		// unloads
+		// Bind to this embed's shared audio element (keyed by file path plus
+		// #t= start) so the same embed across view modes controls one playback
+		// while other embeds of the file stay independent; the registry
+		// releases it once the last player unloads
 		const { audio, isNew } = this.registry.acquireAudio(
-			this.file.path,
+			this.audioKey,
 			this.app.vault.getResourcePath(this.file),
 		);
 		this.audio = audio;
@@ -361,7 +373,7 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 			this.audio.playbackRate = PLAYER_PLAYBACK_RATE;
 		}
 		this.register(() => {
-			this.registry.releaseAudio(this.file.path);
+			this.registry.releaseAudio(this.audioKey);
 		});
 
 		this.registerAudioEvents();
@@ -963,8 +975,9 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 			this.updateProgress();
 		});
 		this.registerDomEvent(this.audio, 'play', () => {
-			// Any play (this embed or another) makes the timeline live, so a
-			// per-embed #t= start hint must not reappear afterwards
+			// Any play (this player or the same embed in another view/pane)
+			// makes the timeline live, so the #t= start hint must not
+			// reappear afterwards
 			this.engageTimeline();
 			setIcon(this.playButton, 'pause');
 		});
@@ -1035,17 +1048,17 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 	}
 
 	/**
-	 * The position to display for this embed: its #t= start hint while the
+	 * The position to display for this embed: its #t= start hint while its
 	 * shared audio is still untouched (at the very start, paused), otherwise the
-	 * real shared playback position. This is what lets two embeds of one file
-	 * show different start positions even though they share one audio element.
+	 * real playback position. The hint keeps the displayed start correct even
+	 * though the element itself is not moved until the user engages this embed.
 	 */
 	private currentPosition(): number {
 		if (
 			this.startHint !== null &&
 			this.audio.currentTime === 0 &&
 			this.audio.paused &&
-			!this.registry.isAudioEngaged(this.file.path)
+			!this.registry.isAudioEngaged(this.audioKey)
 		) {
 			return Number.isFinite(this.audio.duration)
 				? Math.min(this.startHint, this.audio.duration)
@@ -1074,14 +1087,15 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 	}
 
 	/**
-	 * Records that the user has engaged this file's shared playback (played or
-	 * sought it). Consumes this embed's #t= start hint and marks the shared
-	 * timeline engaged in the registry, so the hint never reappears on any
-	 * embed of the file - even after playback later returns to 0.
+	 * Records that the user has engaged this embed's shared playback (played or
+	 * sought it). Consumes the #t= start hint and marks the timeline engaged in
+	 * the registry, so the hint never reappears on this embed (or its copy in
+	 * another view/pane) - even after playback later returns to 0. Other embeds
+	 * of the same file have their own playback and keep their own hints.
 	 */
 	private engageTimeline(): void {
 		this.startHint = null;
-		this.registry.markAudioEngaged(this.file.path);
+		this.registry.markAudioEngaged(this.audioKey);
 	}
 
 	/**

--- a/src/player/AudioPlayerRegistry.ts
+++ b/src/player/AudioPlayerRegistry.ts
@@ -1,15 +1,43 @@
 /**
- * Registry of live enhanced audio players, keyed by the vault path of
- * the file they play. Timecode links use it to seek an already-rendered
- * player instead of opening a fresh one, and a settings change uses it to
- * re-apply the player layout in place (no view re-render).
+ * Registry of live enhanced audio players. Player registrations are keyed
+ * by the vault path of the file they play (timecode links use them to seek
+ * an already-rendered player, marker edits to sync the other views, and a
+ * settings change to re-apply the player layout in place). The shared audio
+ * elements are keyed more finely, by playback key (path + #t= start), so
+ * distinct embeds of one file play independently while the same embed keeps
+ * its playback across a view-mode switch.
  * @module player/AudioPlayerRegistry
  */
 
 import { SHARED_AUDIO_GRACE_MS } from '../constants';
 import type { ResolvedPlayerSettings } from '../player/playerSettings';
 
-/** A reference-counted audio element shared by every player of one file. */
+/**
+ * Separates the path from the #t= start inside a playback key. U+0000 cannot
+ * appear in a vault path, so a file whose name spells out the suffix (e.g.
+ * "rec.wav#t=3") can never collide with a real #t= embed key.
+ */
+const PLAYBACK_KEY_SEPARATOR = '\u0000';
+
+/**
+ * Builds the identity key a player's shared audio element is stored under:
+ * the file path plus the embed's parsed #t= start. Distinct embeds of one
+ * file (a plain embed and a #t= embed, or two different #t= offsets) get
+ * different keys and therefore independent playback, while the same embed
+ * re-created across a view-mode switch or an in-place re-render maps to the
+ * same key and so keeps its element (and running playback). Byte-identical
+ * embeds share a key by design: without a stable source position they are
+ * indistinguishable from the same embed re-rendered, and keeping them on one
+ * element is what preserves cross-view continuity.
+ * @param path - Vault-relative path of the audio file
+ * @param startSeconds - Parsed #t= start of the embed, or null when absent
+ */
+export function playbackKey(path: string, startSeconds: number | null): string {
+	return `${path}${PLAYBACK_KEY_SEPARATOR}t=${startSeconds === null ? '' : String(startSeconds)}`;
+}
+
+/** A reference-counted audio element shared by every player of one
+ * playback key (the same embed shown in several views/panes). */
 interface SharedAudio {
 	audio: HTMLAudioElement;
 	/** Number of live players currently bound to this element. */
@@ -20,9 +48,10 @@ interface SharedAudio {
 	resumeOnReacquire: boolean;
 	/**
 	 * Whether the user has engaged this playback (played or sought it). Once
-	 * engaged, a per-embed #t= start hint is no longer meaningful and must not
-	 * reappear, so it is tracked here (shared across every embed of the file)
-	 * rather than per player.
+	 * engaged, the embed's #t= start hint is no longer meaningful and must not
+	 * reappear, so it is tracked here (shared across every player of the same
+	 * playback key, e.g. the same embed in another pane) rather than per
+	 * player instance.
 	 */
 	engaged: boolean;
 }
@@ -49,26 +78,28 @@ export interface SeekablePlayer {
  */
 export class AudioPlayerRegistry {
 	private readonly playersByPath = new Map<string, Set<SeekablePlayer>>();
-	/** One shared audio element per file path, so every view mode controls
-	 * the same playback (a player in Reading view and one in Live Preview are
-	 * never independent). */
-	private readonly audioByPath = new Map<string, SharedAudio>();
+	/** One shared audio element per playback key (see playbackKey), so the
+	 * same embed across view modes controls one playback while distinct
+	 * embeds of the same file stay independent. */
+	private readonly audioByKey = new Map<string, SharedAudio>();
 
 	/**
-	 * Returns the shared audio element for a file, creating it on first use.
-	 * Every player for the same path gets the SAME element, so playing,
-	 * pausing or seeking from any view mode affects the one playback. A
-	 * re-acquire during the release grace period cancels the release and
-	 * resumes playback if it was running, making a mode switch seamless.
-	 * @param path - Vault-relative path of the file
+	 * Returns the shared audio element for a playback key, creating it on
+	 * first use. Every player for the same key (the same embed across view
+	 * modes/panes) gets the SAME element, so playing, pausing or seeking it
+	 * anywhere affects that one playback - while a different embed of the
+	 * same file has a different key and is untouched. A re-acquire during
+	 * the release grace period cancels the release and resumes playback if
+	 * it was running, making a mode switch seamless.
+	 * @param key - Playback key of the embed (see playbackKey)
 	 * @param src - Resource URL to play (used only when creating)
 	 * @returns The shared element and whether it was just created
 	 */
 	acquireAudio(
-		path: string,
+		key: string,
 		src: string,
 	): { audio: HTMLAudioElement; isNew: boolean } {
-		const existing = this.audioByPath.get(path);
+		const existing = this.audioByKey.get(key);
 		if (existing) {
 			if (existing.releaseTimer !== 0) {
 				window.clearTimeout(existing.releaseTimer);
@@ -86,7 +117,7 @@ export class AudioPlayerRegistry {
 		const audio = new Audio();
 		audio.preload = 'metadata';
 		audio.src = src;
-		this.audioByPath.set(path, {
+		this.audioByKey.set(key, {
 			audio,
 			refs: 1,
 			releaseTimer: 0,
@@ -97,14 +128,14 @@ export class AudioPlayerRegistry {
 	}
 
 	/**
-	 * Releases one player's hold on a file's shared audio. When the last
+	 * Releases one player's hold on its embed's shared audio. When the last
 	 * player lets go, playback is paused immediately (so no audio outlives a
 	 * closed note) but the element is kept for a short grace period, so a
 	 * view-mode switch can re-acquire and resume it instead of restarting.
-	 * @param path - Vault-relative path the audio was acquired under
+	 * @param key - Playback key the audio was acquired under
 	 */
-	releaseAudio(path: string): void {
-		const entry = this.audioByPath.get(path);
+	releaseAudio(key: string): void {
+		const entry = this.audioByKey.get(key);
 		if (!entry) {
 			return;
 		}
@@ -117,7 +148,7 @@ export class AudioPlayerRegistry {
 		entry.releaseTimer = window.setTimeout(() => {
 			entry.audio.removeAttribute('src');
 			entry.audio.load();
-			this.audioByPath.delete(path);
+			this.audioByKey.delete(key);
 		}, SHARED_AUDIO_GRACE_MS);
 	}
 
@@ -153,12 +184,17 @@ export class AudioPlayerRegistry {
 	}
 
 	/**
-	 * Seeks every connected player for a path to the given offset.
-	 * Disconnected players are pruned in passing so a closed view never
-	 * holds a stale registration.
+	 * Seeks the FIRST connected player for a path to the given offset.
+	 * Players of one file drive independent playback elements (one per
+	 * embed), so seeking every player would start several overlapping
+	 * playbacks from a single timecode click; only one is targeted
+	 * (registration order, which follows document order). The same embed
+	 * shown in another view mode shares that player's element, so it stays
+	 * in sync anyway. Disconnected players are pruned in passing so a
+	 * closed view never holds a stale registration.
 	 * @param path - Vault-relative path of the target file
 	 * @param seconds - Offset in seconds to seek to
-	 * @returns True when at least one connected player was seeked
+	 * @returns True when a connected player was seeked
 	 */
 	seek(path: string, seconds: number): boolean {
 		const players = this.playersByPath.get(path);
@@ -171,8 +207,10 @@ export class AudioPlayerRegistry {
 				players.delete(player);
 				continue;
 			}
-			player.seekTo(seconds);
-			seeked = true;
+			if (!seeked) {
+				player.seekTo(seconds);
+				seeked = true;
+			}
 		}
 		if (players.size === 0) {
 			this.playersByPath.delete(path);
@@ -227,27 +265,28 @@ export class AudioPlayerRegistry {
 	}
 
 	/**
-	 * Marks a file's shared playback as engaged: the user has played or sought
-	 * it, so a per-embed #t= start hint is no longer meaningful and must not
+	 * Marks an embed's shared playback as engaged: the user has played or
+	 * sought it, so its #t= start hint is no longer meaningful and must not
 	 * reappear (e.g. when playback later returns to 0). Shared across every
-	 * embed of the file, so engaging from one clears the hint on all of them.
-	 * @param path - Vault-relative path of the file
+	 * player of the same playback key (the same embed in another view/pane),
+	 * while a different embed of the file keeps its own hint.
+	 * @param key - Playback key of the embed (see playbackKey)
 	 */
-	markAudioEngaged(path: string): void {
-		const entry = this.audioByPath.get(path);
+	markAudioEngaged(key: string): void {
+		const entry = this.audioByKey.get(key);
 		if (entry) {
 			entry.engaged = true;
 		}
 	}
 
 	/**
-	 * Whether a file's shared playback has been engaged (played or sought).
-	 * Defaults to false for an unknown path or a freshly created element, so a
-	 * #t= embed shows its start until the timeline actually moves.
-	 * @param path - Vault-relative path of the file
+	 * Whether an embed's shared playback has been engaged (played or sought).
+	 * Defaults to false for an unknown key or a freshly created element, so a
+	 * #t= embed shows its start until its timeline actually moves.
+	 * @param key - Playback key of the embed (see playbackKey)
 	 */
-	isAudioEngaged(path: string): boolean {
-		return this.audioByPath.get(path)?.engaged ?? false;
+	isAudioEngaged(key: string): boolean {
+		return this.audioByKey.get(key)?.engaged ?? false;
 	}
 
 	/**
@@ -255,7 +294,7 @@ export class AudioPlayerRegistry {
 	 * feature is torn down.
 	 */
 	clear(): void {
-		for (const entry of this.audioByPath.values()) {
+		for (const entry of this.audioByKey.values()) {
 			if (entry.releaseTimer !== 0) {
 				window.clearTimeout(entry.releaseTimer);
 			}
@@ -263,7 +302,7 @@ export class AudioPlayerRegistry {
 			entry.audio.removeAttribute('src');
 			entry.audio.load();
 		}
-		this.audioByPath.clear();
+		this.audioByKey.clear();
 		this.playersByPath.clear();
 	}
 }

--- a/tests/integration/AudioPlayer.regression.test.ts
+++ b/tests/integration/AudioPlayer.regression.test.ts
@@ -13,8 +13,11 @@
  * They also cover the waveform decision (drawn progressively for files up to a
  * high safety ceiling; the plain seekable bar is used for pathological files
  * beyond it), the render-scoped teardown that keeps in-place re-renders from
- * accumulating observers, and the seekTo autoplay contract (timecode links
- * play; in-player jumps preserve the play/pause state).
+ * accumulating observers, the seekTo autoplay contract (timecode links play;
+ * in-player jumps preserve the play/pause state), and per-embed playback
+ * independence: distinct embeds of one file (plain vs #t=) drive independent
+ * audio elements, so playing or seeking one never moves the other (issue #38),
+ * while marker registrations stay per file so marker edits sync across embeds.
  */
 
 import { App, Modal } from 'obsidian';
@@ -80,17 +83,30 @@ function makeFakeAudio(): FakeAudio {
 	return audio;
 }
 
-/** A registry that hands out one shared audio: first acquire is "new". */
-function makeRegistry(audio: FakeAudio): AudioPlayerRegistry {
-	let created = false;
-	// Faithfully track the shared engaged flag so #t= hint tests exercise the
-	// real cross-embed behavior (engaging via one embed clears the hint on all)
-	let engaged = false;
+/**
+ * A key-aware registry stand-in that mirrors the real acquire semantics:
+ * each distinct playback key (file path + #t= start) gets its own audio
+ * element and its own engaged flag, and re-acquiring a known key returns
+ * the same element with isNew=false. New keys consume the provided fakes
+ * in acquisition order, then fall back to fresh ones - so a test that
+ * mounts several distinct embeds controls each element it asserts on.
+ */
+function makeRegistry(...audios: FakeAudio[]): AudioPlayerRegistry {
+	const entries = new Map<string, { audio: FakeAudio; engaged: boolean }>();
+	let nextAudio = 0;
 	const registry = {
-		acquireAudio: jest.fn(() => {
-			const isNew = !created;
-			created = true;
-			return { audio: audio as unknown as HTMLAudioElement, isNew };
+		acquireAudio: jest.fn((key: string) => {
+			const existing = entries.get(key);
+			if (existing) {
+				return {
+					audio: existing.audio as unknown as HTMLAudioElement,
+					isNew: false,
+				};
+			}
+			const audio = audios[nextAudio] ?? makeFakeAudio();
+			nextAudio += 1;
+			entries.set(key, { audio, engaged: false });
+			return { audio: audio as unknown as HTMLAudioElement, isNew: true };
 		}),
 		releaseAudio: jest.fn(),
 		register: jest.fn(),
@@ -99,12 +115,17 @@ function makeRegistry(audio: FakeAudio): AudioPlayerRegistry {
 		seek: jest.fn(),
 		applySettings: jest.fn(),
 		clear: jest.fn(),
-		markAudioEngaged: jest.fn(() => {
-			engaged = true;
+		markAudioEngaged: jest.fn((key: string) => {
+			const entry = entries.get(key);
+			if (entry) {
+				entry.engaged = true;
+			}
 		}),
-		isAudioEngaged: jest.fn(() => engaged),
+		isAudioEngaged: jest.fn(
+			(key: string) => entries.get(key)?.engaged ?? false,
+		),
 	};
-	return registry as AudioPlayerRegistry;
+	return registry;
 }
 
 const app = {
@@ -403,13 +424,16 @@ describe('timecode start offset (#t=) positions and shows the embed', () => {
 	});
 
 	it('keeps a plain embed at 0:00 while a same-file #t= embed shows its offset', () => {
-		// Two distinct embeds of ONE file share a single audio element (so one
-		// playback is controllable across view modes). The #t= start must stay
-		// per-embed: the plain embed must not inherit the other embed's 0:03.
-		const audio = makeFakeAudio();
-		audio.duration = 5;
-		audio.readyState = 1;
-		const registry = makeRegistry(audio);
+		// Two distinct embeds of ONE file drive independent playback elements
+		// (issue #38). The #t= start stays per-embed: the plain embed must not
+		// inherit the other embed's 0:03, and neither element is moved.
+		const timedAudio = makeFakeAudio();
+		timedAudio.duration = 5;
+		timedAudio.readyState = 1;
+		const plainAudio = makeFakeAudio();
+		plainAudio.duration = 5;
+		plainAudio.readyState = 1;
+		const registry = makeRegistry(timedAudio, plainAudio);
 
 		const withOffset = makeContainer();
 		makePlayer(
@@ -434,7 +458,8 @@ describe('timecode start offset (#t=) positions and shows the embed', () => {
 		expect(plain.querySelector('.aar-player-time')?.textContent).toBe(
 			'0:00 / 0:05',
 		);
-		expect(audio.currentTime).toBe(0);
+		expect(timedAudio.currentTime).toBe(0);
+		expect(plainAudio.currentTime).toBe(0);
 	});
 
 	it('starts playback from the #t= offset when the user presses play', () => {
@@ -465,7 +490,8 @@ describe('timecode start offset (#t=) positions and shows the embed', () => {
 		const audio = makeFakeAudio();
 		audio.duration = 5;
 		audio.readyState = 1;
-		// Another embed (or the user) has already moved playback
+		// The same embed in another view/pane (or the user) has already moved
+		// this embed's playback
 		audio.currentTime = 4;
 		const container = makeContainer();
 
@@ -534,12 +560,17 @@ describe('timecode start offset (#t=) positions and shows the embed', () => {
 		);
 	});
 
-	it('clears the #t= start on same-file embeds once playback engages', () => {
-		const audio = makeFakeAudio();
-		audio.duration = 5;
-		audio.readyState = 1;
-		// One shared timeline drives both embeds of the file
-		const registry = makeRegistry(audio);
+	it('keeps the #t= start while a different embed of the same file plays (issue #38)', () => {
+		// Distinct embeds of one file have independent playback: playing the
+		// plain embed must neither move the #t= embed's position nor consume
+		// its start hint.
+		const timedAudio = makeFakeAudio();
+		timedAudio.duration = 5;
+		timedAudio.readyState = 1;
+		const plainAudio = makeFakeAudio();
+		plainAudio.duration = 5;
+		plainAudio.readyState = 1;
+		const registry = makeRegistry(timedAudio, plainAudio);
 
 		const withOffset = makeContainer();
 		makePlayer(
@@ -557,20 +588,89 @@ describe('timecode start offset (#t=) positions and shows the embed', () => {
 			makeFile(1000, 'wav'),
 			null,
 		).onload();
+
+		// The plain embed plays and advances to 0:02
+		plainAudio.paused = false;
+		plainAudio.emit('play');
+		plainAudio.currentTime = 2;
+		plainAudio.emit('timeupdate');
+
+		expect(plain.querySelector('.aar-player-time')?.textContent).toBe(
+			'0:02 / 0:05',
+		);
+		// The #t= embed is untouched: still paused at its own 0:03 start
 		expect(withOffset.querySelector('.aar-player-time')?.textContent).toBe(
 			'0:03 / 0:05',
 		);
+		expect(timedAudio.currentTime).toBe(0);
+		expect(timedAudio.play).not.toHaveBeenCalled();
+	});
 
-		// Playing the plain embed engages the shared timeline; after it returns
-		// to 0 paused, the #t= embed must reflect the live timeline, not its hint
-		audio.emit('play');
-		audio.currentTime = 0;
-		audio.paused = true;
-		audio.emit('timeupdate');
+	it('does not move a same-file embed when another embed is seeked (issue #38)', () => {
+		const timedAudio = makeFakeAudio();
+		timedAudio.duration = 5;
+		timedAudio.readyState = 1;
+		const plainAudio = makeFakeAudio();
+		plainAudio.duration = 5;
+		plainAudio.readyState = 1;
+		const registry = makeRegistry(timedAudio, plainAudio);
 
-		expect(withOffset.querySelector('.aar-player-time')?.textContent).toBe(
-			'0:00 / 0:05',
+		const withOffset = makeContainer();
+		makePlayer(
+			withOffset,
+			registry,
+			PLAIN,
+			makeFile(1000, 'wav'),
+			3,
+		).onload();
+		const plain = makeContainer();
+		const plainPlayer = makePlayer(
+			plain,
+			registry,
+			PLAIN,
+			makeFile(1000, 'wav'),
+			null,
 		);
+		plainPlayer.onload();
+
+		// Seeking the plain embed moves only its own element
+		plainPlayer.seekTo(4, false);
+		plainAudio.emit('timeupdate');
+
+		expect(plainAudio.currentTime).toBe(4);
+		expect(plain.querySelector('.aar-player-time')?.textContent).toBe(
+			'0:04 / 0:05',
+		);
+		expect(timedAudio.currentTime).toBe(0);
+		expect(withOffset.querySelector('.aar-player-time')?.textContent).toBe(
+			'0:03 / 0:05',
+		);
+	});
+
+	it('registers every embed of a file under the file path, keeping markers in sync', () => {
+		// Marker data is per FILE: the registry's player registrations (used
+		// to broadcast marker reloads) must stay keyed by path even though
+		// each embed drives its own playback element.
+		const registry = makeRegistry();
+		const first = makePlayer(
+			makeContainer(),
+			registry,
+			PLAIN,
+			makeFile(1000, 'wav'),
+			3,
+		);
+		first.onload();
+		const second = makePlayer(
+			makeContainer(),
+			registry,
+			PLAIN,
+			makeFile(1000, 'wav'),
+			null,
+		);
+		second.onload();
+
+		expect(registry.register).toHaveBeenCalledWith('rec.wav', first);
+		expect(registry.register).toHaveBeenCalledWith('rec.wav', second);
 	});
 });
 

--- a/tests/unit/AudioPlayerRegistry.test.ts
+++ b/tests/unit/AudioPlayerRegistry.test.ts
@@ -4,6 +4,7 @@
 
 import {
 	AudioPlayerRegistry,
+	playbackKey,
 	type SeekablePlayer,
 } from 'src/player/AudioPlayerRegistry';
 import type { ResolvedPlayerSettings } from 'src/player/playerSettings';
@@ -36,22 +37,57 @@ function makePlayer(connected = true): SeekablePlayer & {
 	};
 }
 
+describe('playbackKey', () => {
+	it('separates embeds of one file by their #t= start', () => {
+		expect(playbackKey('rec.wav', null)).toBe(playbackKey('rec.wav', null));
+		expect(playbackKey('rec.wav', 3)).toBe(playbackKey('rec.wav', 3));
+		expect(playbackKey('rec.wav', 3)).not.toBe(
+			playbackKey('rec.wav', null),
+		);
+		expect(playbackKey('rec.wav', 3)).not.toBe(playbackKey('rec.wav', 4));
+		expect(playbackKey('a.wav', null)).not.toBe(playbackKey('b.wav', null));
+	});
+
+	it('cannot collide with a path that spells out the #t= suffix', () => {
+		// The separator is a character no vault path can contain, so a file
+		// literally named "rec.wav#t=3" never aliases a real #t=3 embed key
+		expect(playbackKey('rec.wav#t=3', null)).not.toBe(
+			playbackKey('rec.wav', 3),
+		);
+	});
+});
+
 describe('AudioPlayerRegistry', () => {
-	it('seeks every registered player for a path', () => {
+	it('seeks only the first connected player for a path', () => {
 		const registry = new AudioPlayerRegistry();
 		const a = makePlayer();
 		const b = makePlayer();
 		registry.register('rec.wav', a);
 		registry.register('rec.wav', b);
 
+		// Each player drives its own playback element, so seeking (and
+		// autoplaying) every player would start overlapping playbacks; a
+		// timecode click targets one player only
 		expect(registry.seek('rec.wav', 42)).toBe(true);
 		expect(a.seeks).toEqual([42]);
-		expect(b.seeks).toEqual([42]);
+		expect(b.seeks).toEqual([]);
 	});
 
 	it('returns false when no player is registered for the path', () => {
 		const registry = new AudioPlayerRegistry();
 		expect(registry.seek('missing.wav', 10)).toBe(false);
+	});
+
+	it('falls through to the next player when the first is disconnected', () => {
+		const registry = new AudioPlayerRegistry();
+		const disconnected = makePlayer(false);
+		const connected = makePlayer(true);
+		registry.register('rec.wav', disconnected);
+		registry.register('rec.wav', connected);
+
+		expect(registry.seek('rec.wav', 5)).toBe(true);
+		expect(connected.seeks).toEqual([5]);
+		expect(disconnected.seeks).toEqual([]);
 	});
 
 	it('prunes disconnected players during a seek', () => {
@@ -117,42 +153,60 @@ describe('AudioPlayerRegistry', () => {
 		}).not.toThrow();
 	});
 
-	it('shares one audio element across players of the same file', () => {
+	it('shares one audio element across players of the same embed identity', () => {
 		const registry = new AudioPlayerRegistry();
-		const first = registry.acquireAudio('rec.wav', 'app://rec');
-		const second = registry.acquireAudio('rec.wav', 'app://rec');
+		const key = playbackKey('rec.wav', null);
+		const first = registry.acquireAudio(key, 'app://rec');
+		const second = registry.acquireAudio(key, 'app://rec');
 
-		// Same element -> a player in either view mode controls one playback
+		// Same element -> the same embed in either view mode controls one
+		// playback
 		expect(first.audio).toBe(second.audio);
 		expect(first.isNew).toBe(true);
 		expect(second.isNew).toBe(false);
 
-		expect(registry.acquireAudio('other.wav', 'app://o').audio).not.toBe(
-			first.audio,
+		expect(
+			registry.acquireAudio(playbackKey('other.wav', null), 'app://o')
+				.audio,
+		).not.toBe(first.audio);
+	});
+
+	it('gives distinct embeds of one file independent audio elements', () => {
+		const registry = new AudioPlayerRegistry();
+		// A plain embed and a #t=3 embed of the SAME file must not share a
+		// playback: playing or seeking one must never move the other
+		const plain = registry.acquireAudio(
+			playbackKey('rec.wav', null),
+			'app://rec',
 		);
+		const timed = registry.acquireAudio(
+			playbackKey('rec.wav', 3),
+			'app://rec',
+		);
+
+		expect(timed.audio).not.toBe(plain.audio);
+		expect(plain.isNew).toBe(true);
+		expect(timed.isNew).toBe(true);
 	});
 
 	it('keeps the audio alive across a mode switch, then frees it after the grace period', () => {
 		jest.useFakeTimers();
 		try {
 			const registry = new AudioPlayerRegistry();
-			const a = registry.acquireAudio('rec.wav', 'app://rec');
-			registry.acquireAudio('rec.wav', 'app://rec'); // second view mode
+			const key = playbackKey('rec.wav', null);
+			const a = registry.acquireAudio(key, 'app://rec');
+			registry.acquireAudio(key, 'app://rec'); // second view mode
 
 			// One view unloads; the element must survive for the other
-			registry.releaseAudio('rec.wav');
+			registry.releaseAudio(key);
 			jest.advanceTimersByTime(100);
-			expect(registry.acquireAudio('rec.wav', 'app://rec').audio).toBe(
-				a.audio,
-			);
+			expect(registry.acquireAudio(key, 'app://rec').audio).toBe(a.audio);
 
 			// Now both remaining holders release -> after grace it is freed
-			registry.releaseAudio('rec.wav');
-			registry.releaseAudio('rec.wav');
+			registry.releaseAudio(key);
+			registry.releaseAudio(key);
 			jest.advanceTimersByTime(1000);
-			expect(registry.acquireAudio('rec.wav', 'app://rec').isNew).toBe(
-				true,
-			);
+			expect(registry.acquireAudio(key, 'app://rec').isNew).toBe(true);
 		} finally {
 			jest.useRealTimers();
 		}
@@ -177,20 +231,35 @@ describe('AudioPlayerRegistry', () => {
 
 	it('tracks the engaged state of a shared audio element', () => {
 		const registry = new AudioPlayerRegistry();
-		registry.acquireAudio('rec.wav', 'app://rec');
+		const key = playbackKey('rec.wav', 3);
+		registry.acquireAudio(key, 'app://rec');
 
 		// A fresh element is not engaged, so a #t= embed may show its start
-		expect(registry.isAudioEngaged('rec.wav')).toBe(false);
-		registry.markAudioEngaged('rec.wav');
-		expect(registry.isAudioEngaged('rec.wav')).toBe(true);
+		expect(registry.isAudioEngaged(key)).toBe(false);
+		registry.markAudioEngaged(key);
+		expect(registry.isAudioEngaged(key)).toBe(true);
 	});
 
-	it('reports not engaged for an unknown path', () => {
+	it('tracks the engaged state per embed identity, not per file', () => {
 		const registry = new AudioPlayerRegistry();
-		expect(registry.isAudioEngaged('missing.wav')).toBe(false);
-		// Marking an unknown path is a no-op, never throws
+		const plainKey = playbackKey('rec.wav', null);
+		const timedKey = playbackKey('rec.wav', 3);
+		registry.acquireAudio(plainKey, 'app://rec');
+		registry.acquireAudio(timedKey, 'app://rec');
+
+		// Playing the plain embed must not consume the #t= embed's start hint
+		registry.markAudioEngaged(plainKey);
+		expect(registry.isAudioEngaged(plainKey)).toBe(true);
+		expect(registry.isAudioEngaged(timedKey)).toBe(false);
+	});
+
+	it('reports not engaged for an unknown key', () => {
+		const registry = new AudioPlayerRegistry();
+		const key = playbackKey('missing.wav', null);
+		expect(registry.isAudioEngaged(key)).toBe(false);
+		// Marking an unknown key is a no-op, never throws
 		expect(() => {
-			registry.markAudioEngaged('missing.wav');
+			registry.markAudioEngaged(key);
 		}).not.toThrow();
 	});
 
@@ -198,16 +267,17 @@ describe('AudioPlayerRegistry', () => {
 		jest.useFakeTimers();
 		try {
 			const registry = new AudioPlayerRegistry();
-			registry.acquireAudio('rec.wav', 'app://rec');
-			registry.markAudioEngaged('rec.wav');
+			const key = playbackKey('rec.wav', 3);
+			registry.acquireAudio(key, 'app://rec');
+			registry.markAudioEngaged(key);
 
 			// Release and let the grace period free the element
-			registry.releaseAudio('rec.wav');
+			registry.releaseAudio(key);
 			jest.advanceTimersByTime(1000);
 
 			// A re-mounted #t= embed starts from a fresh, not-engaged element
-			registry.acquireAudio('rec.wav', 'app://rec');
-			expect(registry.isAudioEngaged('rec.wav')).toBe(false);
+			registry.acquireAudio(key, 'app://rec');
+			expect(registry.isAudioEngaged(key)).toBe(false);
 		} finally {
 			jest.useRealTimers();
 		}


### PR DESCRIPTION
## Summary

This change implements per-embed independent playback for distinct embeds of the same audio file. Previously, all embeds of a file shared a single audio element and playback state. Now, embeds with different `#t=` start times (or a plain embed vs. a timed embed) drive independent audio elements while maintaining the same element across view-mode switches for the same embed.

## Key Changes

- **Playback key system**: Introduced `playbackKey(path, startSeconds)` function that creates a unique identity for each embed based on file path and `#t=` start offset. This replaces the previous file-path-only keying.

- **Audio element registry refactoring**: Changed `AudioPlayerRegistry` to key shared audio elements by playback key instead of file path:
  - `audioByPath` → `audioByKey` 
  - `acquireAudio()` and `releaseAudio()` now accept playback keys
  - `markAudioEngaged()` and `isAudioEngaged()` now track engagement per embed, not per file

- **Player registration remains file-based**: The registry still registers players by file path (for timecode links and marker syncing), but audio elements are now keyed by embed identity.

- **Seek behavior change**: `registry.seek()` now targets only the first connected player for a path instead of all players, preventing overlapping playbacks from a single timecode click. The same embed in another view mode shares that player's element and stays in sync.

- **AudioPlayer updates**: 
  - Added `audioKey` field computed from file path and `#t=` start
  - Updated all registry calls to use the playback key instead of file path
  - Updated comments to clarify per-embed vs. per-file semantics

- **Test coverage**: Comprehensive test updates and new tests covering:
  - Plain and timed embeds of the same file maintaining independent positions
  - Seeking one embed not affecting another
  - Marker registrations staying per-file for sync across embeds
  - Engaged state tracking per embed identity, not per file

## Implementation Details

- The playback key separator is U+0000 (null character), which cannot appear in vault paths, preventing collisions with files literally named with the `#t=` suffix.
- The engaged flag (tracking whether a user has played/sought the timeline) is now per-embed, so playing a plain embed doesn't consume the `#t=` start hint of a timed embed of the same file.
- Re-acquiring the same embed across view-mode switches still returns the same audio element and resumes playback, maintaining seamless cross-view continuity.

https://claude.ai/code/session_01U6vnaTpg3vwrmrfnQh17gg