### PR TITLE
Fix issue #39: avoid note re-renders on media probe verdicts

### DIFF
--- a/src/actions/PluginAction.ts
+++ b/src/actions/PluginAction.ts
@@ -13,14 +13,11 @@ import type { TranscriptionModalOptions } from '../ui/TranscriptionModal';
 import type { EncodingWorkerClient } from '../audio/EncodingWorkerClient';
 
 /**
- * Primes freshly written files for the enhanced player so a cleaned or
- * converted file is upgraded immediately instead of after the note is
- * reopened.
+ * Primes freshly written files for the enhanced player: starts their
+ * media probe right away so the embeds are built enhanced (or upgraded
+ * in place) instead of waiting for a lazily started probe.
  */
-export type EnhancementPrimer = (
-	paths: string[],
-	notePath: string | null,
-) => void;
+export type EnhancementPrimer = (paths: string[]) => void;
 
 /**
  * Everything an action handler may need, injected by the plugin at

--- a/src/actions/fileActions.ts
+++ b/src/actions/fileActions.ts
@@ -53,12 +53,9 @@ export const FILE_ACTIONS: readonly FileAction[] = [
 				services.getSettings(),
 				(convertedPath) => {
 					// The note link is already rewritten by the conversion's
-					// linkAction; prime the active note so the new embed
+					// linkAction; prime the converted file so its embed
 					// becomes the enhanced player at once.
-					services.primeForEnhancement(
-						[convertedPath],
-						services.app.workspace.getActiveFile()?.path ?? null,
-					);
+					services.primeForEnhancement([convertedPath]);
 				},
 				services.getWorkerClient,
 			).open();
@@ -89,15 +86,13 @@ export const FILE_ACTIONS: readonly FileAction[] = [
 					// Link the result into the note (replace the source embed
 					// when it is being deleted, else insert after), then prime
 					// it so the enhanced player applies at once.
-					const notePath = await insertProcessedAudioEmbed(
+					await insertProcessedAudioEmbed(
 						services.app,
 						file,
 						outputPath,
 						replaceSource,
 					);
-					if (notePath) {
-						services.primeForEnhancement([outputPath], notePath);
-					}
+					services.primeForEnhancement([outputPath]);
 				},
 			).open();
 		},

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,6 +44,7 @@ import {
 	registerRecordingActionCommands,
 } from './actions/registerActionCommands';
 import { EnhancedPlayerRegistrar } from './player/EnhancedPlayerRegistrar';
+import { MediaKindStore, MEDIA_KIND_STORE_FILE } from './player/MediaKindStore';
 import { MarkerStore } from './markers/MarkerStore';
 import { RecordingMarkerModal } from './ui/MarkerModal';
 import { TranscriptionModal } from './ui/TranscriptionModal';
@@ -195,11 +196,18 @@ export default class AudioRecorderPlugin extends Plugin {
 		);
 		this.contextMenu.register();
 
+		// Media kinds persist across sessions so the first open of a note
+		// never repeats a file's probe (and the embed upgrade behind it)
+		const mediaKindStore = new MediaKindStore(
+			this.app,
+			this.getPluginFilePath(MEDIA_KIND_STORE_FILE),
+		);
 		this.playerRegistrar = new EnhancedPlayerRegistrar(
 			this,
 			this.app,
 			() => this.settings,
 			markerStore,
+			mediaKindStore,
 		);
 		this.playerRegistrar.register();
 
@@ -572,11 +580,8 @@ export default class AudioRecorderPlugin extends Plugin {
 			getSettings: () => this.settings,
 			createTranscriptionModalOptions: () =>
 				this.createTranscriptionModalOptions(),
-			primeForEnhancement: (paths, notePath) =>
-				this.playerRegistrar.primeSavedRecordingsForEnhancement(
-					paths,
-					notePath,
-				),
+			primeForEnhancement: (paths) =>
+				this.playerRegistrar.primeSavedRecordingsForEnhancement(paths),
 			getWorkerClient: () => this.encodingWorker,
 		};
 	}
@@ -665,7 +670,6 @@ export default class AudioRecorderPlugin extends Plugin {
 	private handleRecordingSaved(result: RecordingSaveResult): void {
 		this.playerRegistrar.primeSavedRecordingsForEnhancement(
 			result.audioPaths,
-			result.notePath,
 		);
 
 		if (

--- a/src/player/EnhancedPlayerRegistrar.ts
+++ b/src/player/EnhancedPlayerRegistrar.ts
@@ -14,19 +14,22 @@
  *
  * The media kind is always determined by probing the actual content (the
  * extension is never trusted, since a container can carry a video track):
- * each file is probed once and cached per path. When a probe reveals an
- * audio-only file, the open views are re-rendered so the embed is rebuilt
- * as the enhanced player. Settings changes use the SAME re-render,
- * so any player setting applies immediately and identically in both modes -
- * Reading view via previewMode.rerender, Live Preview via the current
- * sub-view's set(get(), true). When the internal registry API is
- * unavailable, a Markdown post-processor takes over embeds (Reading view
- * only). A document-level click handler routes timecode links to a live
- * player. All paths respect the feature toggle.
+ * each file is probed once per session and cached per path, and confident
+ * results persist across sessions (MediaKindStore, validated by
+ * mtime/size). A not-yet-probed file renders inside a MediaEmbedShell
+ * that hosts the native embed and upgrades to the enhanced player IN
+ * PLACE when the probe confirms audio - the embedding note is never
+ * re-rendered, so a large note is not lagged by a short recording
+ * (issue #39). Only the master toggle flip re-renders open views
+ * (leaf.rebuildView), because it changes what every embed is in both
+ * modes at once. When the internal registry API is unavailable, a
+ * Markdown post-processor takes over embeds (Reading view only). A
+ * document-level click handler routes timecode links to a live player.
+ * All paths respect the feature toggle.
  * @module player/EnhancedPlayerRegistrar
  */
 
-import { TFile, MarkdownView, debounce, getLinkpath } from 'obsidian';
+import { TFile, MarkdownView, debounce } from 'obsidian';
 import type {
 	App,
 	MarkdownPostProcessorContext,
@@ -49,6 +52,8 @@ import {
 	parseTimecodeSubpath,
 } from './timecodeLinks';
 import { probeMediaKind, type MediaKind } from './mediaProbe';
+import { MediaEmbedShell } from './MediaEmbedShell';
+import type { MediaKindStore } from './MediaKindStore';
 import { shouldEnhance } from './playerMode';
 import type { MarkerStore } from '../markers/MarkerStore';
 import {
@@ -63,16 +68,9 @@ const ENHANCED_FLAG = 'aarEnhanced';
 
 /**
  * Debounce window for re-rendering open views. Coalesces a burst of
- * settings changes (e.g. dragging a slider) or simultaneous probe results
- * into a single re-render.
+ * settings changes (e.g. dragging a slider) into a single re-render.
  */
 const RERENDER_DEBOUNCE_MS = 50;
-
-/**
- * Number of extra scoped re-render attempts for a freshly inserted embed
- * whose metadata cache entry may lag behind the editor update.
- */
-const SCOPED_RERENDER_RETRY_LIMIT = 5;
 
 /**
  * Registers and owns the enhanced player integration.
@@ -86,23 +84,12 @@ export class EnhancedPlayerRegistrar {
 	private embedOverride: EmbedRegistryOverride | null = null;
 	/** Probed media kind per file path, shared so each file is probed once. */
 	private readonly mediaKindCache = new Map<string, MediaKind>();
-	/** File paths with a probe in flight, to avoid concurrent probes. */
-	private readonly probing = new Set<string>();
+	/** In-flight probe per file path, shared by every embed of the file. */
+	private readonly probes = new Map<string, Promise<MediaKind>>();
 	/** Last seen feature-enabled state, so refresh re-renders only on a flip. */
 	private lastEnabled = false;
 	/** Last applied resolved layout, so an unchanged save re-applies nothing. */
 	private lastResolved: ResolvedPlayerSettings | null = null;
-	/** Paths pending a scoped re-render (probe upgrades of specific files). */
-	private readonly pendingRerenderPaths = new Set<string>();
-	/** Retry count per scoped path while metadata catches up. */
-	private readonly pendingRerenderRetries = new Map<string, number>();
-	/** Notes to rebuild directly once a saved recording probes as audio. */
-	private readonly pendingDirectRerenderNotePaths = new Map<
-		string,
-		Set<string>
-	>();
-	/** Notes that should receive a direct rebuild after the current probe. */
-	private readonly pendingProbeNotePaths = new Map<string, Set<string>>();
 	/** Whether every leaf must re-render (master toggle flip). */
 	private pendingRerenderAll = false;
 	/** Debounced flush that coalesces a burst of re-render requests. */
@@ -117,12 +104,14 @@ export class EnhancedPlayerRegistrar {
 	 * @param app - Obsidian App instance
 	 * @param getSettings - Returns the current plugin settings
 	 * @param markerStore - Persistence for markers and chapters
+	 * @param mediaKindStore - Cross-session media-kind cache, if any
 	 */
 	constructor(
 		private readonly plugin: Plugin,
 		private readonly app: App,
 		private readonly getSettings: () => AudioRecorderSettings,
 		private readonly markerStore: MarkerStore,
+		private readonly mediaKindStore: MediaKindStore | null = null,
 	) {}
 
 	/**
@@ -131,6 +120,9 @@ export class EnhancedPlayerRegistrar {
 	 * handlers. Safe to call once during plugin load.
 	 */
 	register(): void {
+		// Loading later just means early embeds probe instead of hitting
+		// the persisted cache, so plugin load is never delayed by it
+		void this.mediaKindStore?.load();
 		this.lastEnabled = this.getSettings().enhancedPlayerEnabled;
 		this.lastResolved = this.lastEnabled
 			? resolvePlayerSettings(this.getSettings())
@@ -163,12 +155,18 @@ export class EnhancedPlayerRegistrar {
 			{ capture: true },
 		);
 
-		// Keep each recording's marker sidecar attached to the file: move
-		// it on rename/move and remove it on delete
+		// Keep each recording's marker sidecar and media-kind cache entries
+		// attached to the file: move them on rename/move, drop them on delete
 		this.plugin.registerEvent(
 			this.app.vault.on('rename', (file, oldPath) => {
 				if (file instanceof TFile && isAudioFile(file)) {
 					void this.markerStore.handleRename(oldPath, file.path);
+					const kind = this.mediaKindCache.get(oldPath);
+					if (kind) {
+						this.mediaKindCache.delete(oldPath);
+						this.mediaKindCache.set(file.path, kind);
+					}
+					this.mediaKindStore?.handleRename(oldPath, file.path);
 				}
 			}),
 		);
@@ -176,6 +174,8 @@ export class EnhancedPlayerRegistrar {
 			this.app.vault.on('delete', (file) => {
 				if (file instanceof TFile && isAudioFile(file)) {
 					void this.markerStore.handleDelete(file.path);
+					this.mediaKindCache.delete(file.path);
+					this.mediaKindStore?.handleDelete(file.path);
 				}
 			}),
 		);
@@ -194,11 +194,9 @@ export class EnhancedPlayerRegistrar {
 		this.registry.clear();
 		this.peakCache.clear();
 		this.mediaKindCache.clear();
-		this.probing.clear();
-		this.pendingRerenderPaths.clear();
-		this.pendingRerenderRetries.clear();
-		this.pendingDirectRerenderNotePaths.clear();
-		this.pendingProbeNotePaths.clear();
+		this.probes.clear();
+		// Persist any probe results from the final debounce window
+		this.mediaKindStore?.flush();
 		this.markerStore.clearCache();
 		void this.decoder.close().catch(() => {
 			// Closing a context that never opened or already failed is
@@ -243,19 +241,15 @@ export class EnhancedPlayerRegistrar {
 	}
 
 	/**
-	 * Primes freshly saved recordings for enhancement after the recording
-	 * pipeline inserts their embeds into a note. This avoids depending on
-	 * Obsidian first creating a native embed and starting the lazy probe: once
-	 * the file is proven audio-only, the note that received the embed is
-	 * rebuilt directly.
+	 * Primes freshly saved recordings for enhancement by starting their
+	 * media probe right away. When Obsidian then creates the embed, the
+	 * kind is either already cached (the embed is built enhanced from the
+	 * start) or the embed's shell joins the in-flight probe and upgrades
+	 * in place - no note re-render in either case.
 	 * @param audioPaths - Vault paths written by the recording finalizer
-	 * @param notePath - Note that received the embed links, if any
 	 */
-	primeSavedRecordingsForEnhancement(
-		audioPaths: string[],
-		notePath: string | null,
-	): void {
-		if (!this.getSettings().enhancedPlayerEnabled || !notePath) {
+	primeSavedRecordingsForEnhancement(audioPaths: string[]): void {
+		if (!this.getSettings().enhancedPlayerEnabled) {
 			return;
 		}
 		for (const audioPath of audioPaths) {
@@ -263,7 +257,7 @@ export class EnhancedPlayerRegistrar {
 			if (!(file instanceof TFile) || !isAudioFile(file)) {
 				continue;
 			}
-			void this.probeAndUpgrade(file, notePath);
+			void this.probeKind(file);
 		}
 	}
 
@@ -304,8 +298,9 @@ export class EnhancedPlayerRegistrar {
 	 * for files probed as audio-only when the feature is on, and otherwise
 	 * Obsidian's own native embed unwrapped (so video and unsupported files
 	 * render exactly as Obsidian would, in both view modes). A not-yet-probed
-	 * file renders native now and is probed; if it is audio-only, a re-render
-	 * upgrades it.
+	 * file renders inside a MediaEmbedShell: the native embed shows now,
+	 * the content is probed in the background, and an audio-only verdict
+	 * upgrades this one embed in place - the note is never re-rendered.
 	 * @param info - Embed context from Obsidian
 	 * @param file - Media file to embed
 	 * @param subpath - Embed subpath (timecode, if any)
@@ -327,11 +322,21 @@ export class EnhancedPlayerRegistrar {
 				return this.buildAudioPlayer(info, file, subpath);
 			}
 
-			// Not (yet) known to be audio: render Obsidian's own embed. If the
-			// file has not been probed yet, probe its content in the background
-			// and re-render to upgrade it if it turns out audio-only.
+			// Not yet probed: host Obsidian's own embed in a shell that
+			// upgrades to the enhanced player in place if the probe finds
+			// audio. Video and unsupported files never leave the native
+			// embed, and no probe verdict ever re-renders the note.
 			if (enabled && kind === null && nativeCreator) {
-				void this.probeAndUpgrade(file);
+				return new MediaEmbedShell(
+					nativeCreator(info, file, subpath),
+					this.probeKind(file),
+					(probedKind) =>
+						shouldEnhance(
+							this.getSettings().enhancedPlayerEnabled,
+							probedKind,
+						),
+					() => this.buildAudioPlayer(info, file, subpath),
+				);
 			}
 			if (nativeCreator) {
 				return nativeCreator(info, file, subpath);
@@ -353,77 +358,56 @@ export class EnhancedPlayerRegistrar {
 	}
 
 	/**
-	 * The media kind already determined by a prior probe, or null when the
-	 * file has not been probed yet. The extension is never trusted: a
-	 * container (even one usually holding audio) can carry a video track, so
-	 * audio-vs-video is always decided by probing the actual content.
+	 * The media kind already determined by a prior probe - this session's
+	 * cache first, then the persisted store (validated by mtime/size) -
+	 * or null when the file has not been probed yet. The extension is
+	 * never trusted: a container (even one usually holding audio) can
+	 * carry a video track, so audio-vs-video is always decided by probing
+	 * the actual content.
 	 * @param file - Media file
 	 */
 	private knownKind(file: TFile): MediaKind | null {
-		return this.mediaKindCache.get(file.path) ?? null;
+		const cached = this.mediaKindCache.get(file.path);
+		if (cached) {
+			return cached;
+		}
+		const stored = this.mediaKindStore?.get(file) ?? null;
+		if (stored) {
+			this.mediaKindCache.set(file.path, stored);
+		}
+		return stored;
 	}
 
 	/**
-	 * Probes a media file's content once and, if it is audio-only, re-renders
-	 * open views so the embed is rebuilt as the enhanced player.
-	 * @param file - Media file to probe
+	 * The file's media kind: cached if known, otherwise probed. One probe
+	 * runs per path at a time and every caller (each embed shell of the
+	 * file, the saved-recording primer) shares its promise. Confident
+	 * results are persisted so later sessions skip the probe entirely;
+	 * a timeout fallback is kept for this session only.
+	 * @param file - Media file to classify
 	 */
-	private async probeAndUpgrade(
-		file: TFile,
-		notePath?: string,
-	): Promise<void> {
-		if (notePath) {
-			this.addPendingProbeNotePath(file.path, notePath);
+	private probeKind(file: TFile): Promise<MediaKind> {
+		const known = this.knownKind(file);
+		if (known) {
+			return Promise.resolve(known);
 		}
-		const knownKind = this.mediaKindCache.get(file.path);
-		if (knownKind) {
-			if (
-				shouldEnhance(
-					this.getSettings().enhancedPlayerEnabled,
-					knownKind,
-				)
-			) {
-				this.requestRerenderForFile(file.path, notePath);
-			}
-			return;
+		const inFlight = this.probes.get(file.path);
+		if (inFlight) {
+			return inFlight;
 		}
-		if (this.probing.has(file.path)) {
-			return;
-		}
-		this.probing.add(file.path);
-		try {
-			const kind = await probeMediaKind(
-				this.app.vault.getResourcePath(file),
-			);
-			this.mediaKindCache.set(file.path, kind);
-			if (shouldEnhance(this.getSettings().enhancedPlayerEnabled, kind)) {
-				const notePaths = this.pendingProbeNotePaths.get(file.path);
-				if (notePaths && notePaths.size > 0) {
-					for (const pendingNotePath of notePaths) {
-						this.requestRerenderForFile(file.path, pendingNotePath);
-					}
-				} else {
-					// Only the notes that actually embed this file need rebuilding,
-					// so a large note that does not embed it is never re-rendered
-					this.requestRerenderForFile(file.path);
+		const probe = probeMediaKind(this.app.vault.getResourcePath(file))
+			.then((result) => {
+				this.mediaKindCache.set(file.path, result.kind);
+				if (result.confident) {
+					this.mediaKindStore?.set(file, result.kind);
 				}
-			}
-		} finally {
-			this.pendingProbeNotePaths.delete(file.path);
-			this.probing.delete(file.path);
-		}
-	}
-
-	/**
-	 * Remembers that a saved recording should rebuild a known note after its
-	 * media probe completes.
-	 * @param path - Vault path of the recording
-	 * @param notePath - Note that received the embed link
-	 */
-	private addPendingProbeNotePath(path: string, notePath: string): void {
-		const notePaths = this.pendingProbeNotePaths.get(path) ?? new Set();
-		notePaths.add(notePath);
-		this.pendingProbeNotePaths.set(path, notePaths);
+				return result.kind;
+			})
+			.finally(() => {
+				this.probes.delete(file.path);
+			});
+		this.probes.set(file.path, probe);
+		return probe;
 	}
 
 	/**
@@ -463,142 +447,19 @@ export class EnhancedPlayerRegistrar {
 	}
 
 	/**
-	 * Requests a re-render of only the leaves that embed the given file, so a
-	 * probe upgrade never re-renders unrelated (possibly large) notes.
-	 * @param path - Vault path of the upgraded file
-	 */
-	private requestRerenderForFile(path: string, notePath?: string): void {
-		this.pendingRerenderPaths.add(path);
-		if (notePath) {
-			const notePaths =
-				this.pendingDirectRerenderNotePaths.get(path) ?? new Set();
-			notePaths.add(notePath);
-			this.pendingDirectRerenderNotePaths.set(path, notePaths);
-		}
-		if (!this.pendingRerenderRetries.has(path)) {
-			this.pendingRerenderRetries.set(path, 0);
-		}
-		this.scheduleRerender();
-	}
-
-	/**
-	 * Flushes the coalesced re-render requests: rebuilds every leaf on a full
-	 * request, otherwise only the leaves whose note embeds a pending file.
+	 * Flushes the coalesced re-render request by rebuilding every open
+	 * markdown leaf. Only the master toggle flip requests this: probe
+	 * upgrades happen inside the embed's own shell and never re-render a
+	 * note, which is what keeps a large note from lagging on the first
+	 * probe of a short recording.
 	 */
 	private flushRerender(): void {
-		const all = this.pendingRerenderAll;
-		const paths = new Set(this.pendingRerenderPaths);
+		if (!this.pendingRerenderAll) {
+			return;
+		}
 		this.pendingRerenderAll = false;
-		this.pendingRerenderPaths.clear();
-		if (!all && paths.size === 0) {
-			return;
-		}
-		const leaves = this.app.workspace.getLeavesOfType('markdown');
-		if (all) {
-			for (const leaf of leaves) {
-				this.rerenderLeaf(leaf);
-			}
-			for (const path of paths) {
-				this.pendingRerenderRetries.delete(path);
-				this.pendingDirectRerenderNotePaths.delete(path);
-			}
-			return;
-		}
-		const unmatchedPaths = new Set(paths);
-		const matchedRerenderPaths = new Set<string>();
-		for (const leaf of leaves) {
-			const matchedPaths = new Set([
-				...this.leafDirectRerenderPaths(leaf, paths),
-				...this.leafEmbeddedPaths(leaf, paths),
-			]);
-			if (matchedPaths.size > 0) {
-				this.rerenderLeaf(leaf);
-				for (const path of matchedPaths) {
-					unmatchedPaths.delete(path);
-					matchedRerenderPaths.add(path);
-				}
-			}
-		}
-		for (const path of matchedRerenderPaths) {
-			this.pendingRerenderRetries.delete(path);
-			this.pendingDirectRerenderNotePaths.delete(path);
-		}
-		this.rescheduleUnmatchedRerenders(unmatchedPaths);
-	}
-
-	/**
-	 * Returns probed file paths that should rebuild this exact note because
-	 * the recording pipeline just inserted their embeds there.
-	 * @param leaf - Workspace leaf to test
-	 * @param paths - Candidate embedded file paths
-	 */
-	private leafDirectRerenderPaths(
-		leaf: WorkspaceLeaf,
-		paths: Set<string>,
-	): Set<string> {
-		const matchedPaths = new Set<string>();
-		const view = leaf.view;
-		if (!(view instanceof MarkdownView) || !view.file) {
-			return matchedPaths;
-		}
-		for (const path of paths) {
-			const notePaths = this.pendingDirectRerenderNotePaths.get(path);
-			if (notePaths?.has(view.file.path)) {
-				matchedPaths.add(path);
-			}
-		}
-		return matchedPaths;
-	}
-
-	/**
-	 * Returns the given file paths embedded by a leaf's note, resolved through
-	 * the metadata cache. A note with no matching embed is left untouched.
-	 * @param leaf - Workspace leaf to test
-	 * @param paths - Candidate embedded file paths
-	 */
-	private leafEmbeddedPaths(
-		leaf: WorkspaceLeaf,
-		paths: Set<string>,
-	): Set<string> {
-		const matchedPaths = new Set<string>();
-		const view = leaf.view;
-		if (!(view instanceof MarkdownView) || !view.file) {
-			return matchedPaths;
-		}
-		const embeds = this.app.metadataCache.getFileCache(view.file)?.embeds;
-		if (!embeds) {
-			return matchedPaths;
-		}
-		for (const embed of embeds) {
-			const dest = this.app.metadataCache.getFirstLinkpathDest(
-				getLinkpath(embed.link),
-				view.file.path,
-			);
-			if (dest && paths.has(dest.path)) {
-				matchedPaths.add(dest.path);
-			}
-		}
-		return matchedPaths;
-	}
-
-	/**
-	 * Keeps a scoped upgrade alive briefly when the media probe finished before
-	 * Obsidian indexed the newly inserted embed in metadataCache.
-	 * @param unmatchedPaths - Probed audio paths not found in open note caches
-	 */
-	private rescheduleUnmatchedRerenders(unmatchedPaths: Set<string>): void {
-		for (const path of unmatchedPaths) {
-			const retryCount = this.pendingRerenderRetries.get(path) ?? 0;
-			if (retryCount >= SCOPED_RERENDER_RETRY_LIMIT) {
-				this.pendingRerenderRetries.delete(path);
-				this.pendingDirectRerenderNotePaths.delete(path);
-				continue;
-			}
-			this.pendingRerenderRetries.set(path, retryCount + 1);
-			this.pendingRerenderPaths.add(path);
-		}
-		if (this.pendingRerenderPaths.size > 0) {
-			this.scheduleRerender();
+		for (const leaf of this.app.workspace.getLeavesOfType('markdown')) {
+			this.rerenderLeaf(leaf);
 		}
 	}
 

--- a/src/player/MediaEmbedShell.ts
+++ b/src/player/MediaEmbedShell.ts
@@ -1,0 +1,102 @@
+/**
+ * Embed component for a media file whose kind (audio vs video) is not
+ * known yet. It hosts Obsidian's native embed while the content probe
+ * runs and, when the probe proves the file audio-only, swaps to the
+ * enhanced player IN PLACE - inside this embed's own container. The swap
+ * costs one embed, not a note: previously the upgrade re-rendered the
+ * whole embedding view via leaf.rebuildView(), which lagged large notes
+ * for even a 5-second recording (issue #39).
+ *
+ * Unloading the native child stops any media it was playing - the same
+ * guarantee rebuildView provided, scoped to this embed. The player's own
+ * render empties the container, so the shell never touches the DOM
+ * directly. When the probe finds video or an unsupported file, the shell
+ * simply keeps hosting the native embed and nothing re-renders.
+ * @module player/MediaEmbedShell
+ */
+
+import { Component } from 'obsidian';
+import type { TFile } from 'obsidian';
+import type { EmbedComponent } from '../obsidian/embedRegistry';
+import type { MediaKind } from './mediaProbe';
+
+/**
+ * Hosts the native embed for a not-yet-probed media file and upgrades it
+ * to the enhanced player in place once the probe confirms audio.
+ */
+export class MediaEmbedShell extends Component implements EmbedComponent {
+	/** The embed currently shown: the native embed, then maybe the player. */
+	private current: EmbedComponent;
+	/** Set once torn down, so a probe settling later never swaps. */
+	private disposed = false;
+	/** Whether Obsidian drove this embed through loadFile (Live Preview). */
+	private loadFileCalled = false;
+	/** The file the last loadFile call carried, replayed after a swap. */
+	private lastLoadedFile: TFile | undefined;
+
+	/**
+	 * @param native - Obsidian's own embed for the file, shown immediately
+	 * @param probe - The shared media-kind probe for the file
+	 * @param shouldUpgrade - Whether a probed kind warrants the enhanced
+	 * player, checked when the probe settles (the toggle may have flipped)
+	 * @param buildPlayer - Builds the enhanced player into the same container
+	 */
+	constructor(
+		native: EmbedComponent,
+		probe: Promise<MediaKind>,
+		private readonly shouldUpgrade: (kind: MediaKind) => boolean,
+		private readonly buildPlayer: () => EmbedComponent,
+	) {
+		super();
+		this.current = native;
+		this.addChild(native);
+		void probe.then(
+			(kind) => {
+				this.upgradeWhen(kind);
+			},
+			() => {
+				// A failed probe leaves the native embed in place, which
+				// renders the file exactly as Obsidian would on its own
+			},
+		);
+	}
+
+	/**
+	 * Obsidian's Live Preview embed lifecycle calls loadFile on the embed
+	 * component; forward it to whichever embed is currently hosted and
+	 * remember it so a later swap can replay it on the new child.
+	 * @param file - File Obsidian asks to load (the embed's own file)
+	 */
+	loadFile(file?: TFile): void | Promise<void> {
+		this.loadFileCalled = true;
+		this.lastLoadedFile = file;
+		return this.current.loadFile?.(file);
+	}
+
+	/**
+	 * Marks the shell torn down so a probe that settles afterwards never
+	 * builds a player into a container Obsidian has abandoned.
+	 */
+	override onunload(): void {
+		this.disposed = true;
+	}
+
+	/**
+	 * Swaps the native embed for the enhanced player when the probed kind
+	 * warrants it. Unloading the native child stops any media it was
+	 * playing; the player's render then owns (and empties) the container.
+	 * @param kind - The probed media kind
+	 */
+	private upgradeWhen(kind: MediaKind): void {
+		if (this.disposed || !this.shouldUpgrade(kind)) {
+			return;
+		}
+		this.removeChild(this.current);
+		const player = this.buildPlayer();
+		this.current = player;
+		this.addChild(player);
+		if (this.loadFileCalled) {
+			void player.loadFile?.(this.lastLoadedFile);
+		}
+	}
+}

--- a/src/player/MediaKindStore.ts
+++ b/src/player/MediaKindStore.ts
@@ -1,0 +1,238 @@
+/**
+ * Persists probed media kinds (audio vs video vs unsupported) across
+ * Obsidian sessions, so a file probed once never causes a probe - or the
+ * embed swap that follows it - in a later session (issue #39: the
+ * in-memory cache alone made the first open of each file repeat every
+ * session). Entries are validated by file mtime and size, so an edited
+ * or replaced file is transparently re-probed.
+ *
+ * The cache lives in its own JSON file in the plugin folder, NOT in
+ * data.json: settings persistence carries backup/recovery machinery that
+ * a frequently rewritten, losable cache must not trigger or block. A
+ * missing or corrupt cache file is harmless - everything just re-probes.
+ * @module player/MediaKindStore
+ */
+
+import { debounce } from 'obsidian';
+import type { App, TFile } from 'obsidian';
+import { PLUGIN_LOG_PREFIX } from '../constants';
+import { MEDIA_KIND, type MediaKind } from './mediaProbe';
+
+/** Cache file name inside the plugin folder. */
+export const MEDIA_KIND_STORE_FILE = 'media-kinds.json';
+
+/** Debounce window for writing the cache file after a change. */
+const SAVE_DEBOUNCE_MS = 2000;
+
+/**
+ * Entry cap. Oldest entries are evicted first; an evicted file is simply
+ * re-probed, so the cap only bounds the file size, never correctness.
+ */
+const MAX_ENTRIES = 2000;
+
+/** On-disk format version, for future migrations. */
+const STORE_VERSION = 1;
+
+/** A persisted classification with the file stats that validate it. */
+interface StoredEntry {
+	kind: MediaKind;
+	mtime: number;
+	size: number;
+}
+
+/** Shape of the cache file. */
+interface StoreFileShape {
+	version: number;
+	entries: Record<string, StoredEntry>;
+}
+
+/** Runtime guard for entries read from disk. */
+function isValidEntry(entry: unknown): entry is StoredEntry {
+	if (typeof entry !== 'object' || entry === null) {
+		return false;
+	}
+	const candidate = entry as Partial<StoredEntry>;
+	return (
+		typeof candidate.mtime === 'number' &&
+		typeof candidate.size === 'number' &&
+		typeof candidate.kind === 'string' &&
+		Object.values(MEDIA_KIND).includes(candidate.kind)
+	);
+}
+
+/**
+ * Media-kind cache persisted in the plugin folder and validated by file
+ * mtime/size. Inert (never reads or writes) when constructed without a
+ * file path, e.g. when the plugin directory is unknown.
+ */
+export class MediaKindStore {
+	/** Entries in insertion order; the oldest is evicted at the cap. */
+	private readonly entries = new Map<string, StoredEntry>();
+	/** True while in-memory entries differ from the file on disk. */
+	private dirty = false;
+	/** Debounced write that coalesces a burst of probe results. */
+	private readonly scheduleSave = debounce(
+		() => {
+			void this.save();
+		},
+		SAVE_DEBOUNCE_MS,
+		true,
+	);
+
+	/**
+	 * @param app - Obsidian App instance (for the vault adapter)
+	 * @param filePath - Vault-relative cache file path, or null to disable
+	 * persistence entirely
+	 */
+	constructor(
+		private readonly app: App,
+		private readonly filePath: string | null,
+	) {}
+
+	/**
+	 * Loads the cache file. Entries set in this session before the load
+	 * completes win over loaded ones (they are fresher). Any read or
+	 * parse failure leaves the cache empty: files are just re-probed.
+	 */
+	async load(): Promise<void> {
+		if (!this.filePath) {
+			return;
+		}
+		try {
+			if (!(await this.app.vault.adapter.exists(this.filePath))) {
+				return;
+			}
+			const raw = await this.app.vault.adapter.read(this.filePath);
+			const parsed = JSON.parse(raw) as Partial<StoreFileShape> | null;
+			if (
+				parsed?.version !== STORE_VERSION ||
+				typeof parsed.entries !== 'object' ||
+				parsed.entries === null
+			) {
+				return;
+			}
+			for (const [path, entry] of Object.entries(parsed.entries)) {
+				if (!this.entries.has(path) && isValidEntry(entry)) {
+					this.entries.set(path, entry);
+				}
+			}
+		} catch (error) {
+			console.warn(
+				`${PLUGIN_LOG_PREFIX} Failed to read the media-kind cache; media files will be re-probed.`,
+				error,
+			);
+		}
+	}
+
+	/**
+	 * The persisted kind for a file, or null when absent or stale. A
+	 * stale entry (mtime or size changed since it was probed) is dropped
+	 * so the caller re-probes the current content.
+	 * @param file - Media file to look up
+	 */
+	get(file: TFile): MediaKind | null {
+		const entry = this.entries.get(file.path);
+		if (!entry) {
+			return null;
+		}
+		if (entry.mtime !== file.stat.mtime || entry.size !== file.stat.size) {
+			this.entries.delete(file.path);
+			this.markDirty();
+			return null;
+		}
+		return entry.kind;
+	}
+
+	/**
+	 * Records a probed kind with the file's current stats. Re-inserting
+	 * moves the entry to the back of the eviction order.
+	 * @param file - The probed media file
+	 * @param kind - Its probed kind (callers persist confident results only)
+	 */
+	set(file: TFile, kind: MediaKind): void {
+		this.entries.delete(file.path);
+		this.entries.set(file.path, {
+			kind,
+			mtime: file.stat.mtime,
+			size: file.stat.size,
+		});
+		while (this.entries.size > MAX_ENTRIES) {
+			const oldest: string | undefined = this.entries.keys().next().value;
+			if (oldest === undefined) {
+				break;
+			}
+			this.entries.delete(oldest);
+		}
+		this.markDirty();
+	}
+
+	/**
+	 * Moves an entry to a file's new path. The content is unchanged by a
+	 * rename, so the stored stats stay valid.
+	 * @param oldPath - Previous vault path
+	 * @param newPath - New vault path
+	 */
+	handleRename(oldPath: string, newPath: string): void {
+		const entry = this.entries.get(oldPath);
+		if (!entry) {
+			return;
+		}
+		this.entries.delete(oldPath);
+		this.entries.set(newPath, entry);
+		this.markDirty();
+	}
+
+	/**
+	 * Drops the entry of a deleted file.
+	 * @param path - Vault path of the deleted file
+	 */
+	handleDelete(path: string): void {
+		if (this.entries.delete(path)) {
+			this.markDirty();
+		}
+	}
+
+	/**
+	 * Writes any pending change immediately. Called on plugin unload so a
+	 * probe result from the final debounce window is not lost.
+	 */
+	flush(): void {
+		this.scheduleSave.run();
+	}
+
+	/** Marks the cache changed and schedules the debounced write. */
+	private markDirty(): void {
+		if (!this.filePath) {
+			return;
+		}
+		this.dirty = true;
+		this.scheduleSave();
+	}
+
+	/**
+	 * Writes the cache file. A failed write keeps the dirty flag so the
+	 * next change retries; the cache is best-effort by design.
+	 */
+	private async save(): Promise<void> {
+		if (!this.filePath || !this.dirty) {
+			return;
+		}
+		this.dirty = false;
+		const shape: StoreFileShape = {
+			version: STORE_VERSION,
+			entries: Object.fromEntries(this.entries),
+		};
+		try {
+			await this.app.vault.adapter.write(
+				this.filePath,
+				JSON.stringify(shape),
+			);
+		} catch (error) {
+			this.dirty = true;
+			console.warn(
+				`${PLUGIN_LOG_PREFIX} Failed to write the media-kind cache.`,
+				error,
+			);
+		}
+	}
+}

--- a/src/player/mediaProbe.ts
+++ b/src/player/mediaProbe.ts
@@ -24,20 +24,34 @@ export type MediaKind = (typeof MEDIA_KIND)[keyof typeof MEDIA_KIND];
 const PROBE_TIMEOUT_MS = 4000;
 
 /**
+ * A probe's classification plus whether it came from real metadata.
+ * A timeout fallback is usable for this session but must not be
+ * persisted, or a slow-loading video would stay misclassified as audio
+ * across sessions.
+ */
+export interface MediaProbeResult {
+	/** The media classification. */
+	kind: MediaKind;
+	/** True when derived from metadata/error, false on the timeout fallback. */
+	confident: boolean;
+}
+
+/**
  * Loads a media resource's metadata to classify it. A video track (non
  * zero dimensions) marks it as video; metadata without video is audio; a
  * load error is unsupported. Resolves to audio if metadata never arrives,
- * so a slow probe still yields the enhanced player.
+ * so a slow probe still yields the enhanced player - but flagged as not
+ * confident, so the fallback is never persisted as the file's true kind.
  * @param resourceUrl - Resource URL from app.vault.getResourcePath
  */
-export function probeMediaKind(resourceUrl: string): Promise<MediaKind> {
+export function probeMediaKind(resourceUrl: string): Promise<MediaProbeResult> {
 	return new Promise((resolve) => {
 		const el = activeDocument.createElement('video');
 		el.preload = 'metadata';
 		el.muted = true;
 		let settled = false;
 		let timer = 0;
-		const settle = (kind: MediaKind): void => {
+		const settle = (kind: MediaKind, confident: boolean): void => {
 			if (settled) {
 				return;
 			}
@@ -46,7 +60,7 @@ export function probeMediaKind(resourceUrl: string): Promise<MediaKind> {
 			// Release the probe element's decoder
 			el.removeAttribute('src');
 			el.load();
-			resolve(kind);
+			resolve({ kind, confident });
 		};
 		el.addEventListener(
 			'loadedmetadata',
@@ -55,6 +69,7 @@ export function probeMediaKind(resourceUrl: string): Promise<MediaKind> {
 					el.videoWidth > 0 && el.videoHeight > 0
 						? MEDIA_KIND.video
 						: MEDIA_KIND.audio,
+					true,
 				);
 			},
 			{ once: true },
@@ -62,12 +77,12 @@ export function probeMediaKind(resourceUrl: string): Promise<MediaKind> {
 		el.addEventListener(
 			'error',
 			() => {
-				settle(MEDIA_KIND.unsupported);
+				settle(MEDIA_KIND.unsupported, true);
 			},
 			{ once: true },
 		);
 		timer = window.setTimeout(() => {
-			settle(MEDIA_KIND.audio);
+			settle(MEDIA_KIND.audio, false);
 		}, PROBE_TIMEOUT_MS);
 		el.src = resourceUrl;
 	});

--- a/tests/unit/EnhancedPlayerRegistrar.test.ts
+++ b/tests/unit/EnhancedPlayerRegistrar.test.ts
@@ -1,24 +1,32 @@
 /** @jest-environment jsdom */
 /**
- * Regression guard for the recurring "settings apply in one view mode but
- * not the other" / "video shows twice in Live Preview" defects. The fix:
- * the registrar is the single decision point - it returns Obsidian's OWN
- * native embed (unwrapped) for anything it does not enhance, returns the
- * enhanced player for audio, and applies settings by RE-RENDERING the view
- * through Obsidian's own pipeline (identical for Reading view and Live
- * Preview) instead of mutating embed DOM in place.
+ * Regression guard for two recurring defect families in the enhanced
+ * player integration:
  *
- * These tests fail on the previous design (which always wrapped the embed
- * and refreshed in place via a private list) and pass on the re-render
- * design.
+ * 1. "settings apply in one view mode but not the other" / "video shows
+ *    twice in Live Preview": the registrar is the single decision point -
+ *    it returns Obsidian's OWN native embed (unwrapped) for anything it
+ *    knows it will not enhance, the enhanced player for known audio, and
+ *    applies the master toggle by re-rendering through Obsidian's own
+ *    pipeline.
+ *
+ * 2. Issue #39, "background media probe triggers a full note rebuild":
+ *    a probe verdict must NEVER re-render a note. A not-yet-probed file
+ *    renders inside a MediaEmbedShell that upgrades this one embed to the
+ *    enhanced player in place; leaf.rebuildView() is reserved for the
+ *    master toggle flip alone. These tests fail on the previous design,
+ *    which upgraded probed files by rebuilding the embedding leaves.
  */
 
-import { MarkdownView, TFile } from 'obsidian';
+import { Component, MarkdownView, TFile } from 'obsidian';
 import type { App, Plugin, WorkspaceLeaf } from 'obsidian';
 import { EnhancedPlayerRegistrar } from 'src/player/EnhancedPlayerRegistrar';
+import { MediaEmbedShell } from 'src/player/MediaEmbedShell';
 import { AudioPlayer } from 'src/player/AudioPlayer';
 import { AudioPlayerRegistry } from 'src/player/AudioPlayerRegistry';
 import { probeMediaKind } from 'src/player/mediaProbe';
+import type { MediaKind, MediaProbeResult } from 'src/player/mediaProbe';
+import type { MediaKindStore } from 'src/player/MediaKindStore';
 import { AUDIO_EXTENSIONS } from 'src/constants';
 import { DEFAULT_SETTINGS } from 'src/settings/Settings';
 import type { AudioRecorderSettings } from 'src/settings/Settings';
@@ -30,6 +38,7 @@ jest.mock('src/player/AudioPlayer', () => ({
 		__enhanced: true,
 		load: jest.fn(),
 		unload: jest.fn(),
+		loadFile: jest.fn(),
 	})),
 }));
 
@@ -41,14 +50,41 @@ jest.mock('src/player/mediaProbe', () => ({
 const probeMock = jest.mocked(probeMediaKind);
 const audioPlayerMock = jest.mocked(AudioPlayer);
 
-/** Resolves after the debounced re-render timer has fired. */
+/** Builds a probe result; probes are confident unless stated otherwise. */
+function probeResult(kind: MediaKind, confident = true): MediaProbeResult {
+	return { kind, confident };
+}
+
+/** Resolves after the probe microtasks and the re-render debounce. */
 function flush(): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, 120));
 }
 
-/** A native embed instance tagged with the file extension that produced it. */
-interface NativeInstance {
-	__native: string;
+/**
+ * A native embed instance: a real Component (so a shell can host and
+ * unload it) tagged with the extension that produced it.
+ */
+class NativeEmbed extends Component {
+	readonly __native: string;
+	/** Set when the shell (or Obsidian) unloaded this embed. */
+	unloaded = false;
+	readonly loadFile = jest.fn();
+
+	constructor(extension: string) {
+		super();
+		this.__native = extension;
+	}
+
+	override onunload(): void {
+		this.unloaded = true;
+	}
+}
+
+/** The mocked enhanced-player instance shape. */
+interface EnhancedInstance {
+	__enhanced: boolean;
+	load: jest.Mock;
+	loadFile: jest.Mock;
 }
 
 /** Builds a MarkdownView stub for a given mode with re-render spies. */
@@ -70,18 +106,37 @@ function viewStub(
 	});
 }
 
+/** A fully mocked persistent media-kind store. */
+function kindStoreStub(): jest.Mocked<
+	Pick<
+		MediaKindStore,
+		'load' | 'get' | 'set' | 'handleRename' | 'handleDelete' | 'flush'
+	>
+> {
+	return {
+		load: jest.fn().mockResolvedValue(undefined),
+		get: jest.fn().mockReturnValue(null),
+		set: jest.fn(),
+		handleRename: jest.fn(),
+		handleDelete: jest.fn(),
+		flush: jest.fn(),
+	};
+}
+
 /**
  * Builds a registrar wired to fakes and registers it. Returns the installed
  * embed creator plus the spies needed to assert behaviour.
  */
-function setup(enabled = true): {
+function setup(
+	enabled = true,
+	kindStore: ReturnType<typeof kindStoreStub> | null = null,
+): {
 	registrar: EnhancedPlayerRegistrar;
 	creator: (info: EmbedInfo, file: TFile, subpath: string) => unknown;
 	nativeCreator: jest.Mock;
 	settings: AudioRecorderSettings;
 	leaves: { preview: WorkspaceLeaf; source: WorkspaceLeaf };
 	getLeaves: jest.Mock;
-	embedsByNote: Record<string, { embeds: Array<{ link: string }> }>;
 } {
 	const settings: AudioRecorderSettings = {
 		...DEFAULT_SETTINGS,
@@ -89,9 +144,8 @@ function setup(enabled = true): {
 	};
 
 	const nativeCreator = jest.fn(
-		(_info: EmbedInfo, file: TFile): NativeInstance => ({
-			__native: file.extension,
-		}),
+		(_info: EmbedInfo, file: TFile): NativeEmbed =>
+			new NativeEmbed(file.extension),
 	);
 
 	const embedByExtension: Record<string, unknown> = {};
@@ -99,8 +153,6 @@ function setup(enabled = true): {
 		embedByExtension[ext] = nativeCreator;
 	}
 
-	// The preview note embeds the recording; the source note does not, so a
-	// probe upgrade should rebuild only the preview leaf (scoped re-render).
 	const previewLeaf = {
 		view: viewStub('preview', 'note.md'),
 		rebuildView: jest.fn(),
@@ -111,10 +163,6 @@ function setup(enabled = true): {
 	} as unknown as WorkspaceLeaf;
 	const getLeaves = jest.fn(() => [previewLeaf, sourceLeaf]);
 
-	const embedsByNote: Record<string, { embeds: Array<{ link: string }> }> = {
-		'note.md': { embeds: [{ link: 'recording.mp4' }] },
-		'other.md': { embeds: [] },
-	};
 	const app = {
 		embedRegistry: { embedByExtension },
 		vault: {
@@ -123,8 +171,7 @@ function setup(enabled = true): {
 			on: jest.fn(() => ({})),
 		},
 		metadataCache: {
-			getFileCache: (file: { path: string }) =>
-				embedsByNote[file.path] ?? { embeds: [] },
+			getFileCache: () => ({ embeds: [] }),
 			getFirstLinkpathDest: (linkPath: string) => ({ path: linkPath }),
 		},
 		workspace: {
@@ -150,6 +197,7 @@ function setup(enabled = true): {
 		app,
 		() => settings,
 		markerStore,
+		kindStore,
 	);
 	registrar.register();
 
@@ -166,7 +214,6 @@ function setup(enabled = true): {
 		settings,
 		leaves: { preview: previewLeaf, source: sourceLeaf },
 		getLeaves,
-		embedsByNote,
 	};
 }
 
@@ -182,6 +229,13 @@ function fileOf(extension: string): TFile {
 	return fileFromPath(`recording.${extension}`);
 }
 
+function embedInfo(): EmbedInfo {
+	return {
+		containerEl: document.createElement('div'),
+		sourcePath: 'note.md',
+	};
+}
+
 const info: EmbedInfo = {
 	containerEl: document.createElement('div'),
 	sourcePath: 'note.md',
@@ -193,45 +247,87 @@ beforeEach(() => {
 });
 
 describe('EnhancedPlayerRegistrar embed creation', () => {
-	it("returns Obsidian's own native embed for a video file (no wrapper, no double)", () => {
-		probeMock.mockResolvedValue('video');
-		const { creator, nativeCreator } = setup(true);
-
-		const result = creator(info, fileOf('mp4'), '') as NativeInstance;
-
-		// The unwrapped native instance - exactly what Obsidian renders on its
-		// own, so Live Preview cannot double it
-		expect(result.__native).toBe('mp4');
-		expect(nativeCreator).toHaveBeenCalledTimes(1);
-		expect(audioPlayerMock).not.toHaveBeenCalled();
-	});
-
-	it('probes content for an audio-extension file too (never trusts the extension)', () => {
-		probeMock.mockResolvedValue('audio');
+	it('hosts the native embed in a shell while a file is unprobed (never trusts the extension)', () => {
+		probeMock.mockResolvedValue(probeResult('audio'));
 		const { creator, nativeCreator } = setup(true);
 
 		// A wav can in principle carry a video track, so it must be probed,
-		// not enhanced on faith: render native first, probe the content
-		const result = creator(info, fileOf('wav'), '') as NativeInstance;
+		// not enhanced on faith: the native embed shows while the probe runs
+		const result = creator(info, fileOf('wav'), '');
 
-		expect(result.__native).toBe('wav');
+		expect(result).toBeInstanceOf(MediaEmbedShell);
 		expect(nativeCreator).toHaveBeenCalledTimes(1);
+		expect(probeMock).toHaveBeenCalledTimes(1);
+		// The player is not built before the probe settles
+		expect(audioPlayerMock).not.toHaveBeenCalled();
+	});
+
+	it('upgrades the embed IN PLACE when the probe finds audio - no note re-render (issue #39)', async () => {
+		probeMock.mockResolvedValue(probeResult('audio'));
+		const { creator, nativeCreator, getLeaves, leaves } = setup(true);
+
+		const shell = creator(info, fileOf('wav'), '') as Component;
+		shell.load();
+
+		await flush();
+
+		// The shell swapped this one embed: the native child was unloaded
+		// (stopping any playback) and the player took over the container
+		const native = nativeCreator.mock.results[0].value as NativeEmbed;
+		expect(native.unloaded).toBe(true);
+		expect(audioPlayerMock).toHaveBeenCalledTimes(1);
+		const player = audioPlayerMock.mock.results[0]
+			.value as unknown as EnhancedInstance;
+		expect(player.load).toHaveBeenCalled();
+		// The core of issue #39: no leaf was inspected or rebuilt, so a
+		// large embedding note is never re-rendered by a probe verdict
+		expect(getLeaves).not.toHaveBeenCalled();
+		expect(
+			(leaves.preview as unknown as { rebuildView: jest.Mock })
+				.rebuildView,
+		).not.toHaveBeenCalled();
+	});
+
+	it('keeps the native embed for a video file - no player, no re-render', async () => {
+		probeMock.mockResolvedValue(probeResult('video'));
+		const { creator, nativeCreator, getLeaves } = setup(true);
+
+		const shell = creator(info, fileOf('mp4'), '') as Component;
+		shell.load();
+
+		await flush();
+
+		const native = nativeCreator.mock.results[0].value as NativeEmbed;
+		expect(native.unloaded).toBe(false);
+		expect(audioPlayerMock).not.toHaveBeenCalled();
+		expect(getLeaves).not.toHaveBeenCalled();
+	});
+
+	it("returns Obsidian's own native embed unwrapped once a file is known video (no wrapper, no double)", async () => {
+		probeMock.mockResolvedValue(probeResult('video'));
+		const { creator } = setup(true);
+
+		creator(info, fileOf('mp4'), '');
+		await flush();
+
+		// The kind is cached now: the next render gets exactly what Obsidian
+		// renders on its own, so Live Preview cannot double it
+		const second = creator(info, fileOf('mp4'), '') as NativeEmbed;
+		expect(second).toBeInstanceOf(NativeEmbed);
+		expect(second.__native).toBe('mp4');
 		expect(probeMock).toHaveBeenCalledTimes(1);
 	});
 
-	it('renders enhanced once a probe has classified the file as audio', async () => {
-		probeMock.mockResolvedValue('audio');
+	it('renders enhanced directly once a probe has classified the file as audio', async () => {
+		probeMock.mockResolvedValue(probeResult('audio'));
 		const { creator } = setup(true);
 
-		// First render probes and shows native
-		const first = creator(info, fileOf('wav'), '') as NativeInstance;
-		expect(first.__native).toBe('wav');
-
+		creator(info, fileOf('wav'), '');
 		await flush();
 		probeMock.mockClear();
 
-		// A later render of the same file (as Obsidian does after the
-		// re-render) is enhanced now, with no further probe
+		// A later render of the same file is enhanced from the start, with
+		// no further probe and no shell
 		const second = creator(info, fileOf('wav'), '') as {
 			__enhanced?: boolean;
 		};
@@ -242,10 +338,88 @@ describe('EnhancedPlayerRegistrar embed creation', () => {
 	it('returns the native embed for every file when the feature is disabled', () => {
 		const { creator } = setup(false);
 
-		const result = creator(info, fileOf('wav'), '') as NativeInstance;
+		const result = creator(info, fileOf('wav'), '') as NativeEmbed;
 
+		expect(result).toBeInstanceOf(NativeEmbed);
 		expect(result.__native).toBe('wav');
+		expect(probeMock).not.toHaveBeenCalled();
 		expect(audioPlayerMock).not.toHaveBeenCalled();
+	});
+
+	it('shares one probe across multiple embeds of the same file and upgrades each in place', async () => {
+		probeMock.mockResolvedValue(probeResult('audio'));
+		const { creator } = setup(true);
+
+		const first = creator(embedInfo(), fileOf('wav'), '') as Component;
+		const second = creator(embedInfo(), fileOf('wav'), '') as Component;
+		expect(probeMock).toHaveBeenCalledTimes(1);
+		first.load();
+		second.load();
+
+		await flush();
+
+		expect(audioPlayerMock).toHaveBeenCalledTimes(2);
+	});
+
+	it('does not swap after the embed was unloaded (note closed mid-probe)', async () => {
+		let resolveProbe!: (result: MediaProbeResult) => void;
+		probeMock.mockImplementation(
+			() =>
+				new Promise<MediaProbeResult>((resolve) => {
+					resolveProbe = resolve;
+				}),
+		);
+		const { creator } = setup(true);
+
+		const shell = creator(info, fileOf('wav'), '') as Component;
+		shell.load();
+		shell.unload();
+		resolveProbe(probeResult('audio'));
+
+		await flush();
+
+		expect(audioPlayerMock).not.toHaveBeenCalled();
+	});
+
+	it('does not swap when the feature was disabled while the probe ran', async () => {
+		let resolveProbe!: (result: MediaProbeResult) => void;
+		probeMock.mockImplementation(
+			() =>
+				new Promise<MediaProbeResult>((resolve) => {
+					resolveProbe = resolve;
+				}),
+		);
+		const { creator, settings } = setup(true);
+
+		const shell = creator(info, fileOf('wav'), '') as Component;
+		shell.load();
+		settings.enhancedPlayerEnabled = false;
+		resolveProbe(probeResult('audio'));
+
+		await flush();
+
+		expect(audioPlayerMock).not.toHaveBeenCalled();
+	});
+
+	it('forwards loadFile to the hosted embed and replays it after the swap', async () => {
+		probeMock.mockResolvedValue(probeResult('audio'));
+		const { creator, nativeCreator } = setup(true);
+
+		const shell = creator(info, fileOf('wav'), '') as MediaEmbedShell;
+		shell.load();
+		const file = fileOf('wav');
+		void shell.loadFile(file);
+
+		const native = nativeCreator.mock.results[0].value as NativeEmbed;
+		expect(native.loadFile).toHaveBeenCalledWith(file);
+
+		await flush();
+
+		// Live Preview drove the old child through loadFile, so the new
+		// child gets the same call and renders
+		const player = audioPlayerMock.mock.results[0]
+			.value as unknown as EnhancedInstance;
+		expect(player.loadFile).toHaveBeenCalledWith(file);
 	});
 });
 
@@ -312,88 +486,81 @@ describe('EnhancedPlayerRegistrar re-renders only when needed', () => {
 		}
 	});
 
-	it('upgrades an audio-only container to enhanced by re-rendering after the probe', async () => {
-		probeMock.mockResolvedValue('audio');
-		const { creator, getLeaves } = setup(true);
+	it('primes a saved recording so its embed is enhanced from the start - still no re-render', async () => {
+		probeMock.mockResolvedValue(probeResult('audio'));
+		const { registrar, creator, getLeaves } = setup(true);
 
-		// First render of a not-yet-probed file shows native and probes
-		creator(info, fileOf('mp4'), '');
+		registrar.primeSavedRecordingsForEnhancement(['recording.wav']);
 		expect(probeMock).toHaveBeenCalledTimes(1);
-
 		await flush();
 
-		// The probe found audio, so a re-render is requested to upgrade it
-		expect(getLeaves).toHaveBeenCalledWith('markdown');
-	});
-
-	it('primes a saved recording for enhancement without waiting for native embed render', async () => {
-		probeMock.mockResolvedValue('audio');
-		const { registrar, embedsByNote, leaves } = setup(true);
-		const previewLeaf = leaves.preview as unknown as {
-			rebuildView: jest.Mock;
+		// The kind was probed before Obsidian ever created the embed, so
+		// the embed is built enhanced directly - no native pass, no swap
+		const embed = creator(info, fileOf('wav'), '') as {
+			__enhanced?: boolean;
 		};
-		embedsByNote['note.md'] = { embeds: [] };
-
-		registrar.primeSavedRecordingsForEnhancement(
-			['recording.mp4'],
-			'note.md',
-		);
-		await flush();
-
+		expect(embed.__enhanced).toBe(true);
 		expect(probeMock).toHaveBeenCalledTimes(1);
-		expect(previewLeaf.rebuildView).toHaveBeenCalledTimes(1);
-		expect(
-			(leaves.source as unknown as { rebuildView: jest.Mock })
-				.rebuildView,
-		).not.toHaveBeenCalled();
-	});
-
-	it('re-renders only the leaves that embed the probed file (scoped upgrade)', async () => {
-		probeMock.mockResolvedValue('audio');
-		const { creator, leaves } = setup(true);
-
-		// recording.mp4 is embedded only by the preview note (note.md)
-		creator(info, fileOf('mp4'), '');
-		await flush();
-
-		expect(
-			(leaves.preview as unknown as { rebuildView: jest.Mock })
-				.rebuildView,
-		).toHaveBeenCalledTimes(1);
-		// The source note (other.md) does not embed it, so it is left alone
-		expect(
-			(leaves.source as unknown as { rebuildView: jest.Mock })
-				.rebuildView,
-		).not.toHaveBeenCalled();
-	});
-
-	it('retries a scoped upgrade when metadata has not indexed the new embed yet', async () => {
-		probeMock.mockResolvedValue('audio');
-		const { creator, embedsByNote, leaves } = setup(true);
-		const previewLeaf = leaves.preview as unknown as {
-			rebuildView: jest.Mock;
-		};
-		const rebuildView = previewLeaf.rebuildView;
-		embedsByNote['note.md'] = { embeds: [] };
-
-		creator(info, fileOf('mp4'), '');
-		await flush();
-
-		expect(rebuildView).not.toHaveBeenCalled();
-
-		embedsByNote['note.md'] = { embeds: [{ link: 'recording.mp4' }] };
-		await flush();
-
-		expect(rebuildView).toHaveBeenCalledTimes(1);
-	});
-
-	it('does not re-render after probing a real video file', async () => {
-		probeMock.mockResolvedValue('video');
-		const { creator, getLeaves } = setup(true);
-
-		creator(info, fileOf('mp4'), '');
-		await flush();
-
 		expect(getLeaves).not.toHaveBeenCalled();
+	});
+});
+
+describe('EnhancedPlayerRegistrar persistent media kinds', () => {
+	it('loads the persisted store on register', () => {
+		const kindStore = kindStoreStub();
+		setup(true, kindStore);
+
+		expect(kindStore.load).toHaveBeenCalledTimes(1);
+	});
+
+	it('renders enhanced immediately when the store knows the file is audio (no probe, no swap)', () => {
+		const kindStore = kindStoreStub();
+		kindStore.get.mockReturnValue('audio');
+		const { creator } = setup(true, kindStore);
+
+		const embed = creator(info, fileOf('wav'), '') as {
+			__enhanced?: boolean;
+		};
+
+		expect(embed.__enhanced).toBe(true);
+		expect(probeMock).not.toHaveBeenCalled();
+	});
+
+	it('persists a confident probe result', async () => {
+		probeMock.mockResolvedValue(probeResult('audio'));
+		const kindStore = kindStoreStub();
+		const { creator } = setup(true, kindStore);
+
+		const shell = creator(info, fileOf('wav'), '') as Component;
+		shell.load();
+		await flush();
+
+		expect(kindStore.set).toHaveBeenCalledWith(
+			expect.objectContaining({ path: 'recording.wav' }),
+			'audio',
+		);
+	});
+
+	it('does NOT persist a timeout fallback, but still upgrades this session', async () => {
+		probeMock.mockResolvedValue(probeResult('audio', false));
+		const kindStore = kindStoreStub();
+		const { creator } = setup(true, kindStore);
+
+		const shell = creator(info, fileOf('wav'), '') as Component;
+		shell.load();
+		await flush();
+
+		// A slow-loading video must not be remembered as audio forever
+		expect(kindStore.set).not.toHaveBeenCalled();
+		expect(audioPlayerMock).toHaveBeenCalledTimes(1);
+	});
+
+	it('flushes pending store writes on dispose', () => {
+		const kindStore = kindStoreStub();
+		const { registrar } = setup(true, kindStore);
+
+		registrar.dispose();
+
+		expect(kindStore.flush).toHaveBeenCalledTimes(1);
 	});
 });

--- a/tests/unit/MediaKindStore.test.ts
+++ b/tests/unit/MediaKindStore.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Tests for the cross-session media-kind cache (issue #39: without it,
+ * the first probe of every file - and the embed work behind it - repeated
+ * every Obsidian session). The cache must be strictly best-effort: stale
+ * entries are dropped by mtime/size, and a missing or corrupt file only
+ * means files are re-probed.
+ */
+
+import { TFile } from 'obsidian';
+import type { App } from 'obsidian';
+import { MediaKindStore } from 'src/player/MediaKindStore';
+
+const STORE_PATH = '.obsidian/plugins/advanced-audio-recorder/media-kinds.json';
+
+/** In-memory adapter backing so two stores can share "disk". */
+function makeApp(files: Map<string, string> = new Map()): {
+	app: App;
+	files: Map<string, string>;
+	write: jest.Mock;
+} {
+	const write = jest.fn((path: string, data: string) => {
+		files.set(path, data);
+		return Promise.resolve();
+	});
+	const app = {
+		vault: {
+			adapter: {
+				exists: (path: string) => Promise.resolve(files.has(path)),
+				read: (path: string) => {
+					const data = files.get(path);
+					return data === undefined
+						? Promise.reject(new Error('missing'))
+						: Promise.resolve(data);
+				},
+				write,
+			},
+		},
+	} as unknown as App;
+	return { app, files, write };
+}
+
+/** Builds a TFile stub with the stats the store validates against. */
+function fileWithStat(path: string, mtime: number, size: number): TFile {
+	return Object.assign(Object.create(TFile.prototype), {
+		path,
+		stat: { ctime: 0, mtime, size },
+	}) as TFile;
+}
+
+describe('MediaKindStore', () => {
+	it('persists entries and loads them back in a later session', async () => {
+		const { app, files } = makeApp();
+		const first = new MediaKindStore(app, STORE_PATH);
+		first.set(fileWithStat('a.webm', 111, 5), 'audio');
+		first.set(fileWithStat('b.mp4', 222, 9), 'video');
+		first.flush();
+		await Promise.resolve();
+		expect(files.has(STORE_PATH)).toBe(true);
+
+		// A fresh store (next session) reads the same file back
+		const second = new MediaKindStore(app, STORE_PATH);
+		await second.load();
+		expect(second.get(fileWithStat('a.webm', 111, 5))).toBe('audio');
+		expect(second.get(fileWithStat('b.mp4', 222, 9))).toBe('video');
+	});
+
+	it('drops an entry whose mtime or size changed (file was edited/replaced)', () => {
+		const { app } = makeApp();
+		const store = new MediaKindStore(app, STORE_PATH);
+		store.set(fileWithStat('a.webm', 111, 5), 'audio');
+
+		expect(store.get(fileWithStat('a.webm', 999, 5))).toBeNull();
+		// The stale entry was dropped, so even the original stats miss now
+		// and the caller re-probes the current content
+		expect(store.get(fileWithStat('a.webm', 111, 5))).toBeNull();
+	});
+
+	it('lets entries set before load completes win over loaded ones', async () => {
+		const { app, files } = makeApp();
+		files.set(
+			STORE_PATH,
+			JSON.stringify({
+				version: 1,
+				entries: { 'a.webm': { kind: 'video', mtime: 1, size: 1 } },
+			}),
+		);
+		const store = new MediaKindStore(app, STORE_PATH);
+
+		// A probe from this session lands before the async load finishes
+		store.set(fileWithStat('a.webm', 2, 2), 'audio');
+		await store.load();
+
+		expect(store.get(fileWithStat('a.webm', 2, 2))).toBe('audio');
+	});
+
+	it('tolerates a corrupt cache file (everything just re-probes)', async () => {
+		const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+		try {
+			const { app, files } = makeApp();
+			files.set(STORE_PATH, 'not json at all');
+			const store = new MediaKindStore(app, STORE_PATH);
+
+			await expect(store.load()).resolves.toBeUndefined();
+			expect(store.get(fileWithStat('a.webm', 1, 1))).toBeNull();
+		} finally {
+			warnSpy.mockRestore();
+		}
+	});
+
+	it('ignores a cache file with an unknown version or malformed entries', async () => {
+		const { app, files } = makeApp();
+		files.set(
+			STORE_PATH,
+			JSON.stringify({
+				version: 999,
+				entries: { 'a.webm': { kind: 'audio', mtime: 1, size: 1 } },
+			}),
+		);
+		const store = new MediaKindStore(app, STORE_PATH);
+		await store.load();
+		expect(store.get(fileWithStat('a.webm', 1, 1))).toBeNull();
+
+		files.set(
+			STORE_PATH,
+			JSON.stringify({
+				version: 1,
+				entries: {
+					'bad-kind.webm': { kind: 'noise', mtime: 1, size: 1 },
+					'bad-stat.webm': { kind: 'audio', mtime: 'x', size: 1 },
+					'good.webm': { kind: 'audio', mtime: 1, size: 1 },
+				},
+			}),
+		);
+		const second = new MediaKindStore(app, STORE_PATH);
+		await second.load();
+		expect(second.get(fileWithStat('bad-kind.webm', 1, 1))).toBeNull();
+		expect(second.get(fileWithStat('bad-stat.webm', 1, 1))).toBeNull();
+		expect(second.get(fileWithStat('good.webm', 1, 1))).toBe('audio');
+	});
+
+	it('moves an entry on rename and drops it on delete', () => {
+		const { app } = makeApp();
+		const store = new MediaKindStore(app, STORE_PATH);
+		store.set(fileWithStat('old.webm', 111, 5), 'audio');
+
+		store.handleRename('old.webm', 'new.webm');
+		expect(store.get(fileWithStat('old.webm', 111, 5))).toBeNull();
+		expect(store.get(fileWithStat('new.webm', 111, 5))).toBe('audio');
+
+		store.handleDelete('new.webm');
+		expect(store.get(fileWithStat('new.webm', 111, 5))).toBeNull();
+	});
+
+	it('evicts the oldest entries beyond the cap', () => {
+		const { app } = makeApp();
+		const store = new MediaKindStore(app, STORE_PATH);
+		// One over the cap: the first inserted entry must give way
+		for (let i = 0; i <= 2000; i++) {
+			store.set(fileWithStat(`file-${String(i)}.webm`, i, i), 'audio');
+		}
+
+		expect(store.get(fileWithStat('file-0.webm', 0, 0))).toBeNull();
+		expect(store.get(fileWithStat('file-2000.webm', 2000, 2000))).toBe(
+			'audio',
+		);
+	});
+
+	it('is inert without a file path (plugin directory unknown)', async () => {
+		const { app, write } = makeApp();
+		const store = new MediaKindStore(app, null);
+
+		store.set(fileWithStat('a.webm', 1, 1), 'audio');
+		store.flush();
+		await store.load();
+		await Promise.resolve();
+
+		expect(write).not.toHaveBeenCalled();
+		// The in-memory side still works for the current session
+		expect(store.get(fileWithStat('a.webm', 1, 1))).toBe('audio');
+	});
+
+	it('keeps the change pending when a write fails, and retries on the next flush', async () => {
+		const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+		try {
+			const { app, write } = makeApp();
+			write.mockRejectedValueOnce(new Error('disk full'));
+			const store = new MediaKindStore(app, STORE_PATH);
+
+			store.set(fileWithStat('a.webm', 1, 1), 'audio');
+			store.flush();
+			await Promise.resolve();
+			await Promise.resolve();
+
+			// The failed write left the store dirty; another change + flush
+			// writes everything
+			store.set(fileWithStat('b.webm', 2, 2), 'audio');
+			store.flush();
+			await Promise.resolve();
+			expect(write).toHaveBeenCalledTimes(2);
+			const lastPayload = JSON.parse(
+				write.mock.calls[1][1] as string,
+			) as { entries: Record<string, unknown> };
+			expect(Object.keys(lastPayload.entries)).toEqual([
+				'a.webm',
+				'b.webm',
+			]);
+		} finally {
+			warnSpy.mockRestore();
+		}
+	});
+});

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -365,7 +365,7 @@ describe('AudioRecorderPlugin settings persistence', () => {
 
 		expect(
 			registrar.primeSavedRecordingsForEnhancement,
-		).toHaveBeenCalledWith(['recordings/fresh.webm'], 'notes/daily.md');
+		).toHaveBeenCalledWith(['recordings/fresh.webm']);
 	});
 
 	it('treats a rejected settings read as a failed read', async () => {

--- a/tests/unit/mediaProbe.test.ts
+++ b/tests/unit/mediaProbe.test.ts
@@ -75,20 +75,29 @@ describe('probeMediaKind', () => {
 		fakeVideo.videoWidth = 1920;
 		fakeVideo.videoHeight = 1080;
 		fakeVideo.fire('loadedmetadata');
-		await expect(result).resolves.toBe('video');
+		await expect(result).resolves.toEqual({
+			kind: 'video',
+			confident: true,
+		});
 	});
 
 	it('classifies metadata without video dimensions as audio', async () => {
 		const result = probeMediaKind('app://media');
 		// videoWidth/videoHeight stay 0 -> audio-only
 		fakeVideo.fire('loadedmetadata');
-		await expect(result).resolves.toBe('audio');
+		await expect(result).resolves.toEqual({
+			kind: 'audio',
+			confident: true,
+		});
 	});
 
 	it('classifies a load error as unsupported', async () => {
 		const result = probeMediaKind('app://media');
 		fakeVideo.fire('error');
-		await expect(result).resolves.toBe('unsupported');
+		await expect(result).resolves.toEqual({
+			kind: 'unsupported',
+			confident: true,
+		});
 	});
 
 	it('falls back to audio when metadata never arrives (timeout)', async () => {
@@ -96,7 +105,11 @@ describe('probeMediaKind', () => {
 		try {
 			const result = probeMediaKind('app://media');
 			jest.advanceTimersByTime(4000);
-			await expect(result).resolves.toBe('audio');
+			// The fallback is usable now but flagged, so it is never persisted
+			await expect(result).resolves.toEqual({
+				kind: 'audio',
+				confident: false,
+			});
 		} finally {
 			jest.useRealTimers();
 		}
@@ -119,7 +132,10 @@ describe('probeMediaKind', () => {
 		fakeVideo.videoHeight = 100;
 		fakeVideo.fire('loadedmetadata'); // first settle -> video
 		fakeVideo.fire('error'); // must be ignored
-		await expect(result).resolves.toBe('video');
+		await expect(result).resolves.toEqual({
+			kind: 'video',
+			confident: true,
+		});
 		expect(fakeVideo.load).toHaveBeenCalledTimes(1);
 	});
 });


### PR DESCRIPTION
## Summary

This PR resolves issue #39 by eliminating unnecessary note re-renders when media files are probed for their kind (audio vs video). Previously, when a file was probed and found to be audio-only, the entire embedding note would be rebuilt via `leaf.rebuildView()`, causing significant lag for large notes embedding even short recordings. The fix uses in-place embed upgrades within a new `MediaEmbedShell` component, ensuring only the specific embed is swapped when a probe completes.

## Key Changes

- **MediaEmbedShell component**: New wrapper that hosts Obsidian's native embed while a file is being probed. When the probe confirms audio, it upgrades to the enhanced player in place without re-rendering the note. Video and unsupported files remain as native embeds.

- **MediaKindStore**: New persistent cross-session cache for probed media kinds, validated by file mtime/size. Eliminates repeated probes of the same file across Obsidian sessions and prevents the embed swap work from repeating on every session start.

- **Probe result structure**: `probeMediaKind()` now returns a `MediaProbeResult` object with both the `kind` and a `confident` flag. Confident results (from actual metadata or errors) are persisted; timeout fallbacks are session-only to avoid misclassifying slow-loading videos.

- **Simplified registrar logic**: Removed complex scoped re-render tracking (`pendingRerenderPaths`, `pendingRerenderRetries`, `pendingDirectRerenderNotePaths`, etc.). The registrar now only re-renders all open views when the master toggle flips; probe verdicts never trigger re-renders.

- **Probe deduplication**: In-flight probes are now shared across multiple embeds of the same file via a `probes` Map, preventing concurrent probes and allowing multiple embeds to join a single probe operation.

- **Updated primeSavedRecordingsForEnhancement**: Simplified to accept only audio paths (no longer takes a note path), since the probe-and-upgrade now happens in-place via the shell rather than requiring note-level re-renders.

## Implementation Details

- The shell's `loadFile()` method forwards calls to the current child embed and remembers the file so it can replay the call after swapping to the player.
- Unloading the native child stops any media playback, providing the same guarantee that `rebuildView()` did but scoped to a single embed.
- The media-kind cache file (`media-kinds.json`) lives in the plugin folder, separate from `data.json`, so it doesn't trigger backup/recovery machinery and can be safely lost without data integrity concerns.
- Stale cache entries are automatically dropped when file mtime or size changes, ensuring edited or replaced files are transparently re-probed.

https://claude.ai/code/session_01FesbAspGB6Xv7QBMZjJHnU