### PR TITLE
Audit follow-up: decompose god objects, close remaining findings, adopt TS 6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10326 +1,10326 @@
 {
-  "name": "advanced-audio-recorder",
-  "version": "1.5.0",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {
-    "": {
-      "name": "advanced-audio-recorder",
-      "version": "1.5.0",
-      "license": "MIT",
-      "dependencies": {
-        "@mediabunny/flac-encoder": "1.50.4",
-        "@mediabunny/mp3-encoder": "1.50.4",
-        "mediabunny": "1.50.4"
-      },
-      "devDependencies": {
-        "@types/jest": "30.0.0",
-        "@types/node": "22.19.21",
-        "esbuild": "0.28.1",
-        "eslint": "10.4.1",
-        "eslint-config-prettier": "10.1.8",
-        "eslint-plugin-obsidianmd": "0.3.0",
-        "eslint-plugin-prettier": "^5.5.4",
-        "globals": "^16.5.0",
-        "husky": "^9.0.0",
-        "jest": "30.4.2",
-        "jest-environment-jsdom": "30.4.1",
-        "nano-staged": "0.8.0",
-        "obsidian": "1.12.3",
-        "prettier": "3.8.1",
-        "ts-jest": "29.4.11",
-        "tslib": "2.8.1",
-        "typescript": "^5.9.3",
-        "typescript-eslint": "8.61.0"
-      }
-    },
-    "node_modules/@asamuzakjp/css-color": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
-      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@csstools/css-calc": "^2.1.3",
-        "@csstools/css-color-parser": "^3.0.9",
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3",
-        "lru-cache": "^10.4.3"
-      }
-    },
-    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
-        "@jridgewell/remapping": "^2.3.5",
-        "convert-source-map": "^2.0.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.3",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@babel/generator": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.0.tgz",
-      "integrity": "sha512-vSH118/wwM/pLR38g/Sgk05sNtro6TlTJKuiMXDaZqPUfjTFcudpCOt00IhOfj+1BFAX+UFAlzCU+6WXr3GLFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
-        "@jridgewell/gen-mapping": "^0.3.12",
-        "@jridgewell/trace-mapping": "^0.3.28",
-        "jsesc": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
-        "browserslist": "^4.24.0",
-        "lru-cache": "^5.1.1",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
-      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.29.0"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-async-generators": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
-      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-bigint": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
-      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-class-properties": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
-      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.12.13"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-class-static-block": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
-      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-import-attributes": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
-      "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-import-meta": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
-      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.10.4"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-json-strings": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
-      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
-      "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
-      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.10.4"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
-      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-numeric-separator": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
-      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.10.4"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-object-rest-spread": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
-      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
-      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-optional-chaining": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
-      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-private-property-in-object": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
-      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-top-level-await": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
-      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
-      "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
-        "debug": "^4.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@bcoe/v8-coverage": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
-      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@codemirror/state": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.0.tgz",
-      "integrity": "sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@marijn/find-cluster-break": "^1.0.0"
-      }
-    },
-    "node_modules/@codemirror/view": {
-      "version": "6.38.6",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.6.tgz",
-      "integrity": "sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@codemirror/state": "^6.5.0",
-        "crelt": "^1.0.6",
-        "style-mod": "^4.1.0",
-        "w3c-keyname": "^2.2.4"
-      }
-    },
-    "node_modules/@csstools/color-helpers": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
-      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT-0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@csstools/css-calc": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
-      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.5",
-        "@csstools/css-tokenizer": "^3.0.4"
-      }
-    },
-    "node_modules/@csstools/css-color-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
-      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@csstools/color-helpers": "^5.1.0",
-        "@csstools/css-calc": "^2.1.4"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.5",
-        "@csstools/css-tokenizer": "^3.0.4"
-      }
-    },
-    "node_modules/@csstools/css-parser-algorithms": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
-      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@csstools/css-tokenizer": "^3.0.4"
-      }
-    },
-    "node_modules/@csstools/css-tokenizer": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
-      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
-      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
-      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
-      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
-      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
-      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
-      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
-      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
-      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
-      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
-      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
-      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
-      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
-      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
-      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
-      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
-      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
-      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
-      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
-      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
-      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
-      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
-      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
-      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
-      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
-      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
-      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
-      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eslint-visitor-keys": "^3.4.3"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
-      }
-    },
-    "node_modules/@eslint-community/regexpp": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
-      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@eslint/config-array": {
-      "version": "0.23.5",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
-      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@eslint/object-schema": "^3.0.5",
-        "debug": "^4.3.1",
-        "minimatch": "^10.2.4"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@eslint/config-helpers": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
-      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@eslint/core": "^1.2.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
-    },
-    "node_modules/@eslint/config-helpers/node_modules/@eslint/core": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
-      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
-    },
-    "node_modules/@eslint/core": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/eslintrc": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.14.0",
-        "debug": "^4.3.2",
-        "espree": "^10.0.1",
-        "globals": "^14.0.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
-        "minimatch": "^3.1.5",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "acorn": "^8.15.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
-      }
-    },
-    "node_modules/@eslint/json": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@eslint/json/-/json-0.14.0.tgz",
-      "integrity": "sha512-rvR/EZtvUG3p9uqrSmcDJPYSH7atmWr0RnFWN6m917MAPx82+zQgPUmDu0whPFG6XTyM0vB/hR6c1Q63OaYtCQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@eslint/core": "^0.17.0",
-        "@eslint/plugin-kit": "^0.4.1",
-        "@humanwhocodes/momoa": "^3.3.10",
-        "natural-compare": "^1.4.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/object-schema": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
-      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
-    },
-    "node_modules/@eslint/plugin-kit": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
-      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@eslint/core": "^0.17.0",
-        "levn": "^0.4.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.18.0"
-      }
-    },
-    "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@humanfs/core": "^0.19.1",
-        "@humanwhocodes/retry": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18.18.0"
-      }
-    },
-    "node_modules/@humanwhocodes/module-importer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
-      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.22"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/nzakas"
-      }
-    },
-    "node_modules/@humanwhocodes/momoa": {
-      "version": "3.3.10",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-3.3.10.tgz",
-      "integrity": "sha512-KWiFQpSAqEIyrTXko3hFNLeQvSK8zXlJQzhhxsyVn58WFRYXST99b3Nqnu+ttOtjds2Pl2grUHGpe2NzhPynuQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@humanwhocodes/retry": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
-      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.18"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/nzakas"
-      }
-    },
-    "node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
-      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "camelcase": "^5.3.1",
-        "find-up": "^4.1.0",
-        "get-package-type": "^0.1.0",
-        "js-yaml": "^3.13.1",
-        "resolve-from": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@istanbuljs/schema": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@jest/console": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.4.1.tgz",
-      "integrity": "sha512-v3bhyxUh9Hgmo5p6hAOXe14/R3ZxZDOsvHleh4B07z3m/x4/ngPUXEm9XwK4sF4u+f+P2ORb0Ge+MgpaqRMVDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "jest-message-util": "30.4.1",
-        "jest-util": "30.4.1",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/core": {
-      "version": "30.4.2",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.4.2.tgz",
-      "integrity": "sha512-TZJA6cPJUFxoWhxaLo8t0VX/MZX2wPWr0uIDvLSHIvN4gu9h02vSzqI2kBADG1ExqQlC+cY09xKMSreivvrChQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/console": "30.4.1",
-        "@jest/pattern": "30.4.0",
-        "@jest/reporters": "30.4.1",
-        "@jest/test-result": "30.4.1",
-        "@jest/transform": "30.4.1",
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "ansi-escapes": "^4.3.2",
-        "chalk": "^4.1.2",
-        "ci-info": "^4.2.0",
-        "exit-x": "^0.2.2",
-        "fast-json-stable-stringify": "^2.1.0",
-        "graceful-fs": "^4.2.11",
-        "jest-changed-files": "30.4.1",
-        "jest-config": "30.4.2",
-        "jest-haste-map": "30.4.1",
-        "jest-message-util": "30.4.1",
-        "jest-regex-util": "30.4.0",
-        "jest-resolve": "30.4.1",
-        "jest-resolve-dependencies": "30.4.2",
-        "jest-runner": "30.4.2",
-        "jest-runtime": "30.4.2",
-        "jest-snapshot": "30.4.1",
-        "jest-util": "30.4.1",
-        "jest-validate": "30.4.1",
-        "jest-watcher": "30.4.1",
-        "pretty-format": "30.4.1",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "node-notifier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@jest/diff-sequences": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
-      "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/environment": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
-      "integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/fake-timers": "30.4.1",
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "jest-mock": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/environment-jsdom-abstract": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.4.1.tgz",
-      "integrity": "sha512-dSlKrqug3siYNHVnjwIldShY12wAH3spwRltO/+8VOjg0X+xEq7vOs3DbBs4LRKsu7OH+NUb9kuZUNBF9Ho3TA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/environment": "30.4.1",
-        "@jest/fake-timers": "30.4.1",
-        "@jest/types": "30.4.1",
-        "@types/jsdom": "^21.1.7",
-        "@types/node": "*",
-        "jest-mock": "30.4.1",
-        "jest-util": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "canvas": "^3.0.0",
-        "jsdom": "*"
-      },
-      "peerDependenciesMeta": {
-        "canvas": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@jest/expect": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.4.1.tgz",
-      "integrity": "sha512-ginrj6TMgh2GshLUGCjO94Ptx9HhdZA/I6A9iUfyeLKFtdAjnKzHDgzgP9HYQgbxM1lbXScQ2eUBz2lGeVDPWA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "expect": "30.4.1",
-        "jest-snapshot": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/expect-utils": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
-      "integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/get-type": "30.1.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/fake-timers": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
-      "integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.4.1",
-        "@sinonjs/fake-timers": "^15.4.0",
-        "@types/node": "*",
-        "jest-message-util": "30.4.1",
-        "jest-mock": "30.4.1",
-        "jest-util": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/get-type": {
-      "version": "30.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
-      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/globals": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.4.1.tgz",
-      "integrity": "sha512-ZbuY4cmXC8DkxYjfvT2DbcHWL2T6vmsMhXCDcmTB2T0y0gaezBI77ufq5ZAIdcRkYZ7NEQEDg1xFeKbxUJ5v5Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/environment": "30.4.1",
-        "@jest/expect": "30.4.1",
-        "@jest/types": "30.4.1",
-        "jest-mock": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/pattern": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
-      "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "jest-regex-util": "30.4.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/reporters": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.4.1.tgz",
-      "integrity": "sha512-/SnkPCzEQpUaBH81kjdEdDdo2WZl5hxw+BmLDGWjRkm8o7XlhjwsU36cqwe5PGBE5WYpBvDzRSdXx9rbGuJtNA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "30.4.1",
-        "@jest/test-result": "30.4.1",
-        "@jest/transform": "30.4.1",
-        "@jest/types": "30.4.1",
-        "@jridgewell/trace-mapping": "^0.3.25",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "collect-v8-coverage": "^1.0.2",
-        "exit-x": "^0.2.2",
-        "glob": "^10.5.0",
-        "graceful-fs": "^4.2.11",
-        "istanbul-lib-coverage": "^3.0.0",
-        "istanbul-lib-instrument": "^6.0.0",
-        "istanbul-lib-report": "^3.0.0",
-        "istanbul-lib-source-maps": "^5.0.0",
-        "istanbul-reports": "^3.1.3",
-        "jest-message-util": "30.4.1",
-        "jest-util": "30.4.1",
-        "jest-worker": "30.4.1",
-        "slash": "^3.0.0",
-        "string-length": "^4.0.2",
-        "v8-to-istanbul": "^9.0.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "node-notifier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@jest/schemas": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.34.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/snapshot-utils": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.4.1.tgz",
-      "integrity": "sha512-ObY4ljvQ95mt6iwKtVLetR/4yXiAgl3H4nJxhztr0MTjrN97TwDYrnCp/kF60Ec9HdhkWTHSu+Hg05aXfngpOA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.4.1",
-        "chalk": "^4.1.2",
-        "graceful-fs": "^4.2.11",
-        "natural-compare": "^1.4.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/source-map": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-30.0.1.tgz",
-      "integrity": "sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.25",
-        "callsites": "^3.1.0",
-        "graceful-fs": "^4.2.11"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/test-result": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.4.1.tgz",
-      "integrity": "sha512-/ZG7pgEiOmmWkN9TplKbOu4id2N5lh7FHwRwlkgBVAzGdRH+OkkQ8wX/kIxg4zmd3ZQvAL1RwL2yWsvNYYECTw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/console": "30.4.1",
-        "@jest/types": "30.4.1",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "collect-v8-coverage": "^1.0.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/test-sequencer": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.4.1.tgz",
-      "integrity": "sha512-PeYE+4td5rKjoRPxztObrXU+H8hsjZfxKMXOcmrr34JerSyB/ROOxbbicz8B7A5j9R9VayDnVPvBmedqCsFCdw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/test-result": "30.4.1",
-        "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.4.1",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/transform": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.4.1.tgz",
-      "integrity": "sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.27.4",
-        "@jest/types": "30.4.1",
-        "@jridgewell/trace-mapping": "^0.3.25",
-        "babel-plugin-istanbul": "^7.0.1",
-        "chalk": "^4.1.2",
-        "convert-source-map": "^2.0.0",
-        "fast-json-stable-stringify": "^2.1.0",
-        "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.4.1",
-        "jest-regex-util": "30.4.0",
-        "jest-util": "30.4.1",
-        "pirates": "^4.0.7",
-        "slash": "^3.0.0",
-        "write-file-atomic": "^5.0.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/types": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
-      "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/pattern": "30.4.0",
-        "@jest/schemas": "30.4.1",
-        "@types/istanbul-lib-coverage": "^2.0.6",
-        "@types/istanbul-reports": "^3.0.4",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.33",
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
-      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "node_modules/@jridgewell/remapping": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
-      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.31",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
-      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@marijn/find-cluster-break": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
-      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@mediabunny/flac-encoder": {
-      "version": "1.50.4",
-      "resolved": "https://registry.npmjs.org/@mediabunny/flac-encoder/-/flac-encoder-1.50.4.tgz",
-      "integrity": "sha512-QWLRiLBxOa2QqshvIRN+znIy1pZvfQxDaN3rtE/RYypVV+Qan37diFxw/ICRLAAWYsg83nICmDaOn/1RtBwKxQ==",
-      "license": "MPL-2.0",
-      "funding": {
-        "type": "individual",
-        "url": "https://github.com/sponsors/Vanilagy"
-      },
-      "peerDependencies": {
-        "mediabunny": "^1.0.0"
-      }
-    },
-    "node_modules/@mediabunny/mp3-encoder": {
-      "version": "1.50.4",
-      "resolved": "https://registry.npmjs.org/@mediabunny/mp3-encoder/-/mp3-encoder-1.50.4.tgz",
-      "integrity": "sha512-wGjGq0rm5zPXkLIRZFHcVNBlgRnY4kB1LWTFj8qtrXuZQcLPNqZJOka8Ytggdx7Fn6drWhetFOqA9CHf7PVTww==",
-      "license": "MPL-2.0",
-      "funding": {
-        "type": "individual",
-        "url": "https://github.com/sponsors/Vanilagy"
-      },
-      "peerDependencies": {
-        "mediabunny": "^1.0.0"
-      }
-    },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
-      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
-    },
-    "node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@pkgr/core": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.2.tgz",
-      "integrity": "sha512-fdDH1LSGfZdTH2sxdpVMw31BanV28K/Gry0cVFxaNP77neJSkd82mM8ErPNYs9e+0O7SdHBLTDzDgwUuy18RnQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/unts"
-      }
-    },
-    "node_modules/@rtsao/scc": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
-      "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@sinclair/typebox": {
-      "version": "0.34.49",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
-      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@sinonjs/commons": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
-      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "type-detect": "4.0.8"
-      }
-    },
-    "node_modules/@sinonjs/fake-timers": {
-      "version": "15.4.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
-      "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.1"
-      }
-    },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@types/babel__core": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
-      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.20.7",
-        "@babel/types": "^7.20.7",
-        "@types/babel__generator": "*",
-        "@types/babel__template": "*",
-        "@types/babel__traverse": "*"
-      }
-    },
-    "node_modules/@types/babel__generator": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
-      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__template": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
-      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.1.0",
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__traverse": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
-      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.28.2"
-      }
-    },
-    "node_modules/@types/codemirror": {
-      "version": "5.60.8",
-      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.8.tgz",
-      "integrity": "sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==",
-      "dev": true,
-      "dependencies": {
-        "@types/tern": "*"
-      }
-    },
-    "node_modules/@types/dom-mediacapture-transform": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-transform/-/dom-mediacapture-transform-0.1.11.tgz",
-      "integrity": "sha512-Y2p+nGf1bF2XMttBnsVPHUWzRRZzqUoJAKmiP10b5umnO6DDrWI0BrGDJy1pOHoOULVmGSfFNkQrAlC5dcj6nQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/dom-webcodecs": "*"
-      }
-    },
-    "node_modules/@types/dom-webcodecs": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/@types/dom-webcodecs/-/dom-webcodecs-0.1.13.tgz",
-      "integrity": "sha512-O5hkiFIcjjszPIYyUSyvScyvrBoV3NOEEZx/pMlsu44TKzWNkLVBBxnxJz42in5n3QIolYOcBYFCPZZ0h8SkwQ==",
-      "license": "MIT"
-    },
-    "node_modules/@types/eslint": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
-      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
-    "node_modules/@types/esrecurse": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
-      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/istanbul-lib-coverage": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
-      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/istanbul-lib-report": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
-      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "*"
-      }
-    },
-    "node_modules/@types/istanbul-reports": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
-      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/istanbul-lib-report": "*"
-      }
-    },
-    "node_modules/@types/jest": {
-      "version": "30.0.0",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
-      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "expect": "^30.0.0",
-        "pretty-format": "^30.0.0"
-      }
-    },
-    "node_modules/@types/jsdom": {
-      "version": "21.1.7",
-      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
-      "integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/tough-cookie": "*",
-        "parse5": "^7.0.0"
-      }
-    },
-    "node_modules/@types/json-schema": {
-      "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/json5": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/node": {
-      "version": "22.19.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
-      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@types/node/node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/stack-utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
-      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/tern": {
-      "version": "0.23.9",
-      "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.9.tgz",
-      "integrity": "sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==",
-      "dev": true,
-      "dependencies": {
-        "@types/estree": "*"
-      }
-    },
-    "node_modules/@types/tough-cookie": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
-      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/yargs": {
-      "version": "17.0.35",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
-      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
-    "node_modules/@types/yargs-parser": {
-      "version": "21.0.3",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
-      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.0.tgz",
-      "integrity": "sha512-bFNvl9ZczlVb+wR2Akszf3gHfKVj/8WanXaGJ3UstTA7brNKg0cNdk6X1Psu5V7MZ2oQtzZKOEzIUehaoxbDGw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.61.0",
-        "@typescript-eslint/type-utils": "8.61.0",
-        "@typescript-eslint/utils": "8.61.0",
-        "@typescript-eslint/visitor-keys": "8.61.0",
-        "ignore": "^7.0.5",
-        "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.5.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/parser": "^8.61.0",
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/@typescript-eslint/parser": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.0.tgz",
-      "integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/scope-manager": "8.61.0",
-        "@typescript-eslint/types": "8.61.0",
-        "@typescript-eslint/typescript-estree": "8.61.0",
-        "@typescript-eslint/visitor-keys": "8.61.0",
-        "debug": "^4.4.3"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.0.tgz",
-      "integrity": "sha512-IWdXFHFSb6mlC3HPc7QsLDm5zYEbUla6trDEHf32D3/dnuUyXd87plScSNXSbm0/RxMvObpI17sv/EDTGrGZkA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.61.0",
-        "@typescript-eslint/visitor-keys": "8.61.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.61.0.tgz",
-      "integrity": "sha512-TuBiQYIkd97yBfInHCTKVYMbX4kvEmpOEuixIuzCU9p8BGT1SfyyO0d0IfDMbPIHcjn/hWnusUX5e8v5Xg+X8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.61.0",
-        "@typescript-eslint/typescript-estree": "8.61.0",
-        "@typescript-eslint/utils": "8.61.0",
-        "debug": "^4.4.3",
-        "ts-api-utils": "^2.5.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/types": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.0.tgz",
-      "integrity": "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.0.tgz",
-      "integrity": "sha512-42zatd5qSvvcV1JdDBCLxYRznvP4eIHpPoZXdkPFnAmanA4FuZ5dibSnCBggY8hQnqajPpoGjXFdZ7fIJKQnlA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/project-service": "8.61.0",
-        "@typescript-eslint/tsconfig-utils": "8.61.0",
-        "@typescript-eslint/types": "8.61.0",
-        "@typescript-eslint/visitor-keys": "8.61.0",
-        "debug": "^4.4.3",
-        "minimatch": "^10.2.2",
-        "semver": "^7.7.3",
-        "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.5.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/project-service": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.0.tgz",
-      "integrity": "sha512-DV42F7MLJO6Rax7SK1yg43tcnEfGUrurSpSxKuVX+a3RCTzBlH3fuxprrOJXKCJGAaw82xXocikJ0uQaqwXgGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.61.0",
-        "@typescript-eslint/types": "^8.61.0",
-        "debug": "^4.4.3"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.0.tgz",
-      "integrity": "sha512-O5Amvdv9ztMpxpf+vmFULGG78IE6Qwdr3bCGvqwG4nwc9H2qXkOYJJnRbRHyMkQTjv1d03olqwwwzHLMqpFePQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@typescript-eslint/utils": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.0.tgz",
-      "integrity": "sha512-3bzFt7ImFMW/jVYwJamDoe/dMOdFLSC6pom6rRjdh4SZJEYupyMzem8e7vKZLclLfpHjlwSAXOUxtKxGXUiLqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.61.0",
-        "@typescript-eslint/types": "8.61.0",
-        "@typescript-eslint/typescript-estree": "8.61.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.0.tgz",
-      "integrity": "sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.61.0",
-        "eslint-visitor-keys": "^5.0.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@ungap/structured-clone": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
-      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.12.2.tgz",
-      "integrity": "sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-android-arm64": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.12.2.tgz",
-      "integrity": "sha512-YGCRZv/9GLhwmz6mYDeTsm/92BAyR28l6c2ReweVW5pWgfsitWLY8upvfRlGdoyD8HjeTHSYJWyZGD4KJA/nFQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-darwin-arm64": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.12.2.tgz",
-      "integrity": "sha512-u9DiNT1auQMO20A9SyTuG3wUgQWB9Z7KjAg0uFuCDR1FsAY8A0CG2S6JpHS1xwm/w1G08bjXZDcyOCjv1WAm2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-darwin-x64": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.12.2.tgz",
-      "integrity": "sha512-f7rPLi/T1HVKZu/u6t87lroib16n8vrSzcyxI7lg4BGO9UF26KhQL44sd9eOUgrTYhvRXtWOIZT5PejdPyJfUA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-freebsd-x64": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.12.2.tgz",
-      "integrity": "sha512-BpcOjWCJub6nRZUS2zA20pmLvjtqAtGejETaIyRLiZiQf++cbrjltLA5NN/xaXfqeOBOSlMFbemIl5/S5tljmg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.12.2.tgz",
-      "integrity": "sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.12.2.tgz",
-      "integrity": "sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.12.2.tgz",
-      "integrity": "sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.12.2.tgz",
-      "integrity": "sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-loong64-gnu": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-gnu/-/resolver-binding-linux-loong64-gnu-1.12.2.tgz",
-      "integrity": "sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-loong64-musl": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-musl/-/resolver-binding-linux-loong64-musl-1.12.2.tgz",
-      "integrity": "sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.12.2.tgz",
-      "integrity": "sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.12.2.tgz",
-      "integrity": "sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.12.2.tgz",
-      "integrity": "sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.12.2.tgz",
-      "integrity": "sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.12.2.tgz",
-      "integrity": "sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.12.2.tgz",
-      "integrity": "sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-openharmony-arm64": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-openharmony-arm64/-/resolver-binding-openharmony-arm64-1.12.2.tgz",
-      "integrity": "sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.12.2.tgz",
-      "integrity": "sha512-tYFDIkMxSflfEc/h92ZWNsZlHSwgimbNHSO3PL2JWQHfCuC2q316jMyYU9TIWZsFK2bQwyK5VAdYgn8ygPj69A==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
-      "integrity": "sha512-qzNyg3xL0VPQmCaUh+N5jSitce6k+uCBfMDesWRnlULOZaqUkaJ0ybdT+UqlAWJoQjuqfIU/0Ptx9bteN4D82g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.12.2.tgz",
-      "integrity": "sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.12.2.tgz",
-      "integrity": "sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/acorn": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-jsx": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/ajv": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ansi-escapes": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^0.21.3"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/anymatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
-    "node_modules/array-buffer-byte-length": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
-      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "is-array-buffer": "^3.0.5"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array-includes": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
-      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.24.0",
-        "es-object-atoms": "^1.1.1",
-        "get-intrinsic": "^1.3.0",
-        "is-string": "^1.1.1",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.findlast": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
-      "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
-        "es-shim-unscopables": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.findlastindex": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
-      "integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.9",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "es-shim-unscopables": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.flat": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
-      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
-        "es-shim-unscopables": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.flatmap": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
-      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
-        "es-shim-unscopables": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.tosorted": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
-      "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.3",
-        "es-errors": "^1.3.0",
-        "es-shim-unscopables": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/arraybuffer.prototype.slice": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
-      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.1",
-        "call-bind": "^1.0.8",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "is-array-buffer": "^3.0.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/async-function": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
-      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/available-typed-arrays": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
-      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "possible-typed-array-names": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/babel-jest": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.4.1.tgz",
-      "integrity": "sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/transform": "30.4.1",
-        "@types/babel__core": "^7.20.5",
-        "babel-plugin-istanbul": "^7.0.1",
-        "babel-preset-jest": "30.4.0",
-        "chalk": "^4.1.2",
-        "graceful-fs": "^4.2.11",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.11.0 || ^8.0.0-0"
-      }
-    },
-    "node_modules/babel-plugin-istanbul": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
-      "integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "workspaces": [
-        "test/babel-8"
-      ],
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@istanbuljs/load-nyc-config": "^1.0.0",
-        "@istanbuljs/schema": "^0.1.3",
-        "istanbul-lib-instrument": "^6.0.2",
-        "test-exclude": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/babel-plugin-jest-hoist": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.4.0.tgz",
-      "integrity": "sha512-9EdtWM/sSfXLOGLwSn+GS6pIXyBnL07/8gyJlwFXjWy4DxMOyItqyUT29d4lQiS380EZwYlX7/At4PgBS+m2aA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/babel__core": "^7.20.5"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/babel-preset-current-node-syntax": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
-      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/plugin-syntax-async-generators": "^7.8.4",
-        "@babel/plugin-syntax-bigint": "^7.8.3",
-        "@babel/plugin-syntax-class-properties": "^7.12.13",
-        "@babel/plugin-syntax-class-static-block": "^7.14.5",
-        "@babel/plugin-syntax-import-attributes": "^7.24.7",
-        "@babel/plugin-syntax-import-meta": "^7.10.4",
-        "@babel/plugin-syntax-json-strings": "^7.8.3",
-        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
-        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
-        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
-        "@babel/plugin-syntax-top-level-await": "^7.14.5"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0 || ^8.0.0-0"
-      }
-    },
-    "node_modules/babel-preset-jest": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.4.0.tgz",
-      "integrity": "sha512-lBY4jxsNmCnSiu7kquw8ZC9F4+XLMOKypT3RnNHPvU2Kpd4W0xaPuLr5ZkRyOsvLYAY4yaW1ZwTW4xB7NIiZzg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-jest-hoist": "30.4.0",
-        "babel-preset-current-node-syntax": "^1.2.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.11.0 || ^8.0.0-beta.1"
-      }
-    },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
-    },
-    "node_modules/baseline-browser-mapping": {
-      "version": "2.9.19",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
-      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
-      }
-    },
-    "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "engines": {
-        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/bs-logger": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
-      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-json-stable-stringify": "2.x"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/bser": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
-      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "node-int64": "^0.4.0"
-      }
-    },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/call-bind": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
-      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "get-intrinsic": "^1.3.0",
-        "set-function-length": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/call-bound": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "get-intrinsic": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/caniuse-lite": {
-      "version": "1.0.30001767",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001767.tgz",
-      "integrity": "sha512-34+zUAMhSH+r+9eKmYG+k2Rpt8XttfE4yXAjoZvkAPs15xcYQhyBYdalJ65BzivAvGRMViEjy6oKr/S91loekQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "CC-BY-4.0"
-    },
-    "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/char-regex": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
-      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/ci-info": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
-      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cjs-module-lexer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
-      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/cliui/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/cliui/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "iojs": ">= 1.0.0",
-        "node": ">= 0.12.0"
-      }
-    },
-    "node_modules/collect-v8-coverage": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
-      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
-    },
-    "node_modules/convert-source-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/crelt": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
-      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/cssstyle": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
-      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@asamuzakjp/css-color": "^3.2.0",
-        "rrweb-cssom": "^0.8.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/data-urls": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
-      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^14.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/data-view-buffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
-      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "es-errors": "^1.3.0",
-        "is-data-view": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/data-view-byte-length": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
-      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "es-errors": "^1.3.0",
-        "is-data-view": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/inspect-js"
-      }
-    },
-    "node_modules/data-view-byte-offset": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
-      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "is-data-view": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/decimal.js": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
-      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/dedent": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
-      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "babel-plugin-macros": "^3.1.0"
-      },
-      "peerDependenciesMeta": {
-        "babel-plugin-macros": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/deep-is": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true
-    },
-    "node_modules/deepmerge": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/define-data-property": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/define-properties": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
-      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.0.1",
-        "has-property-descriptors": "^1.0.0",
-        "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/detect-newline": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
-      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/doctrine": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "esutils": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/electron-to-chromium": {
-      "version": "1.5.283",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.283.tgz",
-      "integrity": "sha512-3vifjt1HgrGW/h76UEeny+adYApveS9dH2h3p57JYzBSXJIKUJAvtmIytDKjcSCt9xHfrNCFJ7gts6vkhuq++w==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/emittery": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
-      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
-      }
-    },
-    "node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/empathic": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
-      "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/enhanced-resolve": {
-      "version": "5.24.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.0.tgz",
-      "integrity": "sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.3"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/error-ex": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
-      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-arrayish": "^0.2.1"
-      }
-    },
-    "node_modules/es-abstract": {
-      "version": "1.24.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
-      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.2",
-        "arraybuffer.prototype.slice": "^1.0.4",
-        "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "data-view-buffer": "^1.0.2",
-        "data-view-byte-length": "^1.0.2",
-        "data-view-byte-offset": "^1.0.1",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "es-set-tostringtag": "^2.1.0",
-        "es-to-primitive": "^1.3.0",
-        "function.prototype.name": "^1.1.8",
-        "get-intrinsic": "^1.3.0",
-        "get-proto": "^1.0.1",
-        "get-symbol-description": "^1.1.0",
-        "globalthis": "^1.0.4",
-        "gopd": "^1.2.0",
-        "has-property-descriptors": "^1.0.2",
-        "has-proto": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "internal-slot": "^1.1.0",
-        "is-array-buffer": "^3.0.5",
-        "is-callable": "^1.2.7",
-        "is-data-view": "^1.0.2",
-        "is-negative-zero": "^2.0.3",
-        "is-regex": "^1.2.1",
-        "is-set": "^2.0.3",
-        "is-shared-array-buffer": "^1.0.4",
-        "is-string": "^1.1.1",
-        "is-typed-array": "^1.1.15",
-        "is-weakref": "^1.1.1",
-        "math-intrinsics": "^1.1.0",
-        "object-inspect": "^1.13.4",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.7",
-        "own-keys": "^1.0.1",
-        "regexp.prototype.flags": "^1.5.4",
-        "safe-array-concat": "^1.1.3",
-        "safe-push-apply": "^1.0.0",
-        "safe-regex-test": "^1.1.0",
-        "set-proto": "^1.0.0",
-        "stop-iteration-iterator": "^1.1.0",
-        "string.prototype.trim": "^1.2.10",
-        "string.prototype.trimend": "^1.0.9",
-        "string.prototype.trimstart": "^1.0.8",
-        "typed-array-buffer": "^1.0.3",
-        "typed-array-byte-length": "^1.0.3",
-        "typed-array-byte-offset": "^1.0.4",
-        "typed-array-length": "^1.0.7",
-        "unbox-primitive": "^1.1.0",
-        "which-typed-array": "^1.1.19"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-iterator-helpers": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.3.tgz",
-      "integrity": "sha512-0PuBxFi+4uPanB97iDxCLWuHeYud2FALrw5HFZGtAF38UpJDbDC8frwp2cnDyae692CQ0dou60UwWfhgsa4U/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.9",
-        "call-bound": "^1.0.4",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.24.2",
-        "es-errors": "^1.3.0",
-        "es-set-tostringtag": "^2.1.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.3.0",
-        "globalthis": "^1.0.4",
-        "gopd": "^1.2.0",
-        "has-property-descriptors": "^1.0.2",
-        "has-proto": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "internal-slot": "^1.1.0",
-        "iterator.prototype": "^1.1.5",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-shim-unscopables": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
-      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-to-primitive": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
-      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-callable": "^1.2.7",
-        "is-date-object": "^1.0.5",
-        "is-symbol": "^1.0.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/esbuild": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
-      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.1",
-        "@esbuild/android-arm": "0.28.1",
-        "@esbuild/android-arm64": "0.28.1",
-        "@esbuild/android-x64": "0.28.1",
-        "@esbuild/darwin-arm64": "0.28.1",
-        "@esbuild/darwin-x64": "0.28.1",
-        "@esbuild/freebsd-arm64": "0.28.1",
-        "@esbuild/freebsd-x64": "0.28.1",
-        "@esbuild/linux-arm": "0.28.1",
-        "@esbuild/linux-arm64": "0.28.1",
-        "@esbuild/linux-ia32": "0.28.1",
-        "@esbuild/linux-loong64": "0.28.1",
-        "@esbuild/linux-mips64el": "0.28.1",
-        "@esbuild/linux-ppc64": "0.28.1",
-        "@esbuild/linux-riscv64": "0.28.1",
-        "@esbuild/linux-s390x": "0.28.1",
-        "@esbuild/linux-x64": "0.28.1",
-        "@esbuild/netbsd-arm64": "0.28.1",
-        "@esbuild/netbsd-x64": "0.28.1",
-        "@esbuild/openbsd-arm64": "0.28.1",
-        "@esbuild/openbsd-x64": "0.28.1",
-        "@esbuild/openharmony-arm64": "0.28.1",
-        "@esbuild/sunos-x64": "0.28.1",
-        "@esbuild/win32-arm64": "0.28.1",
-        "@esbuild/win32-ia32": "0.28.1",
-        "@esbuild/win32-x64": "0.28.1"
-      }
-    },
-    "node_modules/escalade": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.1.tgz",
-      "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.2",
-        "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.6.0",
-        "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.2",
-        "@humanfs/node": "^0.16.6",
-        "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.4.2",
-        "@types/estree": "^1.0.6",
-        "ajv": "^6.14.0",
-        "cross-spawn": "^7.0.6",
-        "debug": "^4.3.2",
-        "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^9.1.2",
-        "eslint-visitor-keys": "^5.0.1",
-        "espree": "^11.2.0",
-        "esquery": "^1.7.0",
-        "esutils": "^2.0.2",
-        "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^8.0.0",
-        "find-up": "^5.0.0",
-        "glob-parent": "^6.0.2",
-        "ignore": "^5.2.0",
-        "imurmurhash": "^0.1.4",
-        "is-glob": "^4.0.0",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.4",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3"
-      },
-      "bin": {
-        "eslint": "bin/eslint.js"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
-      },
-      "peerDependencies": {
-        "jiti": "*"
-      },
-      "peerDependenciesMeta": {
-        "jiti": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-compat-utils": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.5.1.tgz",
-      "integrity": "sha512-3z3vFexKIEnjHE3zCMRo6fn/e44U7T1khUjg+Hp0ZQMCigh28rALD0nPFBcGZuiLC5rLZa2ubQHDRln09JfU2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "eslint": ">=6.0.0"
-      }
-    },
-    "node_modules/eslint-config-prettier": {
-      "version": "10.1.8",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
-      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "eslint-config-prettier": "bin/cli.js"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint-config-prettier"
-      },
-      "peerDependencies": {
-        "eslint": ">=7.0.0"
-      }
-    },
-    "node_modules/eslint-import-resolver-node": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.10.tgz",
-      "integrity": "sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^3.2.7",
-        "is-core-module": "^2.16.1",
-        "resolve": "^2.0.0-next.6"
-      }
-    },
-    "node_modules/eslint-import-resolver-node/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/eslint-module-utils": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.13.0.tgz",
-      "integrity": "sha512-bLohSkT6469rRs8czj0tLTD8vaeIS/whvPRJVjDr7IuoTT1k5DYDERlNycjDj/HkOlvQdYurmfZ/g3fG5bgeLQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^3.2.7"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependenciesMeta": {
-        "eslint": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-module-utils/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/eslint-plugin-depend": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-depend/-/eslint-plugin-depend-1.3.1.tgz",
-      "integrity": "sha512-1uo2rFAr9vzNrCYdp7IBZRB54LiyVxfaIso0R6/QV3t6Dax6DTbW/EV2Hktf0f4UtmGHK8UyzJWI382pwW04jw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "empathic": "^2.0.0",
-        "module-replacements": "^2.8.0",
-        "semver": "^7.6.3"
-      }
-    },
-    "node_modules/eslint-plugin-es-x": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.8.0.tgz",
-      "integrity": "sha512-7Ds8+wAAoV3T+LAKeu39Y5BzXCrGKrcISfgKEqTS4BDN8SFEDQd0S43jiQ8vIa3wUKD07qitZdfzlenSi8/0qQ==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/ota-meshi",
-        "https://opencollective.com/eslint"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.1.2",
-        "@eslint-community/regexpp": "^4.11.0",
-        "eslint-compat-utils": "^0.5.1"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=8"
-      }
-    },
-    "node_modules/eslint-plugin-json-schema-validator": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-json-schema-validator/-/eslint-plugin-json-schema-validator-5.1.0.tgz",
-      "integrity": "sha512-ZmVyxRIjm58oqe2kTuy90PpmZPrrKvOjRPXKzq8WCgRgAkidCgm5X8domL2KSfadZ3QFAmifMgGTcVNhZ5ez2g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.3.0",
-        "ajv": "^8.0.0",
-        "debug": "^4.3.1",
-        "eslint-compat-utils": "^0.5.0",
-        "json-schema-migrate": "^2.0.0",
-        "jsonc-eslint-parser": "^2.0.0",
-        "minimatch": "^8.0.0",
-        "synckit": "^0.9.0",
-        "toml-eslint-parser": "^0.9.0",
-        "tunnel-agent": "^0.6.0",
-        "yaml-eslint-parser": "^1.0.0"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ota-meshi"
-      },
-      "peerDependencies": {
-        "eslint": ">=6.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-json-schema-validator/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/eslint-plugin-json-schema-validator/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-json-schema-validator/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/eslint-plugin-json-schema-validator/node_modules/minimatch": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
-      "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/eslint-plugin-n": {
-      "version": "17.10.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.10.3.tgz",
-      "integrity": "sha512-ySZBfKe49nQZWR1yFaA0v/GsH6Fgp8ah6XV0WDz6CN8WO0ek4McMzb7A2xnf4DCYV43frjCygvb9f/wx7UUxRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "enhanced-resolve": "^5.17.0",
-        "eslint-plugin-es-x": "^7.5.0",
-        "get-tsconfig": "^4.7.0",
-        "globals": "^15.8.0",
-        "ignore": "^5.2.4",
-        "minimatch": "^9.0.5",
-        "semver": "^7.5.3"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      },
-      "peerDependencies": {
-        "eslint": ">=8.23.0"
-      }
-    },
-    "node_modules/eslint-plugin-n/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-n/node_modules/globals": {
-      "version": "15.15.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
-      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint-plugin-n/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/eslint-plugin-no-unsanitized": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-no-unsanitized/-/eslint-plugin-no-unsanitized-4.1.5.tgz",
-      "integrity": "sha512-MSB4hXPVFQrI8weqzs6gzl7reP2k/qSjtCoL2vUMSDejIIq9YL1ZKvq5/ORBXab/PvfBBrWO2jWviYpL+4Ghfg==",
-      "dev": true,
-      "license": "MPL-2.0",
-      "peerDependencies": {
-        "eslint": "^9 || ^10"
-      }
-    },
-    "node_modules/eslint-plugin-obsidianmd": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-obsidianmd/-/eslint-plugin-obsidianmd-0.3.0.tgz",
-      "integrity": "sha512-QvGDI6B2nxJBrsZKGTg31da2A/fEJNlnwN+fRZkaoPIu1QL3fYXUdpP7ThyMdr/0iTYQxifb9lt2X9cpydQx1w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint/config-helpers": "^0.4.2",
-        "@eslint/js": "^9.30.1",
-        "@eslint/json": "0.14.0",
-        "@microsoft/eslint-plugin-sdl": "^1.1.0",
-        "@types/eslint": "9.6.1",
-        "@types/node": "20.12.12",
-        "@typescript-eslint/types": "^8.33.1",
-        "@typescript-eslint/utils": "^8.33.1",
-        "eslint": ">=9.0.0",
-        "eslint-plugin-depend": "1.3.1",
-        "eslint-plugin-import": "^2.31.0",
-        "eslint-plugin-json-schema-validator": "5.1.0",
-        "eslint-plugin-no-unsanitized": "^4.1.5",
-        "eslint-plugin-security": "2.1.1",
-        "globals": "14.0.0",
-        "obsidian": "1.12.3",
-        "semver": "^7.7.4",
-        "typescript": "5.4.5",
-        "typescript-eslint": "^8.35.1"
-      },
-      "bin": {
-        "eslint-plugin-obsidian": "dist/lib/index.js"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@eslint/js": "^9.30.1",
-        "@eslint/json": "0.14.0",
-        "eslint": ">=9.0.0",
-        "obsidian": "1.8.7",
-        "typescript-eslint": "^8.35.1"
-      }
-    },
-    "node_modules/eslint-plugin-obsidianmd/node_modules/@eslint/config-array": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
-      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@eslint/object-schema": "^2.1.7",
-        "debug": "^4.3.1",
-        "minimatch": "^3.1.5"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/eslint-plugin-obsidianmd/node_modules/@eslint/config-helpers": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
-      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@eslint/core": "^0.17.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/eslint-plugin-obsidianmd/node_modules/@eslint/object-schema": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
-      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/eslint-plugin-obsidianmd/node_modules/@microsoft/eslint-plugin-sdl": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/eslint-plugin-sdl/-/eslint-plugin-sdl-1.1.0.tgz",
-      "integrity": "sha512-dxdNHOemLnBhfY3eByrujX9KyLigcNtW8sU+axzWv5nLGcsSBeKW2YYyTpfPo1hV8YPOmIGnfA4fZHyKVtWqBQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eslint-plugin-n": "17.10.3",
-        "eslint-plugin-react": "7.37.3",
-        "eslint-plugin-security": "1.4.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "eslint": "^9"
-      }
-    },
-    "node_modules/eslint-plugin-obsidianmd/node_modules/@microsoft/eslint-plugin-sdl/node_modules/eslint-plugin-security": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-1.4.0.tgz",
-      "integrity": "sha512-xlS7P2PLMXeqfhyf3NpqbvbnW04kN8M9NtmhpR3XGyOvt/vNKS7XPXT5EDbwKW9vCjWH4PpfQvgD/+JgN0VJKA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-regex": "^1.1.0"
-      }
-    },
-    "node_modules/eslint-plugin-obsidianmd/node_modules/@types/node": {
-      "version": "20.12.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
-      "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/eslint-plugin-obsidianmd/node_modules/eslint": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.2",
-        "@eslint/config-helpers": "^0.4.2",
-        "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.5",
-        "@eslint/js": "9.39.4",
-        "@eslint/plugin-kit": "^0.4.1",
-        "@humanfs/node": "^0.16.6",
-        "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.4.2",
-        "@types/estree": "^1.0.6",
-        "ajv": "^6.14.0",
-        "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.6",
-        "debug": "^4.3.2",
-        "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.4.0",
-        "eslint-visitor-keys": "^4.2.1",
-        "espree": "^10.4.0",
-        "esquery": "^1.5.0",
-        "esutils": "^2.0.2",
-        "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^8.0.0",
-        "find-up": "^5.0.0",
-        "glob-parent": "^6.0.2",
-        "ignore": "^5.2.0",
-        "imurmurhash": "^0.1.4",
-        "is-glob": "^4.0.0",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.5",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3"
-      },
-      "bin": {
-        "eslint": "bin/eslint.js"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
-      },
-      "peerDependencies": {
-        "jiti": "*"
-      },
-      "peerDependenciesMeta": {
-        "jiti": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-plugin-obsidianmd/node_modules/eslint-plugin-import": {
-      "version": "2.32.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
-      "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rtsao/scc": "^1.1.0",
-        "array-includes": "^3.1.9",
-        "array.prototype.findlastindex": "^1.2.6",
-        "array.prototype.flat": "^1.3.3",
-        "array.prototype.flatmap": "^1.3.3",
-        "debug": "^3.2.7",
-        "doctrine": "^2.1.0",
-        "eslint-import-resolver-node": "^0.3.9",
-        "eslint-module-utils": "^2.12.1",
-        "hasown": "^2.0.2",
-        "is-core-module": "^2.16.1",
-        "is-glob": "^4.0.3",
-        "minimatch": "^3.1.2",
-        "object.fromentries": "^2.0.8",
-        "object.groupby": "^1.0.3",
-        "object.values": "^1.2.1",
-        "semver": "^6.3.1",
-        "string.prototype.trimend": "^1.0.9",
-        "tsconfig-paths": "^3.15.0"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependencies": {
-        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
-      }
-    },
-    "node_modules/eslint-plugin-obsidianmd/node_modules/eslint-plugin-import/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/eslint-plugin-obsidianmd/node_modules/eslint-plugin-import/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/eslint-plugin-obsidianmd/node_modules/eslint-plugin-react": {
-      "version": "7.37.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.3.tgz",
-      "integrity": "sha512-DomWuTQPFYZwF/7c9W2fkKkStqZmBd3uugfqBYLdkZ3Hii23WzZuOLUskGxB8qkSKqftxEeGL1TB2kMhrce0jA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-includes": "^3.1.8",
-        "array.prototype.findlast": "^1.2.5",
-        "array.prototype.flatmap": "^1.3.3",
-        "array.prototype.tosorted": "^1.1.4",
-        "doctrine": "^2.1.0",
-        "es-iterator-helpers": "^1.2.1",
-        "estraverse": "^5.3.0",
-        "hasown": "^2.0.2",
-        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
-        "minimatch": "^3.1.2",
-        "object.entries": "^1.1.8",
-        "object.fromentries": "^2.0.8",
-        "object.values": "^1.2.1",
-        "prop-types": "^15.8.1",
-        "resolve": "^2.0.0-next.5",
-        "semver": "^6.3.1",
-        "string.prototype.matchall": "^4.0.12",
-        "string.prototype.repeat": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependencies": {
-        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
-      }
-    },
-    "node_modules/eslint-plugin-obsidianmd/node_modules/eslint-plugin-react/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/eslint-plugin-obsidianmd/node_modules/eslint-scope": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint-plugin-obsidianmd/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint-plugin-obsidianmd/node_modules/espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "acorn": "^8.15.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint-plugin-obsidianmd/node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint-plugin-obsidianmd/node_modules/safe-regex": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
-      "integrity": "sha512-aJXcif4xnaNUzvUuC5gcb46oTS7zvg4jpMTnuqtrEPlR3vFr4pxtdTwaF1Qs3Enjn9HK+ZlwQui+a7z0SywIzg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ret": "~0.1.10"
-      }
-    },
-    "node_modules/eslint-plugin-obsidianmd/node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "node_modules/eslint-plugin-prettier": {
-      "version": "5.5.5",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.5.tgz",
-      "integrity": "sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "prettier-linter-helpers": "^1.0.1",
-        "synckit": "^0.11.12"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint-plugin-prettier"
-      },
-      "peerDependencies": {
-        "@types/eslint": ">=8.0.0",
-        "eslint": ">=8.0.0",
-        "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0",
-        "prettier": ">=3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/eslint": {
-          "optional": true
-        },
-        "eslint-config-prettier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-plugin-prettier/node_modules/@pkgr/core": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
-      "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/pkgr"
-      }
-    },
-    "node_modules/eslint-plugin-prettier/node_modules/synckit": {
-      "version": "0.11.12",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
-      "integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@pkgr/core": "^0.2.9"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/synckit"
-      }
-    },
-    "node_modules/eslint-plugin-security": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-2.1.1.tgz",
-      "integrity": "sha512-7cspIGj7WTfR3EhaILzAPcfCo5R9FbeWvbgsPYWivSurTBKW88VQxtP3c4aWMG9Hz/GfJlJVdXEJ3c8LqS+u2w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-regex": "^2.1.1"
-      }
-    },
-    "node_modules/eslint-scope": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
-      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "@types/esrecurse": "^4.3.1",
-        "@types/estree": "^1.0.8",
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/@eslint/core": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
-      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
-    },
-    "node_modules/eslint/node_modules/@eslint/plugin-kit": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
-      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@eslint/core": "^1.2.1",
-        "levn": "^0.4.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
-    },
-    "node_modules/eslint/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/eslint/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/espree": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
-      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "acorn": "^8.16.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^5.0.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/esquery": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
-      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "estraverse": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/esrecurse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/esutils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/execa": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.0",
-        "human-signals": "^2.1.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.1",
-        "onetime": "^5.1.2",
-        "signal-exit": "^3.0.3",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/exit-x": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz",
-      "integrity": "sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/expect": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
-      "integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/expect-utils": "30.4.1",
-        "@jest/get-type": "30.1.0",
-        "jest-matcher-utils": "30.4.1",
-        "jest-message-util": "30.4.1",
-        "jest-mock": "30.4.1",
-        "jest-util": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/fast-diff": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
-      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
-    },
-    "node_modules/fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "dev": true
-    },
-    "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/fb-watchman": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
-      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bser": "2.1.1"
-      }
-    },
-    "node_modules/file-entry-cache": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
-      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "flat-cache": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
-      "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/flat-cache": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
-      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "flatted": "^3.2.9",
-        "keyv": "^4.5.4"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/for-each": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
-      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-callable": "^1.2.7"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/foreground-child": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/foreground-child/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/function.prototype.name": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
-      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "define-properties": "^1.2.1",
-        "functions-have-names": "^1.2.3",
-        "hasown": "^2.0.2",
-        "is-callable": "^1.2.7"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/functions-have-names": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/generator-function": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
-      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/gensync": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-package-type": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
-      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/get-symbol-description": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
-      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-tsconfig": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
-      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-      }
-    },
-    "node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/glob-parent": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
-      "dependencies": {
-        "is-glob": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/globals": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
-      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/globalthis": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
-      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-properties": "^1.2.1",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/handlebars": {
-      "version": "4.7.9",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
-      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.2",
-        "source-map": "^0.6.1",
-        "wordwrap": "^1.0.0"
-      },
-      "bin": {
-        "handlebars": "bin/handlebars"
-      },
-      "engines": {
-        "node": ">=0.4.7"
-      },
-      "optionalDependencies": {
-        "uglify-js": "^3.1.4"
-      }
-    },
-    "node_modules/has-bigints": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
-      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-proto": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
-      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
-      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/html-encoding-sniffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
-      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-encoding": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/html-escaper": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
-      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/http-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/human-signals": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.17.0"
-      }
-    },
-    "node_modules/husky": {
-      "version": "9.1.7",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
-      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "husky": "bin.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
-      }
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ignore": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/import-fresh": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/import-local": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
-      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pkg-dir": "^4.2.0",
-        "resolve-cwd": "^3.0.0"
-      },
-      "bin": {
-        "import-local-fixture": "fixtures/cli.js"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.19"
-      }
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/internal-slot": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
-      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "hasown": "^2.0.2",
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/is-array-buffer": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
-      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "get-intrinsic": "^1.2.6"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/is-async-function": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
-      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "async-function": "^1.0.0",
-        "call-bound": "^1.0.3",
-        "get-proto": "^1.0.1",
-        "has-tostringtag": "^1.0.2",
-        "safe-regex-test": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-bigint": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
-      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-bigints": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-boolean-object": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
-      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-callable": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-core-module": {
-      "version": "2.16.2",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
-      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "hasown": "^2.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-data-view": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
-      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "get-intrinsic": "^1.2.6",
-        "is-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-date-object": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
-      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-finalizationregistry": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
-      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/is-generator-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
-      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/is-generator-function": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
-      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.4",
-        "generator-function": "^2.0.0",
-        "get-proto": "^1.0.1",
-        "has-tostringtag": "^1.0.2",
-        "safe-regex-test": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
-      "dependencies": {
-        "is-extglob": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-map": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
-      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-negative-zero": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
-      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-number-object": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
-      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-potential-custom-element-name": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
-      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/is-regex": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
-      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-set": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
-      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-shared-array-buffer": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
-      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-string": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
-      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-symbol": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
-      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "has-symbols": "^1.1.0",
-        "safe-regex-test": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-typed-array": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
-      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "which-typed-array": "^1.1.16"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-weakmap": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
-      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-weakref": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
-      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-weakset": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
-      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "get-intrinsic": "^1.2.6"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
-    },
-    "node_modules/istanbul-lib-coverage": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
-      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/istanbul-lib-instrument": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
-      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/core": "^7.23.9",
-        "@babel/parser": "^7.23.9",
-        "@istanbuljs/schema": "^0.1.3",
-        "istanbul-lib-coverage": "^3.2.0",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/istanbul-lib-report": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
-      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "istanbul-lib-coverage": "^3.0.0",
-        "make-dir": "^4.0.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/istanbul-lib-source-maps": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
-      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.23",
-        "debug": "^4.1.1",
-        "istanbul-lib-coverage": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/istanbul-reports": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
-      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "html-escaper": "^2.0.0",
-        "istanbul-lib-report": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/iterator.prototype": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
-      "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-object-atoms": "^1.0.0",
-        "get-intrinsic": "^1.2.6",
-        "get-proto": "^1.0.0",
-        "has-symbols": "^1.1.0",
-        "set-function-name": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/jest": {
-      "version": "30.4.2",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-30.4.2.tgz",
-      "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/core": "30.4.2",
-        "@jest/types": "30.4.1",
-        "import-local": "^3.2.0",
-        "jest-cli": "30.4.2"
-      },
-      "bin": {
-        "jest": "bin/jest.js"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "node-notifier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jest-changed-files": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.4.1.tgz",
-      "integrity": "sha512-IuctmYrxi21iOSOaIXpJWalHyPAsVv0GeBHKDn8C1CA4W5htHn7INL+wdnL4Bo0+olEndvAFkmb++tIQJG+vvg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "execa": "^5.1.1",
-        "jest-util": "30.4.1",
-        "p-limit": "^3.1.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-circus": {
-      "version": "30.4.2",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.4.2.tgz",
-      "integrity": "sha512-rvHH7VlY6LgbJXJTQ87GW62g1FntOtbhh0zT+v04kC+pgL6aBKyYINXxWukCpj3dcIBMw5/XUbtDS9dU9JTXeQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/environment": "30.4.1",
-        "@jest/expect": "30.4.1",
-        "@jest/test-result": "30.4.1",
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "co": "^4.6.0",
-        "dedent": "^1.6.0",
-        "is-generator-fn": "^2.1.0",
-        "jest-each": "30.4.1",
-        "jest-matcher-utils": "30.4.1",
-        "jest-message-util": "30.4.1",
-        "jest-runtime": "30.4.2",
-        "jest-snapshot": "30.4.1",
-        "jest-util": "30.4.1",
-        "p-limit": "^3.1.0",
-        "pretty-format": "30.4.1",
-        "pure-rand": "^7.0.0",
-        "slash": "^3.0.0",
-        "stack-utils": "^2.0.6"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-cli": {
-      "version": "30.4.2",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.4.2.tgz",
-      "integrity": "sha512-jfA2ocvVHMXS2QijrJ0d31ektP+d/W0T5RpcTX2Pq+3sVqHlsXVCM2+FmwpL+bdY8OfHpIg9xMxLF17Zg0U49Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/core": "30.4.2",
-        "@jest/test-result": "30.4.1",
-        "@jest/types": "30.4.1",
-        "chalk": "^4.1.2",
-        "exit-x": "^0.2.2",
-        "import-local": "^3.2.0",
-        "jest-config": "30.4.2",
-        "jest-util": "30.4.1",
-        "jest-validate": "30.4.1",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "jest": "bin/jest.js"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "node-notifier": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jest-config": {
-      "version": "30.4.2",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.4.2.tgz",
-      "integrity": "sha512-rNHAShJQqQwFNoL0hbf3BphSBOWnpOUAKvidLS/AjNVLPfoj5mSf4jQMfW3cYOs6hXeZC7nF7mDHaBnbxELOzg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.27.4",
-        "@jest/get-type": "30.1.0",
-        "@jest/pattern": "30.4.0",
-        "@jest/test-sequencer": "30.4.1",
-        "@jest/types": "30.4.1",
-        "babel-jest": "30.4.1",
-        "chalk": "^4.1.2",
-        "ci-info": "^4.2.0",
-        "deepmerge": "^4.3.1",
-        "glob": "^10.5.0",
-        "graceful-fs": "^4.2.11",
-        "jest-circus": "30.4.2",
-        "jest-docblock": "30.4.0",
-        "jest-environment-node": "30.4.1",
-        "jest-regex-util": "30.4.0",
-        "jest-resolve": "30.4.1",
-        "jest-runner": "30.4.2",
-        "jest-util": "30.4.1",
-        "jest-validate": "30.4.1",
-        "parse-json": "^5.2.0",
-        "pretty-format": "30.4.1",
-        "slash": "^3.0.0",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@types/node": "*",
-        "esbuild-register": ">=3.4.0",
-        "ts-node": ">=9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "esbuild-register": {
-          "optional": true
-        },
-        "ts-node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jest-diff": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
-      "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/diff-sequences": "30.4.0",
-        "@jest/get-type": "30.1.0",
-        "chalk": "^4.1.2",
-        "pretty-format": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-docblock": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.4.0.tgz",
-      "integrity": "sha512-ZPMabUZCx5MpbZ2eBYSvZ0J8fvo3dR9oM+eeUpb3aKNQFuS2tu3Duw1TNlMoP8k3WQgKGJuhcMFvwcVuq6T7oA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "detect-newline": "^3.1.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-each": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.4.1.tgz",
-      "integrity": "sha512-/8MJbH6fuj48TstjrMf+u/pd06Qezz5xOXvZA6442heNOWr8bdeoGZX2d9fCn028CoMgYmroH9//zky5GfyYmA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/get-type": "30.1.0",
-        "@jest/types": "30.4.1",
-        "chalk": "^4.1.2",
-        "jest-util": "30.4.1",
-        "pretty-format": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-environment-jsdom": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.4.1.tgz",
-      "integrity": "sha512-o3nfaN4zej7qgk2X0j8Jhq/S9nAVKs2xK3QeQxeHVvpkEPxaA1yxDGydR+iVI7zPy7Cp62Aq2h3Ja46QvfWHGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/environment": "30.4.1",
-        "@jest/environment-jsdom-abstract": "30.4.1",
-        "jsdom": "^26.1.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "canvas": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "canvas": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jest-environment-node": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.4.1.tgz",
-      "integrity": "sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/environment": "30.4.1",
-        "@jest/fake-timers": "30.4.1",
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "jest-mock": "30.4.1",
-        "jest-util": "30.4.1",
-        "jest-validate": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-haste-map": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.4.1.tgz",
-      "integrity": "sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "anymatch": "^3.1.3",
-        "fb-watchman": "^2.0.2",
-        "graceful-fs": "^4.2.11",
-        "jest-regex-util": "30.4.0",
-        "jest-util": "30.4.1",
-        "jest-worker": "30.4.1",
-        "picomatch": "^4.0.3",
-        "walker": "^1.0.8"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "^2.3.3"
-      }
-    },
-    "node_modules/jest-haste-map/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/jest-leak-detector": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.4.1.tgz",
-      "integrity": "sha512-IpmyiioeHxiWDhesHnUFmOxcTzwCwKpgACgWajtAP+nYQXiY7DakTxB6Bx9JFiRMljr0AX1PvnQdaU1KFoz6NQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/get-type": "30.1.0",
-        "pretty-format": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-matcher-utils": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
-      "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/get-type": "30.1.0",
-        "chalk": "^4.1.2",
-        "jest-diff": "30.4.1",
-        "pretty-format": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-message-util": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
-      "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@jest/types": "30.4.1",
-        "@types/stack-utils": "^2.0.3",
-        "chalk": "^4.1.2",
-        "graceful-fs": "^4.2.11",
-        "jest-util": "30.4.1",
-        "picomatch": "^4.0.3",
-        "pretty-format": "30.4.1",
-        "slash": "^3.0.0",
-        "stack-utils": "^2.0.6"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-message-util/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/jest-mock": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
-      "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "jest-util": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-pnp-resolver": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
-      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "jest-resolve": "*"
-      },
-      "peerDependenciesMeta": {
-        "jest-resolve": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jest-regex-util": {
-      "version": "30.4.0",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
-      "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-resolve": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.4.1.tgz",
-      "integrity": "sha512-Zry8Yq/yJcNAZ7dJ5F2heic8AheXvbFZ7XI5V+h28nrYZ7Qoyy4dItq8OodjnYD270mvX+ZudmrNV9cysqhW5Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.4.1",
-        "jest-pnp-resolver": "^1.2.3",
-        "jest-util": "30.4.1",
-        "jest-validate": "30.4.1",
-        "slash": "^3.0.0",
-        "unrs-resolver": "^1.7.11"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-resolve-dependencies": {
-      "version": "30.4.2",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.4.2.tgz",
-      "integrity": "sha512-gDiVh1I+GxYzz9oXlyw+1wv6VOYX1WYxMOfjsA3iGKePV2oxmbHhwxfkALxNxYy1ciw6APWwkW2zZONwP97aEQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "jest-regex-util": "30.4.0",
-        "jest-snapshot": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-runner": {
-      "version": "30.4.2",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.4.2.tgz",
-      "integrity": "sha512-2dw0PslVYXxffXGpLo+Ejad+KcI1Qkjn7f4X4619gf21oCUmL+SPfjqIa/losUem3yEOvfNZe/F1HWUcNpODcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/console": "30.4.1",
-        "@jest/environment": "30.4.1",
-        "@jest/test-result": "30.4.1",
-        "@jest/transform": "30.4.1",
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "emittery": "^0.13.1",
-        "exit-x": "^0.2.2",
-        "graceful-fs": "^4.2.11",
-        "jest-docblock": "30.4.0",
-        "jest-environment-node": "30.4.1",
-        "jest-haste-map": "30.4.1",
-        "jest-leak-detector": "30.4.1",
-        "jest-message-util": "30.4.1",
-        "jest-resolve": "30.4.1",
-        "jest-runtime": "30.4.2",
-        "jest-util": "30.4.1",
-        "jest-watcher": "30.4.1",
-        "jest-worker": "30.4.1",
-        "p-limit": "^3.1.0",
-        "source-map-support": "0.5.13"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-runtime": {
-      "version": "30.4.2",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.4.2.tgz",
-      "integrity": "sha512-3/5e8iPz2k/VLqlr8DgTftYyLUv8Su3FkCAO2/Od81UsUTpSxOrS6O5x5KkoQwyUjmpYyDJKeyAvg2T2nvpNkQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/environment": "30.4.1",
-        "@jest/fake-timers": "30.4.1",
-        "@jest/globals": "30.4.1",
-        "@jest/source-map": "30.0.1",
-        "@jest/test-result": "30.4.1",
-        "@jest/transform": "30.4.1",
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "cjs-module-lexer": "^2.1.0",
-        "collect-v8-coverage": "^1.0.2",
-        "glob": "^10.5.0",
-        "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.4.1",
-        "jest-message-util": "30.4.1",
-        "jest-mock": "30.4.1",
-        "jest-regex-util": "30.4.0",
-        "jest-resolve": "30.4.1",
-        "jest-snapshot": "30.4.1",
-        "jest-util": "30.4.1",
-        "slash": "^3.0.0",
-        "strip-bom": "^4.0.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-snapshot": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.4.1.tgz",
-      "integrity": "sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.27.4",
-        "@babel/generator": "^7.27.5",
-        "@babel/plugin-syntax-jsx": "^7.27.1",
-        "@babel/plugin-syntax-typescript": "^7.27.1",
-        "@babel/types": "^7.27.3",
-        "@jest/expect-utils": "30.4.1",
-        "@jest/get-type": "30.1.0",
-        "@jest/snapshot-utils": "30.4.1",
-        "@jest/transform": "30.4.1",
-        "@jest/types": "30.4.1",
-        "babel-preset-current-node-syntax": "^1.2.0",
-        "chalk": "^4.1.2",
-        "expect": "30.4.1",
-        "graceful-fs": "^4.2.11",
-        "jest-diff": "30.4.1",
-        "jest-matcher-utils": "30.4.1",
-        "jest-message-util": "30.4.1",
-        "jest-util": "30.4.1",
-        "pretty-format": "30.4.1",
-        "semver": "^7.7.2",
-        "synckit": "^0.11.8"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/@pkgr/core": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
-      "integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/pkgr"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/synckit": {
-      "version": "0.11.13",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
-      "integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@pkgr/core": "^0.3.6"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/synckit"
-      }
-    },
-    "node_modules/jest-util": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
-      "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "ci-info": "^4.2.0",
-        "graceful-fs": "^4.2.11",
-        "picomatch": "^4.0.3"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-util/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/jest-validate": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.4.1.tgz",
-      "integrity": "sha512-PDWi4SOwLnwqNDfHZjOcsEFyZ4fc/2W2gVL3DEoyqnB6jCQMLRtfBong8s6omIw3lI0HWOus12xfnFmQtjW3fw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/get-type": "30.1.0",
-        "@jest/types": "30.4.1",
-        "camelcase": "^6.3.0",
-        "chalk": "^4.1.2",
-        "leven": "^3.1.0",
-        "pretty-format": "30.4.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-validate/node_modules/camelcase": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/jest-watcher": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.4.1.tgz",
-      "integrity": "sha512-/l9UonmvCwjHH7d2h3iAwIloLc1H0S8mJZ/LNK3i86hqwPAz8otUJjP9MfYtz9Tt77Su5FD2xGjZn8d31IZHlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/test-result": "30.4.1",
-        "@jest/types": "30.4.1",
-        "@types/node": "*",
-        "ansi-escapes": "^4.3.2",
-        "chalk": "^4.1.2",
-        "emittery": "^0.13.1",
-        "jest-util": "30.4.1",
-        "string-length": "^4.0.2"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-worker": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.4.1.tgz",
-      "integrity": "sha512-SHynN/q/QD++iNyvMdy+WMmbCGk8jIsNcRxycXbWubSOhvo6T+j2afcfUSl+3hYsiBebOTo0cT7c2H7CXugu1g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@ungap/structured-clone": "^1.3.0",
-        "jest-util": "30.4.1",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.1.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-worker/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/jsdom": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
-      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssstyle": "^4.2.1",
-        "data-urls": "^5.0.0",
-        "decimal.js": "^10.5.0",
-        "html-encoding-sniffer": "^4.0.0",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.6",
-        "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.16",
-        "parse5": "^7.2.1",
-        "rrweb-cssom": "^0.8.0",
-        "saxes": "^6.0.0",
-        "symbol-tree": "^3.2.4",
-        "tough-cookie": "^5.1.1",
-        "w3c-xmlserializer": "^5.0.0",
-        "webidl-conversions": "^7.0.0",
-        "whatwg-encoding": "^3.1.1",
-        "whatwg-mimetype": "^4.0.0",
-        "whatwg-url": "^14.1.1",
-        "ws": "^8.18.0",
-        "xml-name-validator": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "canvas": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "canvas": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jsesc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "jsesc": "bin/jsesc"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/json-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/json-schema-migrate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-migrate/-/json-schema-migrate-2.0.0.tgz",
-      "integrity": "sha512-r38SVTtojDRp4eD6WsCqiE0eNDt4v1WalBXb9cyZYw9ai5cGtBwzRNWjHzJl38w6TxFkXAIA7h+fyX3tnrAFhQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      }
-    },
-    "node_modules/json-schema-migrate/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/json-schema-migrate/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/json-stable-stringify-without-jsonify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-      "dev": true
-    },
-    "node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/jsonc-eslint-parser": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-2.4.2.tgz",
-      "integrity": "sha512-1e4qoRgnn448pRuMvKGsFFymUCquZV0mpGgOyIKNgD3JVDTsVJyRBGH/Fm0tBb8WsWGgmB1mDe6/yJMQM37DUA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.5.0",
-        "eslint-visitor-keys": "^3.0.0",
-        "espree": "^9.0.0",
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ota-meshi"
-      }
-    },
-    "node_modules/jsonc-eslint-parser/node_modules/espree": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
-      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "acorn": "^8.9.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.4.1"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/jsx-ast-utils": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
-      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-includes": "^3.1.6",
-        "array.prototype.flat": "^1.3.1",
-        "object.assign": "^4.1.4",
-        "object.values": "^1.1.6"
-      },
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/keyv": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "json-buffer": "3.0.1"
-      }
-    },
-    "node_modules/leven": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
-      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/levn": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
-      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-      "dev": true,
-      "dependencies": {
-        "prelude-ls": "^1.2.1",
-        "type-check": "~0.4.0"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/lines-and-columns": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/lodash.memoize": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
-    "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/make-dir": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
-      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.5.3"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/makeerror": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
-      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tmpl": "1.0.5"
-      }
-    },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/mediabunny": {
-      "version": "1.50.4",
-      "resolved": "https://registry.npmjs.org/mediabunny/-/mediabunny-1.50.4.tgz",
-      "integrity": "sha512-RcJ3xt839gopNTHVl+dLypKdABDL3KYtRszIXjaCmwG/rGglKpEKWcdaXN2tWiaubQguibK5Uem1aLy2+aEUaw==",
-      "license": "MPL-2.0",
-      "workspaces": [
-        ".",
-        "packages/*"
-      ],
-      "dependencies": {
-        "@types/dom-mediacapture-transform": "^0.1.11",
-        "@types/dom-webcodecs": "0.1.13"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://github.com/sponsors/Vanilagy"
-      }
-    },
-    "node_modules/merge-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/module-replacements": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/module-replacements/-/module-replacements-2.11.0.tgz",
-      "integrity": "sha512-j5sNQm3VCpQQ7nTqGeOZtoJtV3uKERgCBm9QRhmGRiXiqkf7iRFOkfxdJRZWLkqYY8PNf4cDQF/WfXUYLENrRA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/nano-staged": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/nano-staged/-/nano-staged-0.8.0.tgz",
-      "integrity": "sha512-QSEqPGTCJbkHU2yLvfY6huqYPjdBrOaTMKatO1F8nCSrkQGXeKwtCiCnsdxnuMhbg3DTVywKaeWLGCE5oJpq0g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picocolors": "^1.0.0"
-      },
-      "bin": {
-        "nano-staged": "lib/bin.js"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
-    "node_modules/napi-postinstall": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
-      "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "napi-postinstall": "lib/cli.js"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/napi-postinstall"
-      }
-    },
-    "node_modules/natural-compare": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "dev": true
-    },
-    "node_modules/neo-async": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/node-exports-info": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
-      "integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array.prototype.flatmap": "^1.3.3",
-        "es-errors": "^1.3.0",
-        "object.entries": "^1.1.9",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/node-exports-info/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/node-int64": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/npm-run-path": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/nwsapi": {
-      "version": "2.2.24",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
-      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-inspect": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
-      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/object.assign": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
-      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0",
-        "has-symbols": "^1.1.0",
-        "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object.entries": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
-      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/object.fromentries": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
-      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object.groupby": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
-      "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/object.values": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
-      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/obsidian": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.12.3.tgz",
-      "integrity": "sha512-HxWqe763dOqzXjnNiHmAJTRERN8KILBSqxDSEqbeSr7W8R8Jxezzbca+nz1LiiqXnMpM8lV2jzAezw3CZ4xNUw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/codemirror": "5.60.8",
-        "moment": "2.29.4"
-      },
-      "peerDependencies": {
-        "@codemirror/state": "6.5.0",
-        "@codemirror/view": "6.38.6"
-      }
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
-    "node_modules/onetime": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-fn": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/optionator": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
-      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
-      "dev": true,
-      "dependencies": {
-        "deep-is": "^0.1.3",
-        "fast-levenshtein": "^2.0.6",
-        "levn": "^0.4.1",
-        "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0",
-        "word-wrap": "^1.2.5"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/own-keys": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
-      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.2.6",
-        "object-keys": "^1.1.1",
-        "safe-push-apply": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
-      "dependencies": {
-        "yocto-queue": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0"
-    },
-    "node_modules/parent-module": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "callsites": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/parse-json": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "error-ex": "^1.3.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "lines-and-columns": "^1.1.6"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/parse5": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/picocolors": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/pirates": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
-      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/pkg-dir": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/possible-typed-array-names": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
-      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/prelude-ls": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/prettier": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/prettier-linter-helpers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.1.tgz",
-      "integrity": "sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-diff": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/pretty-format": {
-      "version": "30.4.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
-      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "30.4.1",
-        "ansi-styles": "^5.2.0",
-        "react-is-18": "npm:react-is@^18.3.1",
-        "react-is-19": "npm:react-is@^19.2.5"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
-    "node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pure-rand": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
-      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/dubzzz"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fast-check"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/react-is-18": {
-      "name": "react-is",
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/react-is-19": {
-      "name": "react-is",
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
-      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/reflect.getprototypeof": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
-      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.9",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
-        "get-intrinsic": "^1.2.7",
-        "get-proto": "^1.0.1",
-        "which-builtin-type": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/regexp-tree": {
-      "version": "0.1.27",
-      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
-      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "regexp-tree": "bin/regexp-tree"
-      }
-    },
-    "node_modules/regexp.prototype.flags": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
-      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "define-properties": "^1.2.1",
-        "es-errors": "^1.3.0",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "set-function-name": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/resolve": {
-      "version": "2.0.0-next.7",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
-      "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.2",
-        "node-exports-info": "^1.6.0",
-        "object-keys": "^1.1.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/resolve-cwd": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
-      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-from": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/resolve-cwd/node_modules/resolve-from": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/resolve-pkg-maps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-      }
-    },
-    "node_modules/ret": {
-      "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
-    "node_modules/rrweb-cssom": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
-      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/safe-array-concat": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
-      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
-        "get-intrinsic": "^1.2.6",
-        "has-symbols": "^1.1.0",
-        "isarray": "^2.0.5"
-      },
-      "engines": {
-        "node": ">=0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/safe-push-apply": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
-      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "isarray": "^2.0.5"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/safe-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
-      "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "regexp-tree": "~0.1.1"
-      }
-    },
-    "node_modules/safe-regex-test": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
-      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "is-regex": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/saxes": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
-      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "xmlchars": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=v12.22.7"
-      }
-    },
-    "node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/set-function-length": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/set-function-name": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
-      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "functions-have-names": "^1.2.3",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/set-proto": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
-      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
-        "side-channel-map": "^1.0.1",
-        "side-channel-weakmap": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-map": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
-      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/side-channel-weakmap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
-      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3",
-        "side-channel-map": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-support": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/stack-utils": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
-      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/stack-utils/node_modules/escape-string-regexp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/stop-iteration-iterator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
-      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "internal-slot": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/string-length": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
-      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "char-regex": "^1.0.2",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/string-length/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-length/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/string-width-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string.prototype.matchall": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
-      "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.6",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
-        "get-intrinsic": "^1.2.6",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "internal-slot": "^1.1.0",
-        "regexp.prototype.flags": "^1.5.3",
-        "set-function-name": "^2.0.2",
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/string.prototype.repeat": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
-      "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
-      }
-    },
-    "node_modules/string.prototype.trim": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
-      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
-        "define-data-property": "^1.1.4",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
-        "es-object-atoms": "^1.0.0",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/string.prototype.trimend": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
-      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
-        "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/string.prototype.trimstart": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
-      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-bom": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-final-newline": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/style-mod": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
-      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/symbol-tree": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/synckit": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.3.tgz",
-      "integrity": "sha512-JJoOEKTfL1urb1mDoEblhD9NhEbWmq9jHEMEnxoC4ujUaZ4itA8vKgwkFAyNClgxplLi9tsUKX+EduK0p/l7sg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@pkgr/core": "^0.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/unts"
-      }
-    },
-    "node_modules/tapable": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
-      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/test-exclude": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
-      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@istanbuljs/schema": "^0.1.2",
-        "glob": "^7.1.4",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/test-exclude/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/tldts": {
-      "version": "6.1.86",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
-      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tldts-core": "^6.1.86"
-      },
-      "bin": {
-        "tldts": "bin/cli.js"
-      }
-    },
-    "node_modules/tldts-core": {
-      "version": "6.1.86",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
-      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/tmpl": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
-      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/toml-eslint-parser": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/toml-eslint-parser/-/toml-eslint-parser-0.9.3.tgz",
-      "integrity": "sha512-moYoCvkNUAPCxSW9jmHmRElhm4tVJpHL8ItC/+uYD0EpPSFXbck7yREz9tNdJVTSpHVod8+HoipcpbQ0oE6gsw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eslint-visitor-keys": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ota-meshi"
-      }
-    },
-    "node_modules/tough-cookie": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
-      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tldts": "^6.1.32"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/tr46": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
-      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/ts-api-utils": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
-      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.12"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4"
-      }
-    },
-    "node_modules/ts-jest": {
-      "version": "29.4.11",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",
-      "integrity": "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bs-logger": "^0.2.6",
-        "fast-json-stable-stringify": "^2.1.0",
-        "handlebars": "^4.7.9",
-        "json5": "^2.2.3",
-        "lodash.memoize": "^4.1.2",
-        "make-error": "^1.3.6",
-        "semver": "^7.8.0",
-        "type-fest": "^4.41.0",
-        "yargs-parser": "^21.1.1"
-      },
-      "bin": {
-        "ts-jest": "cli.js"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": ">=7.0.0-beta.0 <8",
-        "@jest/transform": "^29.0.0 || ^30.0.0",
-        "@jest/types": "^29.0.0 || ^30.0.0",
-        "babel-jest": "^29.0.0 || ^30.0.0",
-        "jest": "^29.0.0 || ^30.0.0",
-        "jest-util": "^29.0.0 || ^30.0.0",
-        "typescript": ">=4.3 <7"
-      },
-      "peerDependenciesMeta": {
-        "@babel/core": {
-          "optional": true
-        },
-        "@jest/transform": {
-          "optional": true
-        },
-        "@jest/types": {
-          "optional": true
-        },
-        "babel-jest": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "jest-util": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ts-jest/node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/tsconfig-paths": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
-      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/json5": "^0.0.29",
-        "json5": "^1.0.2",
-        "minimist": "^1.2.6",
-        "strip-bom": "^3.0.0"
-      }
-    },
-    "node_modules/tsconfig-paths/node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/tsconfig-paths/node_modules/strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD"
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/type-check": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-      "dev": true,
-      "dependencies": {
-        "prelude-ls": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/typed-array-buffer": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
-      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "es-errors": "^1.3.0",
-        "is-typed-array": "^1.1.14"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/typed-array-byte-length": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
-      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "for-each": "^0.3.3",
-        "gopd": "^1.2.0",
-        "has-proto": "^1.2.0",
-        "is-typed-array": "^1.1.14"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/typed-array-byte-offset": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
-      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
-        "for-each": "^0.3.3",
-        "gopd": "^1.2.0",
-        "has-proto": "^1.2.0",
-        "is-typed-array": "^1.1.15",
-        "reflect.getprototypeof": "^1.0.9"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/typed-array-length": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
-      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "is-typed-array": "^1.1.13",
-        "possible-typed-array-names": "^1.0.0",
-        "reflect.getprototypeof": "^1.0.6"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "node_modules/typescript-eslint": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.61.0.tgz",
-      "integrity": "sha512-8y31Rd0eGTrDKqhy6vT0HtzhN+YLjQizwX3aA3hPXP/ynSfnrBXcQY5IzsP9/DM7+klX4IUncZZjkchP0z+rUw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.61.0",
-        "@typescript-eslint/parser": "8.61.0",
-        "@typescript-eslint/typescript-estree": "8.61.0",
-        "@typescript-eslint/utils": "8.61.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/uglify-js": {
-      "version": "3.19.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
-      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/unbox-primitive": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
-      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "has-bigints": "^1.0.2",
-        "has-symbols": "^1.1.0",
-        "which-boxed-primitive": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/unrs-resolver": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
-      "integrity": "sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "napi-postinstall": "^0.3.4"
-      },
-      "funding": {
-        "url": "https://opencollective.com/unrs-resolver"
-      },
-      "optionalDependencies": {
-        "@unrs/resolver-binding-android-arm-eabi": "1.12.2",
-        "@unrs/resolver-binding-android-arm64": "1.12.2",
-        "@unrs/resolver-binding-darwin-arm64": "1.12.2",
-        "@unrs/resolver-binding-darwin-x64": "1.12.2",
-        "@unrs/resolver-binding-freebsd-x64": "1.12.2",
-        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.12.2",
-        "@unrs/resolver-binding-linux-arm-musleabihf": "1.12.2",
-        "@unrs/resolver-binding-linux-arm64-gnu": "1.12.2",
-        "@unrs/resolver-binding-linux-arm64-musl": "1.12.2",
-        "@unrs/resolver-binding-linux-loong64-gnu": "1.12.2",
-        "@unrs/resolver-binding-linux-loong64-musl": "1.12.2",
-        "@unrs/resolver-binding-linux-ppc64-gnu": "1.12.2",
-        "@unrs/resolver-binding-linux-riscv64-gnu": "1.12.2",
-        "@unrs/resolver-binding-linux-riscv64-musl": "1.12.2",
-        "@unrs/resolver-binding-linux-s390x-gnu": "1.12.2",
-        "@unrs/resolver-binding-linux-x64-gnu": "1.12.2",
-        "@unrs/resolver-binding-linux-x64-musl": "1.12.2",
-        "@unrs/resolver-binding-openharmony-arm64": "1.12.2",
-        "@unrs/resolver-binding-wasm32-wasi": "1.12.2",
-        "@unrs/resolver-binding-win32-arm64-msvc": "1.12.2",
-        "@unrs/resolver-binding-win32-ia32-msvc": "1.12.2",
-        "@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
-      }
-    },
-    "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "escalade": "^3.2.0",
-        "picocolors": "^1.1.1"
-      },
-      "bin": {
-        "update-browserslist-db": "cli.js"
-      },
-      "peerDependencies": {
-        "browserslist": ">= 4.21.0"
-      }
-    },
-    "node_modules/uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/v8-to-istanbul": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
-      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.12",
-        "@types/istanbul-lib-coverage": "^2.0.1",
-        "convert-source-map": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.12.0"
-      }
-    },
-    "node_modules/w3c-keyname": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
-      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/w3c-xmlserializer": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
-      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "xml-name-validator": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/walker": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
-      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "makeerror": "1.0.12"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/whatwg-encoding": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
-      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "0.6.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/whatwg-mimetype": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
-      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "^5.1.0",
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/which-boxed-primitive": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
-      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-bigint": "^1.1.0",
-        "is-boolean-object": "^1.2.1",
-        "is-number-object": "^1.1.1",
-        "is-string": "^1.1.1",
-        "is-symbol": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/which-builtin-type": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
-      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "function.prototype.name": "^1.1.6",
-        "has-tostringtag": "^1.0.2",
-        "is-async-function": "^2.0.0",
-        "is-date-object": "^1.1.0",
-        "is-finalizationregistry": "^1.1.0",
-        "is-generator-function": "^1.0.10",
-        "is-regex": "^1.2.1",
-        "is-weakref": "^1.0.2",
-        "isarray": "^2.0.5",
-        "which-boxed-primitive": "^1.1.0",
-        "which-collection": "^1.0.2",
-        "which-typed-array": "^1.1.16"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/which-collection": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
-      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-map": "^2.0.3",
-        "is-set": "^2.0.3",
-        "is-weakmap": "^2.0.2",
-        "is-weakset": "^2.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/which-typed-array": {
-      "version": "1.1.20",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
-      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "for-each": "^0.3.5",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/word-wrap": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
-      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/write-file-atomic": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
-      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/write-file-atomic/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/xml-name-validator": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
-      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/xmlchars": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
-    "node_modules/yaml-eslint-parser": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/yaml-eslint-parser/-/yaml-eslint-parser-1.3.2.tgz",
-      "integrity": "sha512-odxVsHAkZYYglR30aPYRY4nUGJnoJ2y1ww2HDvZALo0BDETv9kWbi16J52eHs+PWRNmF4ub6nZqfVOeesOvntg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eslint-visitor-keys": "^3.0.0",
-        "yaml": "^2.0.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ota-meshi"
-      }
-    },
-    "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/yargs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yargs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/yargs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yargs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    }
-  }
+	"name": "advanced-audio-recorder",
+	"version": "1.5.0",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "advanced-audio-recorder",
+			"version": "1.5.0",
+			"license": "MIT",
+			"dependencies": {
+				"@mediabunny/flac-encoder": "1.50.4",
+				"@mediabunny/mp3-encoder": "1.50.4",
+				"mediabunny": "1.50.4"
+			},
+			"devDependencies": {
+				"@types/jest": "30.0.0",
+				"@types/node": "22.19.21",
+				"esbuild": "0.28.1",
+				"eslint": "10.4.1",
+				"eslint-config-prettier": "10.1.8",
+				"eslint-plugin-obsidianmd": "0.3.0",
+				"eslint-plugin-prettier": "^5.5.4",
+				"globals": "^16.5.0",
+				"husky": "^9.0.0",
+				"jest": "30.4.2",
+				"jest-environment-jsdom": "30.4.1",
+				"nano-staged": "0.8.0",
+				"obsidian": "1.12.3",
+				"prettier": "3.8.1",
+				"ts-jest": "29.4.11",
+				"tslib": "2.8.1",
+				"typescript": "6.0.3",
+				"typescript-eslint": "8.61.0"
+			}
+		},
+		"node_modules/@asamuzakjp/css-color": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+			"integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@csstools/css-calc": "^2.1.3",
+				"@csstools/css-color-parser": "^3.0.9",
+				"@csstools/css-parser-algorithms": "^3.0.4",
+				"@csstools/css-tokenizer": "^3.0.3",
+				"lru-cache": "^10.4.3"
+			}
+		},
+		"node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/@babel/code-frame": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+			"integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-validator-identifier": "^7.28.5",
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/compat-data": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+			"integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/core": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.29.0",
+				"@babel/generator": "^7.29.0",
+				"@babel/helper-compilation-targets": "^7.28.6",
+				"@babel/helper-module-transforms": "^7.28.6",
+				"@babel/helpers": "^7.28.6",
+				"@babel/parser": "^7.29.0",
+				"@babel/template": "^7.28.6",
+				"@babel/traverse": "^7.29.0",
+				"@babel/types": "^7.29.0",
+				"@jridgewell/remapping": "^2.3.5",
+				"convert-source-map": "^2.0.0",
+				"debug": "^4.1.0",
+				"gensync": "^1.0.0-beta.2",
+				"json5": "^2.2.3",
+				"semver": "^6.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/babel"
+			}
+		},
+		"node_modules/@babel/core/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/@babel/generator": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.0.tgz",
+			"integrity": "sha512-vSH118/wwM/pLR38g/Sgk05sNtro6TlTJKuiMXDaZqPUfjTFcudpCOt00IhOfj+1BFAX+UFAlzCU+6WXr3GLFQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^7.29.0",
+				"@babel/types": "^7.29.0",
+				"@jridgewell/gen-mapping": "^0.3.12",
+				"@jridgewell/trace-mapping": "^0.3.28",
+				"jsesc": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-compilation-targets": {
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+			"integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/compat-data": "^7.28.6",
+				"@babel/helper-validator-option": "^7.27.1",
+				"browserslist": "^4.24.0",
+				"lru-cache": "^5.1.1",
+				"semver": "^6.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/@babel/helper-globals": {
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+			"integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-module-imports": {
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+			"integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/traverse": "^7.28.6",
+				"@babel/types": "^7.28.6"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-module-transforms": {
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+			"integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-module-imports": "^7.28.6",
+				"@babel/helper-validator-identifier": "^7.28.5",
+				"@babel/traverse": "^7.28.6"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
+			}
+		},
+		"node_modules/@babel/helper-plugin-utils": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+			"integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-string-parser": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+			"integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-validator-identifier": {
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+			"integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-validator-option": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+			"integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helpers": {
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
+			"integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/template": "^7.28.6",
+				"@babel/types": "^7.28.6"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/parser": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+			"integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^7.29.0"
+			},
+			"bin": {
+				"parser": "bin/babel-parser.js"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-async-generators": {
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+			"integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-bigint": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+			"integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-class-properties": {
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+			"integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.12.13"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-class-static-block": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+			"integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-import-attributes": {
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
+			"integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.28.6"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-import-meta": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+			"integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-json-strings": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+			"integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-jsx": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+			"integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.29.7"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+			"integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+			"integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-numeric-separator": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+			"integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.10.4"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-object-rest-spread": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+			"integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-optional-catch-binding": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+			"integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-optional-chaining": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+			"integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-private-property-in-object": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+			"integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-top-level-await": {
+			"version": "7.14.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+			"integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.14.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-syntax-typescript": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+			"integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.29.7"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/template": {
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+			"integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.28.6",
+				"@babel/parser": "^7.28.6",
+				"@babel/types": "^7.28.6"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/traverse": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+			"integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.29.0",
+				"@babel/generator": "^7.29.0",
+				"@babel/helper-globals": "^7.28.0",
+				"@babel/parser": "^7.29.0",
+				"@babel/template": "^7.28.6",
+				"@babel/types": "^7.29.0",
+				"debug": "^4.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/types": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+			"integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-string-parser": "^7.27.1",
+				"@babel/helper-validator-identifier": "^7.28.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@bcoe/v8-coverage": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@codemirror/state": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.0.tgz",
+			"integrity": "sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@marijn/find-cluster-break": "^1.0.0"
+			}
+		},
+		"node_modules/@codemirror/view": {
+			"version": "6.38.6",
+			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.6.tgz",
+			"integrity": "sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@codemirror/state": "^6.5.0",
+				"crelt": "^1.0.6",
+				"style-mod": "^4.1.0",
+				"w3c-keyname": "^2.2.4"
+			}
+		},
+		"node_modules/@csstools/color-helpers": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+			"integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@csstools/css-calc": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+			"integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
+		"node_modules/@csstools/css-color-parser": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+			"integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@csstools/color-helpers": "^5.1.0",
+				"@csstools/css-calc": "^2.1.4"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
+		"node_modules/@csstools/css-parser-algorithms": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+			"integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
+		"node_modules/@csstools/css-tokenizer": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+			"integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@emnapi/core": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+			"integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.1",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/runtime": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/wasi-threads": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+			"integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+			"integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+			"integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+			"integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+			"integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+			"integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+			"integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+			"integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+			"integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+			"integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+			"integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+			"integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+			"integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+			"integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+			"integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+			"integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+			"integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+			"integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+			"integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+			"integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+			"integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@eslint-community/eslint-utils": {
+			"version": "4.9.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+			"integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"eslint-visitor-keys": "^3.4.3"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+			}
+		},
+		"node_modules/@eslint-community/regexpp": {
+			"version": "4.12.2",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+			"integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+			}
+		},
+		"node_modules/@eslint/config-array": {
+			"version": "0.23.5",
+			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+			"integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/object-schema": "^3.0.5",
+				"debug": "^4.3.1",
+				"minimatch": "^10.2.4"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/@eslint/config-array/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@eslint/config-array/node_modules/brace-expansion": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@eslint/config-array/node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@eslint/config-helpers": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+			"integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/core": "^1.2.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/@eslint/config-helpers/node_modules/@eslint/core": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+			"integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@types/json-schema": "^7.0.15"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/@eslint/core": {
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+			"integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@types/json-schema": "^7.0.15"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/@eslint/eslintrc": {
+			"version": "3.3.5",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+			"integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ajv": "^6.14.0",
+				"debug": "^4.3.2",
+				"espree": "^10.0.1",
+				"globals": "^14.0.0",
+				"ignore": "^5.2.0",
+				"import-fresh": "^3.2.1",
+				"js-yaml": "^4.1.1",
+				"minimatch": "^3.1.5",
+				"strip-json-comments": "^3.1.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@eslint/eslintrc/node_modules/eslint-visitor-keys": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@eslint/eslintrc/node_modules/espree": {
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+			"integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"acorn": "^8.15.0",
+				"acorn-jsx": "^5.3.2",
+				"eslint-visitor-keys": "^4.2.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@eslint/eslintrc/node_modules/globals": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+			"integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@eslint/js": {
+			"version": "9.39.4",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+			"integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://eslint.org/donate"
+			}
+		},
+		"node_modules/@eslint/json": {
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/@eslint/json/-/json-0.14.0.tgz",
+			"integrity": "sha512-rvR/EZtvUG3p9uqrSmcDJPYSH7atmWr0RnFWN6m917MAPx82+zQgPUmDu0whPFG6XTyM0vB/hR6c1Q63OaYtCQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/core": "^0.17.0",
+				"@eslint/plugin-kit": "^0.4.1",
+				"@humanwhocodes/momoa": "^3.3.10",
+				"natural-compare": "^1.4.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/@eslint/object-schema": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+			"integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/@eslint/plugin-kit": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+			"integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/core": "^0.17.0",
+				"levn": "^0.4.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/@humanfs/core": {
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+			"integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18.18.0"
+			}
+		},
+		"node_modules/@humanfs/node": {
+			"version": "0.16.7",
+			"resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+			"integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@humanfs/core": "^0.19.1",
+				"@humanwhocodes/retry": "^0.4.0"
+			},
+			"engines": {
+				"node": ">=18.18.0"
+			}
+		},
+		"node_modules/@humanwhocodes/module-importer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+			"integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+			"dev": true,
+			"engines": {
+				"node": ">=12.22"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/nzakas"
+			}
+		},
+		"node_modules/@humanwhocodes/momoa": {
+			"version": "3.3.10",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/momoa/-/momoa-3.3.10.tgz",
+			"integrity": "sha512-KWiFQpSAqEIyrTXko3hFNLeQvSK8zXlJQzhhxsyVn58WFRYXST99b3Nqnu+ttOtjds2Pl2grUHGpe2NzhPynuQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@humanwhocodes/retry": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+			"integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18.18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/nzakas"
+			}
+		},
+		"node_modules/@isaacs/cliui": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^5.1.2",
+				"string-width-cjs": "npm:string-width@^4.2.0",
+				"strip-ansi": "^7.0.1",
+				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+				"wrap-ansi": "^8.1.0",
+				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@istanbuljs/load-nyc-config": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+			"integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"camelcase": "^5.3.1",
+				"find-up": "^4.1.0",
+				"get-package-type": "^0.1.0",
+				"js-yaml": "^3.13.1",
+				"resolve-from": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"sprintf-js": "~1.0.2"
+			}
+		},
+		"node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"locate-path": "^5.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+			"version": "3.14.2",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+			"integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-locate": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-try": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-limit": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@istanbuljs/schema": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+			"integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@jest/console": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-30.4.1.tgz",
+			"integrity": "sha512-v3bhyxUh9Hgmo5p6hAOXe14/R3ZxZDOsvHleh4B07z3m/x4/ngPUXEm9XwK4sF4u+f+P2ORb0Ge+MgpaqRMVDA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"jest-message-util": "30.4.1",
+				"jest-util": "30.4.1",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/core": {
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-30.4.2.tgz",
+			"integrity": "sha512-TZJA6cPJUFxoWhxaLo8t0VX/MZX2wPWr0uIDvLSHIvN4gu9h02vSzqI2kBADG1ExqQlC+cY09xKMSreivvrChQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/console": "30.4.1",
+				"@jest/pattern": "30.4.0",
+				"@jest/reporters": "30.4.1",
+				"@jest/test-result": "30.4.1",
+				"@jest/transform": "30.4.1",
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"ansi-escapes": "^4.3.2",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"exit-x": "^0.2.2",
+				"fast-json-stable-stringify": "^2.1.0",
+				"graceful-fs": "^4.2.11",
+				"jest-changed-files": "30.4.1",
+				"jest-config": "30.4.2",
+				"jest-haste-map": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-regex-util": "30.4.0",
+				"jest-resolve": "30.4.1",
+				"jest-resolve-dependencies": "30.4.2",
+				"jest-runner": "30.4.2",
+				"jest-runtime": "30.4.2",
+				"jest-snapshot": "30.4.1",
+				"jest-util": "30.4.1",
+				"jest-validate": "30.4.1",
+				"jest-watcher": "30.4.1",
+				"pretty-format": "30.4.1",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+			},
+			"peerDependenciesMeta": {
+				"node-notifier": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@jest/diff-sequences": {
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
+			"integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/environment": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
+			"integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/fake-timers": "30.4.1",
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"jest-mock": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/environment-jsdom-abstract": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.4.1.tgz",
+			"integrity": "sha512-dSlKrqug3siYNHVnjwIldShY12wAH3spwRltO/+8VOjg0X+xEq7vOs3DbBs4LRKsu7OH+NUb9kuZUNBF9Ho3TA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/environment": "30.4.1",
+				"@jest/fake-timers": "30.4.1",
+				"@jest/types": "30.4.1",
+				"@types/jsdom": "^21.1.7",
+				"@types/node": "*",
+				"jest-mock": "30.4.1",
+				"jest-util": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"canvas": "^3.0.0",
+				"jsdom": "*"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@jest/expect": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.4.1.tgz",
+			"integrity": "sha512-ginrj6TMgh2GshLUGCjO94Ptx9HhdZA/I6A9iUfyeLKFtdAjnKzHDgzgP9HYQgbxM1lbXScQ2eUBz2lGeVDPWA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"expect": "30.4.1",
+				"jest-snapshot": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/expect-utils": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
+			"integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/get-type": "30.1.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/fake-timers": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
+			"integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.4.1",
+				"@sinonjs/fake-timers": "^15.4.0",
+				"@types/node": "*",
+				"jest-message-util": "30.4.1",
+				"jest-mock": "30.4.1",
+				"jest-util": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/get-type": {
+			"version": "30.1.0",
+			"resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+			"integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/globals": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.4.1.tgz",
+			"integrity": "sha512-ZbuY4cmXC8DkxYjfvT2DbcHWL2T6vmsMhXCDcmTB2T0y0gaezBI77ufq5ZAIdcRkYZ7NEQEDg1xFeKbxUJ5v5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/environment": "30.4.1",
+				"@jest/expect": "30.4.1",
+				"@jest/types": "30.4.1",
+				"jest-mock": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/pattern": {
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+			"integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*",
+				"jest-regex-util": "30.4.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/reporters": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.4.1.tgz",
+			"integrity": "sha512-/SnkPCzEQpUaBH81kjdEdDdo2WZl5hxw+BmLDGWjRkm8o7XlhjwsU36cqwe5PGBE5WYpBvDzRSdXx9rbGuJtNA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@bcoe/v8-coverage": "^0.2.3",
+				"@jest/console": "30.4.1",
+				"@jest/test-result": "30.4.1",
+				"@jest/transform": "30.4.1",
+				"@jest/types": "30.4.1",
+				"@jridgewell/trace-mapping": "^0.3.25",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"collect-v8-coverage": "^1.0.2",
+				"exit-x": "^0.2.2",
+				"glob": "^10.5.0",
+				"graceful-fs": "^4.2.11",
+				"istanbul-lib-coverage": "^3.0.0",
+				"istanbul-lib-instrument": "^6.0.0",
+				"istanbul-lib-report": "^3.0.0",
+				"istanbul-lib-source-maps": "^5.0.0",
+				"istanbul-reports": "^3.1.3",
+				"jest-message-util": "30.4.1",
+				"jest-util": "30.4.1",
+				"jest-worker": "30.4.1",
+				"slash": "^3.0.0",
+				"string-length": "^4.0.2",
+				"v8-to-istanbul": "^9.0.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+			},
+			"peerDependenciesMeta": {
+				"node-notifier": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@jest/schemas": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+			"integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@sinclair/typebox": "^0.34.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/snapshot-utils": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.4.1.tgz",
+			"integrity": "sha512-ObY4ljvQ95mt6iwKtVLetR/4yXiAgl3H4nJxhztr0MTjrN97TwDYrnCp/kF60Ec9HdhkWTHSu+Hg05aXfngpOA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.4.1",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"natural-compare": "^1.4.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/source-map": {
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-30.0.1.tgz",
+			"integrity": "sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.25",
+				"callsites": "^3.1.0",
+				"graceful-fs": "^4.2.11"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/test-result": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.4.1.tgz",
+			"integrity": "sha512-/ZG7pgEiOmmWkN9TplKbOu4id2N5lh7FHwRwlkgBVAzGdRH+OkkQ8wX/kIxg4zmd3ZQvAL1RwL2yWsvNYYECTw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/console": "30.4.1",
+				"@jest/types": "30.4.1",
+				"@types/istanbul-lib-coverage": "^2.0.6",
+				"collect-v8-coverage": "^1.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/test-sequencer": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.4.1.tgz",
+			"integrity": "sha512-PeYE+4td5rKjoRPxztObrXU+H8hsjZfxKMXOcmrr34JerSyB/ROOxbbicz8B7A5j9R9VayDnVPvBmedqCsFCdw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/test-result": "30.4.1",
+				"graceful-fs": "^4.2.11",
+				"jest-haste-map": "30.4.1",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/transform": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.4.1.tgz",
+			"integrity": "sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/core": "^7.27.4",
+				"@jest/types": "30.4.1",
+				"@jridgewell/trace-mapping": "^0.3.25",
+				"babel-plugin-istanbul": "^7.0.1",
+				"chalk": "^4.1.2",
+				"convert-source-map": "^2.0.0",
+				"fast-json-stable-stringify": "^2.1.0",
+				"graceful-fs": "^4.2.11",
+				"jest-haste-map": "30.4.1",
+				"jest-regex-util": "30.4.0",
+				"jest-util": "30.4.1",
+				"pirates": "^4.0.7",
+				"slash": "^3.0.0",
+				"write-file-atomic": "^5.0.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jest/types": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+			"integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/pattern": "30.4.0",
+				"@jest/schemas": "30.4.1",
+				"@types/istanbul-lib-coverage": "^2.0.6",
+				"@types/istanbul-reports": "^3.0.4",
+				"@types/node": "*",
+				"@types/yargs": "^17.0.33",
+				"chalk": "^4.1.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@jridgewell/gen-mapping": {
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+			"integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.0",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
+		"node_modules/@jridgewell/remapping": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+			"integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
+		"node_modules/@jridgewell/resolve-uri": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.31",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+			"integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
+		},
+		"node_modules/@marijn/find-cluster-break": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+			"integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@mediabunny/flac-encoder": {
+			"version": "1.50.4",
+			"resolved": "https://registry.npmjs.org/@mediabunny/flac-encoder/-/flac-encoder-1.50.4.tgz",
+			"integrity": "sha512-QWLRiLBxOa2QqshvIRN+znIy1pZvfQxDaN3rtE/RYypVV+Qan37diFxw/ICRLAAWYsg83nICmDaOn/1RtBwKxQ==",
+			"license": "MPL-2.0",
+			"funding": {
+				"type": "individual",
+				"url": "https://github.com/sponsors/Vanilagy"
+			},
+			"peerDependencies": {
+				"mediabunny": "^1.0.0"
+			}
+		},
+		"node_modules/@mediabunny/mp3-encoder": {
+			"version": "1.50.4",
+			"resolved": "https://registry.npmjs.org/@mediabunny/mp3-encoder/-/mp3-encoder-1.50.4.tgz",
+			"integrity": "sha512-wGjGq0rm5zPXkLIRZFHcVNBlgRnY4kB1LWTFj8qtrXuZQcLPNqZJOka8Ytggdx7Fn6drWhetFOqA9CHf7PVTww==",
+			"license": "MPL-2.0",
+			"funding": {
+				"type": "individual",
+				"url": "https://github.com/sponsors/Vanilagy"
+			},
+			"peerDependencies": {
+				"mediabunny": "^1.0.0"
+			}
+		},
+		"node_modules/@napi-rs/wasm-runtime": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+			"integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@tybys/wasm-util": "^0.10.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			},
+			"peerDependencies": {
+				"@emnapi/core": "^1.7.1",
+				"@emnapi/runtime": "^1.7.1"
+			}
+		},
+		"node_modules/@pkgjs/parseargs": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@pkgr/core": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.2.tgz",
+			"integrity": "sha512-fdDH1LSGfZdTH2sxdpVMw31BanV28K/Gry0cVFxaNP77neJSkd82mM8ErPNYs9e+0O7SdHBLTDzDgwUuy18RnQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/unts"
+			}
+		},
+		"node_modules/@rtsao/scc": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
+			"integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@sinclair/typebox": {
+			"version": "0.34.49",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+			"integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@sinonjs/commons": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+			"integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"type-detect": "4.0.8"
+			}
+		},
+		"node_modules/@sinonjs/fake-timers": {
+			"version": "15.4.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+			"integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@sinonjs/commons": "^3.0.1"
+			}
+		},
+		"node_modules/@tybys/wasm-util": {
+			"version": "0.10.2",
+			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+			"integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@types/babel__core": {
+			"version": "7.20.5",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+			"integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^7.20.7",
+				"@babel/types": "^7.20.7",
+				"@types/babel__generator": "*",
+				"@types/babel__template": "*",
+				"@types/babel__traverse": "*"
+			}
+		},
+		"node_modules/@types/babel__generator": {
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+			"integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"node_modules/@types/babel__template": {
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+			"integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/parser": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"node_modules/@types/babel__traverse": {
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+			"integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^7.28.2"
+			}
+		},
+		"node_modules/@types/codemirror": {
+			"version": "5.60.8",
+			"resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.8.tgz",
+			"integrity": "sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==",
+			"dev": true,
+			"dependencies": {
+				"@types/tern": "*"
+			}
+		},
+		"node_modules/@types/dom-mediacapture-transform": {
+			"version": "0.1.11",
+			"resolved": "https://registry.npmjs.org/@types/dom-mediacapture-transform/-/dom-mediacapture-transform-0.1.11.tgz",
+			"integrity": "sha512-Y2p+nGf1bF2XMttBnsVPHUWzRRZzqUoJAKmiP10b5umnO6DDrWI0BrGDJy1pOHoOULVmGSfFNkQrAlC5dcj6nQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/dom-webcodecs": "*"
+			}
+		},
+		"node_modules/@types/dom-webcodecs": {
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/@types/dom-webcodecs/-/dom-webcodecs-0.1.13.tgz",
+			"integrity": "sha512-O5hkiFIcjjszPIYyUSyvScyvrBoV3NOEEZx/pMlsu44TKzWNkLVBBxnxJz42in5n3QIolYOcBYFCPZZ0h8SkwQ==",
+			"license": "MIT"
+		},
+		"node_modules/@types/eslint": {
+			"version": "9.6.1",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+			"integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "*",
+				"@types/json-schema": "*"
+			}
+		},
+		"node_modules/@types/esrecurse": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+			"integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/estree": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/istanbul-lib-coverage": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+			"integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/istanbul-lib-report": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+			"integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/istanbul-lib-coverage": "*"
+			}
+		},
+		"node_modules/@types/istanbul-reports": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+			"integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/istanbul-lib-report": "*"
+			}
+		},
+		"node_modules/@types/jest": {
+			"version": "30.0.0",
+			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+			"integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"expect": "^30.0.0",
+				"pretty-format": "^30.0.0"
+			}
+		},
+		"node_modules/@types/jsdom": {
+			"version": "21.1.7",
+			"resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+			"integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*",
+				"@types/tough-cookie": "*",
+				"parse5": "^7.0.0"
+			}
+		},
+		"node_modules/@types/json-schema": {
+			"version": "7.0.15",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/json5": {
+			"version": "0.0.29",
+			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/node": {
+			"version": "22.19.21",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
+			"integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
+		"node_modules/@types/node/node_modules/undici-types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/stack-utils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+			"integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/tern": {
+			"version": "0.23.9",
+			"resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.9.tgz",
+			"integrity": "sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==",
+			"dev": true,
+			"dependencies": {
+				"@types/estree": "*"
+			}
+		},
+		"node_modules/@types/tough-cookie": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+			"integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/yargs": {
+			"version": "17.0.35",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+			"integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/yargs-parser": "*"
+			}
+		},
+		"node_modules/@types/yargs-parser": {
+			"version": "21.0.3",
+			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+			"integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@typescript-eslint/eslint-plugin": {
+			"version": "8.61.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.0.tgz",
+			"integrity": "sha512-bFNvl9ZczlVb+wR2Akszf3gHfKVj/8WanXaGJ3UstTA7brNKg0cNdk6X1Psu5V7MZ2oQtzZKOEzIUehaoxbDGw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-community/regexpp": "^4.12.2",
+				"@typescript-eslint/scope-manager": "8.61.0",
+				"@typescript-eslint/type-utils": "8.61.0",
+				"@typescript-eslint/utils": "8.61.0",
+				"@typescript-eslint/visitor-keys": "8.61.0",
+				"ignore": "^7.0.5",
+				"natural-compare": "^1.4.0",
+				"ts-api-utils": "^2.5.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"@typescript-eslint/parser": "^8.61.0",
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/@typescript-eslint/parser": {
+			"version": "8.61.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.0.tgz",
+			"integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/scope-manager": "8.61.0",
+				"@typescript-eslint/types": "8.61.0",
+				"@typescript-eslint/typescript-estree": "8.61.0",
+				"@typescript-eslint/visitor-keys": "8.61.0",
+				"debug": "^4.4.3"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/@typescript-eslint/scope-manager": {
+			"version": "8.61.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.0.tgz",
+			"integrity": "sha512-IWdXFHFSb6mlC3HPc7QsLDm5zYEbUla6trDEHf32D3/dnuUyXd87plScSNXSbm0/RxMvObpI17sv/EDTGrGZkA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "8.61.0",
+				"@typescript-eslint/visitor-keys": "8.61.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils": {
+			"version": "8.61.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.61.0.tgz",
+			"integrity": "sha512-TuBiQYIkd97yBfInHCTKVYMbX4kvEmpOEuixIuzCU9p8BGT1SfyyO0d0IfDMbPIHcjn/hWnusUX5e8v5Xg+X8A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "8.61.0",
+				"@typescript-eslint/typescript-estree": "8.61.0",
+				"@typescript-eslint/utils": "8.61.0",
+				"debug": "^4.4.3",
+				"ts-api-utils": "^2.5.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/@typescript-eslint/types": {
+			"version": "8.61.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.0.tgz",
+			"integrity": "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree": {
+			"version": "8.61.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.0.tgz",
+			"integrity": "sha512-42zatd5qSvvcV1JdDBCLxYRznvP4eIHpPoZXdkPFnAmanA4FuZ5dibSnCBggY8hQnqajPpoGjXFdZ7fIJKQnlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/project-service": "8.61.0",
+				"@typescript-eslint/tsconfig-utils": "8.61.0",
+				"@typescript-eslint/types": "8.61.0",
+				"@typescript-eslint/visitor-keys": "8.61.0",
+				"debug": "^4.4.3",
+				"minimatch": "^10.2.2",
+				"semver": "^7.7.3",
+				"tinyglobby": "^0.2.15",
+				"ts-api-utils": "^2.5.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/project-service": {
+			"version": "8.61.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.0.tgz",
+			"integrity": "sha512-DV42F7MLJO6Rax7SK1yg43tcnEfGUrurSpSxKuVX+a3RCTzBlH3fuxprrOJXKCJGAaw82xXocikJ0uQaqwXgGA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/tsconfig-utils": "^8.61.0",
+				"@typescript-eslint/types": "^8.61.0",
+				"debug": "^4.4.3"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/tsconfig-utils": {
+			"version": "8.61.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.0.tgz",
+			"integrity": "sha512-O5Amvdv9ztMpxpf+vmFULGG78IE6Qwdr3bCGvqwG4nwc9H2qXkOYJJnRbRHyMkQTjv1d03olqwwwzHLMqpFePQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@typescript-eslint/utils": {
+			"version": "8.61.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.0.tgz",
+			"integrity": "sha512-3bzFt7ImFMW/jVYwJamDoe/dMOdFLSC6pom6rRjdh4SZJEYupyMzem8e7vKZLclLfpHjlwSAXOUxtKxGXUiLqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.9.1",
+				"@typescript-eslint/scope-manager": "8.61.0",
+				"@typescript-eslint/types": "8.61.0",
+				"@typescript-eslint/typescript-estree": "8.61.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/@typescript-eslint/visitor-keys": {
+			"version": "8.61.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.0.tgz",
+			"integrity": "sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "8.61.0",
+				"eslint-visitor-keys": "^5.0.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@ungap/structured-clone": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+			"integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/@unrs/resolver-binding-android-arm-eabi": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.12.2.tgz",
+			"integrity": "sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-android-arm64": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.12.2.tgz",
+			"integrity": "sha512-YGCRZv/9GLhwmz6mYDeTsm/92BAyR28l6c2ReweVW5pWgfsitWLY8upvfRlGdoyD8HjeTHSYJWyZGD4KJA/nFQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-darwin-arm64": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.12.2.tgz",
+			"integrity": "sha512-u9DiNT1auQMO20A9SyTuG3wUgQWB9Z7KjAg0uFuCDR1FsAY8A0CG2S6JpHS1xwm/w1G08bjXZDcyOCjv1WAm2w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-darwin-x64": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.12.2.tgz",
+			"integrity": "sha512-f7rPLi/T1HVKZu/u6t87lroib16n8vrSzcyxI7lg4BGO9UF26KhQL44sd9eOUgrTYhvRXtWOIZT5PejdPyJfUA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-freebsd-x64": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.12.2.tgz",
+			"integrity": "sha512-BpcOjWCJub6nRZUS2zA20pmLvjtqAtGejETaIyRLiZiQf++cbrjltLA5NN/xaXfqeOBOSlMFbemIl5/S5tljmg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.12.2.tgz",
+			"integrity": "sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.12.2.tgz",
+			"integrity": "sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.12.2.tgz",
+			"integrity": "sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.12.2.tgz",
+			"integrity": "sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-loong64-gnu": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-gnu/-/resolver-binding-linux-loong64-gnu-1.12.2.tgz",
+			"integrity": "sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-loong64-musl": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-musl/-/resolver-binding-linux-loong64-musl-1.12.2.tgz",
+			"integrity": "sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.12.2.tgz",
+			"integrity": "sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.12.2.tgz",
+			"integrity": "sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.12.2.tgz",
+			"integrity": "sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.12.2.tgz",
+			"integrity": "sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.12.2.tgz",
+			"integrity": "sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-linux-x64-musl": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.12.2.tgz",
+			"integrity": "sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-openharmony-arm64": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-openharmony-arm64/-/resolver-binding-openharmony-arm64-1.12.2.tgz",
+			"integrity": "sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-wasm32-wasi": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.12.2.tgz",
+			"integrity": "sha512-tYFDIkMxSflfEc/h92ZWNsZlHSwgimbNHSO3PL2JWQHfCuC2q316jMyYU9TIWZsFK2bQwyK5VAdYgn8ygPj69A==",
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/core": "1.10.0",
+				"@emnapi/runtime": "1.10.0",
+				"@napi-rs/wasm-runtime": "^1.1.4"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
+			"integrity": "sha512-qzNyg3xL0VPQmCaUh+N5jSitce6k+uCBfMDesWRnlULOZaqUkaJ0ybdT+UqlAWJoQjuqfIU/0Ptx9bteN4D82g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.12.2.tgz",
+			"integrity": "sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.12.2.tgz",
+			"integrity": "sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/acorn": {
+			"version": "8.17.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+			"integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/acorn-jsx": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/ajv": {
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/ansi-escapes": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+			"integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"type-fest": "^0.21.3"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/anymatch": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+			"integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"normalize-path": "^3.0.0",
+				"picomatch": "^2.0.4"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true,
+			"license": "Python-2.0"
+		},
+		"node_modules/array-buffer-byte-length": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+			"integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.3",
+				"is-array-buffer": "^3.0.5"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/array-includes": {
+			"version": "3.1.9",
+			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+			"integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.4",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.24.0",
+				"es-object-atoms": "^1.1.1",
+				"get-intrinsic": "^1.3.0",
+				"is-string": "^1.1.1",
+				"math-intrinsics": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/array.prototype.findlast": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+			"integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.2",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.0.0",
+				"es-shim-unscopables": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/array.prototype.findlastindex": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
+			"integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.4",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.9",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.1.1",
+				"es-shim-unscopables": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/array.prototype.flat": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+			"integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.5",
+				"es-shim-unscopables": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/array.prototype.flatmap": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+			"integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.5",
+				"es-shim-unscopables": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/array.prototype.tosorted": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+			"integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.3",
+				"es-errors": "^1.3.0",
+				"es-shim-unscopables": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/arraybuffer.prototype.slice": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+			"integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"array-buffer-byte-length": "^1.0.1",
+				"call-bind": "^1.0.8",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.5",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.6",
+				"is-array-buffer": "^3.0.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/async-function": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+			"integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/available-typed-arrays": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+			"integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"possible-typed-array-names": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/babel-jest": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.4.1.tgz",
+			"integrity": "sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/transform": "30.4.1",
+				"@types/babel__core": "^7.20.5",
+				"babel-plugin-istanbul": "^7.0.1",
+				"babel-preset-jest": "30.4.0",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.11.0 || ^8.0.0-0"
+			}
+		},
+		"node_modules/babel-plugin-istanbul": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
+			"integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"workspaces": [
+				"test/babel-8"
+			],
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@istanbuljs/load-nyc-config": "^1.0.0",
+				"@istanbuljs/schema": "^0.1.3",
+				"istanbul-lib-instrument": "^6.0.2",
+				"test-exclude": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/babel-plugin-jest-hoist": {
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.4.0.tgz",
+			"integrity": "sha512-9EdtWM/sSfXLOGLwSn+GS6pIXyBnL07/8gyJlwFXjWy4DxMOyItqyUT29d4lQiS380EZwYlX7/At4PgBS+m2aA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/babel__core": "^7.20.5"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/babel-preset-current-node-syntax": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+			"integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/plugin-syntax-async-generators": "^7.8.4",
+				"@babel/plugin-syntax-bigint": "^7.8.3",
+				"@babel/plugin-syntax-class-properties": "^7.12.13",
+				"@babel/plugin-syntax-class-static-block": "^7.14.5",
+				"@babel/plugin-syntax-import-attributes": "^7.24.7",
+				"@babel/plugin-syntax-import-meta": "^7.10.4",
+				"@babel/plugin-syntax-json-strings": "^7.8.3",
+				"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+				"@babel/plugin-syntax-numeric-separator": "^7.10.4",
+				"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+				"@babel/plugin-syntax-optional-chaining": "^7.8.3",
+				"@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+				"@babel/plugin-syntax-top-level-await": "^7.14.5"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0 || ^8.0.0-0"
+			}
+		},
+		"node_modules/babel-preset-jest": {
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.4.0.tgz",
+			"integrity": "sha512-lBY4jxsNmCnSiu7kquw8ZC9F4+XLMOKypT3RnNHPvU2Kpd4W0xaPuLr5ZkRyOsvLYAY4yaW1ZwTW4xB7NIiZzg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"babel-plugin-jest-hoist": "30.4.0",
+				"babel-preset-current-node-syntax": "^1.2.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.11.0 || ^8.0.0-beta.1"
+			}
+		},
+		"node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true
+		},
+		"node_modules/baseline-browser-mapping": {
+			"version": "2.9.19",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
+			"integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"baseline-browser-mapping": "dist/cli.js"
+			}
+		},
+		"node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/browserslist": {
+			"version": "4.28.1",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+			"integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"baseline-browser-mapping": "^2.9.0",
+				"caniuse-lite": "^1.0.30001759",
+				"electron-to-chromium": "^1.5.263",
+				"node-releases": "^2.0.27",
+				"update-browserslist-db": "^1.2.0"
+			},
+			"bin": {
+				"browserslist": "cli.js"
+			},
+			"engines": {
+				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+			}
+		},
+		"node_modules/bs-logger": {
+			"version": "0.2.6",
+			"resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+			"integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-json-stable-stringify": "2.x"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/bser": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+			"integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"node-int64": "^0.4.0"
+			}
+		},
+		"node_modules/buffer-from": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/call-bind": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+			"integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"get-intrinsic": "^1.3.0",
+				"set-function-length": "^1.2.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/call-bind-apply-helpers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/call-bound": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"get-intrinsic": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/callsites": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/camelcase": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/caniuse-lite": {
+			"version": "1.0.30001767",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001767.tgz",
+			"integrity": "sha512-34+zUAMhSH+r+9eKmYG+k2Rpt8XttfE4yXAjoZvkAPs15xcYQhyBYdalJ65BzivAvGRMViEjy6oKr/S91loekQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "CC-BY-4.0"
+		},
+		"node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/char-regex": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+			"integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/ci-info": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+			"integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cjs-module-lexer": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+			"integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/cliui": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/cliui/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cliui/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/cliui/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cliui/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cliui/node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/co": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+			"integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"iojs": ">= 1.0.0",
+				"node": ">= 0.12.0"
+			}
+		},
+		"node_modules/collect-v8-coverage": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+			"integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
+		"node_modules/concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+			"dev": true
+		},
+		"node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/crelt": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+			"integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/cross-spawn": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/cssstyle": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+			"integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@asamuzakjp/css-color": "^3.2.0",
+				"rrweb-cssom": "^0.8.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/data-urls": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+			"integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"whatwg-mimetype": "^4.0.0",
+				"whatwg-url": "^14.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/data-view-buffer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+			"integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.3",
+				"es-errors": "^1.3.0",
+				"is-data-view": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/data-view-byte-length": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+			"integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.3",
+				"es-errors": "^1.3.0",
+				"is-data-view": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/inspect-js"
+			}
+		},
+		"node_modules/data-view-byte-offset": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+			"integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"is-data-view": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/decimal.js": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/dedent": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+			"integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"babel-plugin-macros": "^3.1.0"
+			},
+			"peerDependenciesMeta": {
+				"babel-plugin-macros": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/deep-is": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+			"dev": true
+		},
+		"node_modules/deepmerge": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+			"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/define-data-property": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/define-properties": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+			"integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"define-data-property": "^1.0.1",
+				"has-property-descriptors": "^1.0.0",
+				"object-keys": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/detect-newline": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+			"integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/doctrine": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+			"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"esutils": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/dunder-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/eastasianwidth": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/electron-to-chromium": {
+			"version": "1.5.283",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.283.tgz",
+			"integrity": "sha512-3vifjt1HgrGW/h76UEeny+adYApveS9dH2h3p57JYzBSXJIKUJAvtmIytDKjcSCt9xHfrNCFJ7gts6vkhuq++w==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/emittery": {
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+			"integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/emittery?sponsor=1"
+			}
+		},
+		"node_modules/emoji-regex": {
+			"version": "9.2.2",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/empathic": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
+			"integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/enhanced-resolve": {
+			"version": "5.24.0",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.0.tgz",
+			"integrity": "sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.4",
+				"tapable": "^2.3.3"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/entities": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+			"integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/error-ex": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+			"integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-arrayish": "^0.2.1"
+			}
+		},
+		"node_modules/es-abstract": {
+			"version": "1.24.2",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+			"integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"array-buffer-byte-length": "^1.0.2",
+				"arraybuffer.prototype.slice": "^1.0.4",
+				"available-typed-arrays": "^1.0.7",
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.4",
+				"data-view-buffer": "^1.0.2",
+				"data-view-byte-length": "^1.0.2",
+				"data-view-byte-offset": "^1.0.1",
+				"es-define-property": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.1.1",
+				"es-set-tostringtag": "^2.1.0",
+				"es-to-primitive": "^1.3.0",
+				"function.prototype.name": "^1.1.8",
+				"get-intrinsic": "^1.3.0",
+				"get-proto": "^1.0.1",
+				"get-symbol-description": "^1.1.0",
+				"globalthis": "^1.0.4",
+				"gopd": "^1.2.0",
+				"has-property-descriptors": "^1.0.2",
+				"has-proto": "^1.2.0",
+				"has-symbols": "^1.1.0",
+				"hasown": "^2.0.2",
+				"internal-slot": "^1.1.0",
+				"is-array-buffer": "^3.0.5",
+				"is-callable": "^1.2.7",
+				"is-data-view": "^1.0.2",
+				"is-negative-zero": "^2.0.3",
+				"is-regex": "^1.2.1",
+				"is-set": "^2.0.3",
+				"is-shared-array-buffer": "^1.0.4",
+				"is-string": "^1.1.1",
+				"is-typed-array": "^1.1.15",
+				"is-weakref": "^1.1.1",
+				"math-intrinsics": "^1.1.0",
+				"object-inspect": "^1.13.4",
+				"object-keys": "^1.1.1",
+				"object.assign": "^4.1.7",
+				"own-keys": "^1.0.1",
+				"regexp.prototype.flags": "^1.5.4",
+				"safe-array-concat": "^1.1.3",
+				"safe-push-apply": "^1.0.0",
+				"safe-regex-test": "^1.1.0",
+				"set-proto": "^1.0.0",
+				"stop-iteration-iterator": "^1.1.0",
+				"string.prototype.trim": "^1.2.10",
+				"string.prototype.trimend": "^1.0.9",
+				"string.prototype.trimstart": "^1.0.8",
+				"typed-array-buffer": "^1.0.3",
+				"typed-array-byte-length": "^1.0.3",
+				"typed-array-byte-offset": "^1.0.4",
+				"typed-array-length": "^1.0.7",
+				"unbox-primitive": "^1.1.0",
+				"which-typed-array": "^1.1.19"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/es-define-property": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-iterator-helpers": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.3.tgz",
+			"integrity": "sha512-0PuBxFi+4uPanB97iDxCLWuHeYud2FALrw5HFZGtAF38UpJDbDC8frwp2cnDyae692CQ0dou60UwWfhgsa4U/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.9",
+				"call-bound": "^1.0.4",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.24.2",
+				"es-errors": "^1.3.0",
+				"es-set-tostringtag": "^2.1.0",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.3.0",
+				"globalthis": "^1.0.4",
+				"gopd": "^1.2.0",
+				"has-property-descriptors": "^1.0.2",
+				"has-proto": "^1.2.0",
+				"has-symbols": "^1.1.0",
+				"internal-slot": "^1.1.0",
+				"iterator.prototype": "^1.1.5",
+				"math-intrinsics": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-object-atoms": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-set-tostringtag": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+			"integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.6",
+				"has-tostringtag": "^1.0.2",
+				"hasown": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-shim-unscopables": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+			"integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"hasown": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-to-primitive": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+			"integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-callable": "^1.2.7",
+				"is-date-object": "^1.0.5",
+				"is-symbol": "^1.0.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/esbuild": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+			"integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.28.1",
+				"@esbuild/android-arm": "0.28.1",
+				"@esbuild/android-arm64": "0.28.1",
+				"@esbuild/android-x64": "0.28.1",
+				"@esbuild/darwin-arm64": "0.28.1",
+				"@esbuild/darwin-x64": "0.28.1",
+				"@esbuild/freebsd-arm64": "0.28.1",
+				"@esbuild/freebsd-x64": "0.28.1",
+				"@esbuild/linux-arm": "0.28.1",
+				"@esbuild/linux-arm64": "0.28.1",
+				"@esbuild/linux-ia32": "0.28.1",
+				"@esbuild/linux-loong64": "0.28.1",
+				"@esbuild/linux-mips64el": "0.28.1",
+				"@esbuild/linux-ppc64": "0.28.1",
+				"@esbuild/linux-riscv64": "0.28.1",
+				"@esbuild/linux-s390x": "0.28.1",
+				"@esbuild/linux-x64": "0.28.1",
+				"@esbuild/netbsd-arm64": "0.28.1",
+				"@esbuild/netbsd-x64": "0.28.1",
+				"@esbuild/openbsd-arm64": "0.28.1",
+				"@esbuild/openbsd-x64": "0.28.1",
+				"@esbuild/openharmony-arm64": "0.28.1",
+				"@esbuild/sunos-x64": "0.28.1",
+				"@esbuild/win32-arm64": "0.28.1",
+				"@esbuild/win32-ia32": "0.28.1",
+				"@esbuild/win32-x64": "0.28.1"
+			}
+		},
+		"node_modules/escalade": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/escape-string-regexp": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint": {
+			"version": "10.4.1",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.1.tgz",
+			"integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.8.0",
+				"@eslint-community/regexpp": "^4.12.2",
+				"@eslint/config-array": "^0.23.5",
+				"@eslint/config-helpers": "^0.6.0",
+				"@eslint/core": "^1.2.1",
+				"@eslint/plugin-kit": "^0.7.2",
+				"@humanfs/node": "^0.16.6",
+				"@humanwhocodes/module-importer": "^1.0.1",
+				"@humanwhocodes/retry": "^0.4.2",
+				"@types/estree": "^1.0.6",
+				"ajv": "^6.14.0",
+				"cross-spawn": "^7.0.6",
+				"debug": "^4.3.2",
+				"escape-string-regexp": "^4.0.0",
+				"eslint-scope": "^9.1.2",
+				"eslint-visitor-keys": "^5.0.1",
+				"espree": "^11.2.0",
+				"esquery": "^1.7.0",
+				"esutils": "^2.0.2",
+				"fast-deep-equal": "^3.1.3",
+				"file-entry-cache": "^8.0.0",
+				"find-up": "^5.0.0",
+				"glob-parent": "^6.0.2",
+				"ignore": "^5.2.0",
+				"imurmurhash": "^0.1.4",
+				"is-glob": "^4.0.0",
+				"json-stable-stringify-without-jsonify": "^1.0.1",
+				"minimatch": "^10.2.4",
+				"natural-compare": "^1.4.0",
+				"optionator": "^0.9.3"
+			},
+			"bin": {
+				"eslint": "bin/eslint.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://eslint.org/donate"
+			},
+			"peerDependencies": {
+				"jiti": "*"
+			},
+			"peerDependenciesMeta": {
+				"jiti": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/eslint-compat-utils": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.5.1.tgz",
+			"integrity": "sha512-3z3vFexKIEnjHE3zCMRo6fn/e44U7T1khUjg+Hp0ZQMCigh28rALD0nPFBcGZuiLC5rLZa2ubQHDRln09JfU2Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"peerDependencies": {
+				"eslint": ">=6.0.0"
+			}
+		},
+		"node_modules/eslint-config-prettier": {
+			"version": "10.1.8",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+			"integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"eslint-config-prettier": "bin/cli.js"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint-config-prettier"
+			},
+			"peerDependencies": {
+				"eslint": ">=7.0.0"
+			}
+		},
+		"node_modules/eslint-import-resolver-node": {
+			"version": "0.3.10",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.10.tgz",
+			"integrity": "sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^3.2.7",
+				"is-core-module": "^2.16.1",
+				"resolve": "^2.0.0-next.6"
+			}
+		},
+		"node_modules/eslint-import-resolver-node/node_modules/debug": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+			"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.1"
+			}
+		},
+		"node_modules/eslint-module-utils": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.13.0.tgz",
+			"integrity": "sha512-bLohSkT6469rRs8czj0tLTD8vaeIS/whvPRJVjDr7IuoTT1k5DYDERlNycjDj/HkOlvQdYurmfZ/g3fG5bgeLQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^3.2.7"
+			},
+			"engines": {
+				"node": ">=4"
+			},
+			"peerDependenciesMeta": {
+				"eslint": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/eslint-module-utils/node_modules/debug": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+			"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.1"
+			}
+		},
+		"node_modules/eslint-plugin-depend": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-depend/-/eslint-plugin-depend-1.3.1.tgz",
+			"integrity": "sha512-1uo2rFAr9vzNrCYdp7IBZRB54LiyVxfaIso0R6/QV3t6Dax6DTbW/EV2Hktf0f4UtmGHK8UyzJWI382pwW04jw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"empathic": "^2.0.0",
+				"module-replacements": "^2.8.0",
+				"semver": "^7.6.3"
+			}
+		},
+		"node_modules/eslint-plugin-es-x": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.8.0.tgz",
+			"integrity": "sha512-7Ds8+wAAoV3T+LAKeu39Y5BzXCrGKrcISfgKEqTS4BDN8SFEDQd0S43jiQ8vIa3wUKD07qitZdfzlenSi8/0qQ==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/ota-meshi",
+				"https://opencollective.com/eslint"
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.1.2",
+				"@eslint-community/regexpp": "^4.11.0",
+				"eslint-compat-utils": "^0.5.1"
+			},
+			"engines": {
+				"node": "^14.18.0 || >=16.0.0"
+			},
+			"peerDependencies": {
+				"eslint": ">=8"
+			}
+		},
+		"node_modules/eslint-plugin-json-schema-validator": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-json-schema-validator/-/eslint-plugin-json-schema-validator-5.1.0.tgz",
+			"integrity": "sha512-ZmVyxRIjm58oqe2kTuy90PpmZPrrKvOjRPXKzq8WCgRgAkidCgm5X8domL2KSfadZ3QFAmifMgGTcVNhZ5ez2g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.3.0",
+				"ajv": "^8.0.0",
+				"debug": "^4.3.1",
+				"eslint-compat-utils": "^0.5.0",
+				"json-schema-migrate": "^2.0.0",
+				"jsonc-eslint-parser": "^2.0.0",
+				"minimatch": "^8.0.0",
+				"synckit": "^0.9.0",
+				"toml-eslint-parser": "^0.9.0",
+				"tunnel-agent": "^0.6.0",
+				"yaml-eslint-parser": "^1.0.0"
+			},
+			"engines": {
+				"node": "^14.18.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ota-meshi"
+			},
+			"peerDependencies": {
+				"eslint": ">=6.0.0"
+			}
+		},
+		"node_modules/eslint-plugin-json-schema-validator/node_modules/ajv": {
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/eslint-plugin-json-schema-validator/node_modules/brace-expansion": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/eslint-plugin-json-schema-validator/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/eslint-plugin-json-schema-validator/node_modules/minimatch": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
+			"integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/eslint-plugin-n": {
+			"version": "17.10.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.10.3.tgz",
+			"integrity": "sha512-ySZBfKe49nQZWR1yFaA0v/GsH6Fgp8ah6XV0WDz6CN8WO0ek4McMzb7A2xnf4DCYV43frjCygvb9f/wx7UUxRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.4.0",
+				"enhanced-resolve": "^5.17.0",
+				"eslint-plugin-es-x": "^7.5.0",
+				"get-tsconfig": "^4.7.0",
+				"globals": "^15.8.0",
+				"ignore": "^5.2.4",
+				"minimatch": "^9.0.5",
+				"semver": "^7.5.3"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			},
+			"peerDependencies": {
+				"eslint": ">=8.23.0"
+			}
+		},
+		"node_modules/eslint-plugin-n/node_modules/brace-expansion": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+			"integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/eslint-plugin-n/node_modules/globals": {
+			"version": "15.15.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+			"integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint-plugin-n/node_modules/minimatch": {
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/eslint-plugin-no-unsanitized": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-no-unsanitized/-/eslint-plugin-no-unsanitized-4.1.5.tgz",
+			"integrity": "sha512-MSB4hXPVFQrI8weqzs6gzl7reP2k/qSjtCoL2vUMSDejIIq9YL1ZKvq5/ORBXab/PvfBBrWO2jWviYpL+4Ghfg==",
+			"dev": true,
+			"license": "MPL-2.0",
+			"peerDependencies": {
+				"eslint": "^9 || ^10"
+			}
+		},
+		"node_modules/eslint-plugin-obsidianmd": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-obsidianmd/-/eslint-plugin-obsidianmd-0.3.0.tgz",
+			"integrity": "sha512-QvGDI6B2nxJBrsZKGTg31da2A/fEJNlnwN+fRZkaoPIu1QL3fYXUdpP7ThyMdr/0iTYQxifb9lt2X9cpydQx1w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@eslint/config-helpers": "^0.4.2",
+				"@eslint/js": "^9.30.1",
+				"@eslint/json": "0.14.0",
+				"@microsoft/eslint-plugin-sdl": "^1.1.0",
+				"@types/eslint": "9.6.1",
+				"@types/node": "20.12.12",
+				"@typescript-eslint/types": "^8.33.1",
+				"@typescript-eslint/utils": "^8.33.1",
+				"eslint": ">=9.0.0",
+				"eslint-plugin-depend": "1.3.1",
+				"eslint-plugin-import": "^2.31.0",
+				"eslint-plugin-json-schema-validator": "5.1.0",
+				"eslint-plugin-no-unsanitized": "^4.1.5",
+				"eslint-plugin-security": "2.1.1",
+				"globals": "14.0.0",
+				"obsidian": "1.12.3",
+				"semver": "^7.7.4",
+				"typescript": "5.4.5",
+				"typescript-eslint": "^8.35.1"
+			},
+			"bin": {
+				"eslint-plugin-obsidian": "dist/lib/index.js"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@eslint/js": "^9.30.1",
+				"@eslint/json": "0.14.0",
+				"eslint": ">=9.0.0",
+				"obsidian": "1.8.7",
+				"typescript-eslint": "^8.35.1"
+			}
+		},
+		"node_modules/eslint-plugin-obsidianmd/node_modules/@eslint/config-array": {
+			"version": "0.21.2",
+			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+			"integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/object-schema": "^2.1.7",
+				"debug": "^4.3.1",
+				"minimatch": "^3.1.5"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/eslint-plugin-obsidianmd/node_modules/@eslint/config-helpers": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+			"integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/core": "^0.17.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/eslint-plugin-obsidianmd/node_modules/@eslint/object-schema": {
+			"version": "2.1.7",
+			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+			"integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/eslint-plugin-obsidianmd/node_modules/@microsoft/eslint-plugin-sdl": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@microsoft/eslint-plugin-sdl/-/eslint-plugin-sdl-1.1.0.tgz",
+			"integrity": "sha512-dxdNHOemLnBhfY3eByrujX9KyLigcNtW8sU+axzWv5nLGcsSBeKW2YYyTpfPo1hV8YPOmIGnfA4fZHyKVtWqBQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"eslint-plugin-n": "17.10.3",
+				"eslint-plugin-react": "7.37.3",
+				"eslint-plugin-security": "1.4.0"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"eslint": "^9"
+			}
+		},
+		"node_modules/eslint-plugin-obsidianmd/node_modules/@microsoft/eslint-plugin-sdl/node_modules/eslint-plugin-security": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-1.4.0.tgz",
+			"integrity": "sha512-xlS7P2PLMXeqfhyf3NpqbvbnW04kN8M9NtmhpR3XGyOvt/vNKS7XPXT5EDbwKW9vCjWH4PpfQvgD/+JgN0VJKA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"safe-regex": "^1.1.0"
+			}
+		},
+		"node_modules/eslint-plugin-obsidianmd/node_modules/@types/node": {
+			"version": "20.12.12",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
+			"integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~5.26.4"
+			}
+		},
+		"node_modules/eslint-plugin-obsidianmd/node_modules/eslint": {
+			"version": "9.39.4",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+			"integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.8.0",
+				"@eslint-community/regexpp": "^4.12.1",
+				"@eslint/config-array": "^0.21.2",
+				"@eslint/config-helpers": "^0.4.2",
+				"@eslint/core": "^0.17.0",
+				"@eslint/eslintrc": "^3.3.5",
+				"@eslint/js": "9.39.4",
+				"@eslint/plugin-kit": "^0.4.1",
+				"@humanfs/node": "^0.16.6",
+				"@humanwhocodes/module-importer": "^1.0.1",
+				"@humanwhocodes/retry": "^0.4.2",
+				"@types/estree": "^1.0.6",
+				"ajv": "^6.14.0",
+				"chalk": "^4.0.0",
+				"cross-spawn": "^7.0.6",
+				"debug": "^4.3.2",
+				"escape-string-regexp": "^4.0.0",
+				"eslint-scope": "^8.4.0",
+				"eslint-visitor-keys": "^4.2.1",
+				"espree": "^10.4.0",
+				"esquery": "^1.5.0",
+				"esutils": "^2.0.2",
+				"fast-deep-equal": "^3.1.3",
+				"file-entry-cache": "^8.0.0",
+				"find-up": "^5.0.0",
+				"glob-parent": "^6.0.2",
+				"ignore": "^5.2.0",
+				"imurmurhash": "^0.1.4",
+				"is-glob": "^4.0.0",
+				"json-stable-stringify-without-jsonify": "^1.0.1",
+				"lodash.merge": "^4.6.2",
+				"minimatch": "^3.1.5",
+				"natural-compare": "^1.4.0",
+				"optionator": "^0.9.3"
+			},
+			"bin": {
+				"eslint": "bin/eslint.js"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://eslint.org/donate"
+			},
+			"peerDependencies": {
+				"jiti": "*"
+			},
+			"peerDependenciesMeta": {
+				"jiti": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/eslint-plugin-obsidianmd/node_modules/eslint-plugin-import": {
+			"version": "2.32.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
+			"integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@rtsao/scc": "^1.1.0",
+				"array-includes": "^3.1.9",
+				"array.prototype.findlastindex": "^1.2.6",
+				"array.prototype.flat": "^1.3.3",
+				"array.prototype.flatmap": "^1.3.3",
+				"debug": "^3.2.7",
+				"doctrine": "^2.1.0",
+				"eslint-import-resolver-node": "^0.3.9",
+				"eslint-module-utils": "^2.12.1",
+				"hasown": "^2.0.2",
+				"is-core-module": "^2.16.1",
+				"is-glob": "^4.0.3",
+				"minimatch": "^3.1.2",
+				"object.fromentries": "^2.0.8",
+				"object.groupby": "^1.0.3",
+				"object.values": "^1.2.1",
+				"semver": "^6.3.1",
+				"string.prototype.trimend": "^1.0.9",
+				"tsconfig-paths": "^3.15.0"
+			},
+			"engines": {
+				"node": ">=4"
+			},
+			"peerDependencies": {
+				"eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
+			}
+		},
+		"node_modules/eslint-plugin-obsidianmd/node_modules/eslint-plugin-import/node_modules/debug": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+			"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.1"
+			}
+		},
+		"node_modules/eslint-plugin-obsidianmd/node_modules/eslint-plugin-import/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/eslint-plugin-obsidianmd/node_modules/eslint-plugin-react": {
+			"version": "7.37.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.3.tgz",
+			"integrity": "sha512-DomWuTQPFYZwF/7c9W2fkKkStqZmBd3uugfqBYLdkZ3Hii23WzZuOLUskGxB8qkSKqftxEeGL1TB2kMhrce0jA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"array-includes": "^3.1.8",
+				"array.prototype.findlast": "^1.2.5",
+				"array.prototype.flatmap": "^1.3.3",
+				"array.prototype.tosorted": "^1.1.4",
+				"doctrine": "^2.1.0",
+				"es-iterator-helpers": "^1.2.1",
+				"estraverse": "^5.3.0",
+				"hasown": "^2.0.2",
+				"jsx-ast-utils": "^2.4.1 || ^3.0.0",
+				"minimatch": "^3.1.2",
+				"object.entries": "^1.1.8",
+				"object.fromentries": "^2.0.8",
+				"object.values": "^1.2.1",
+				"prop-types": "^15.8.1",
+				"resolve": "^2.0.0-next.5",
+				"semver": "^6.3.1",
+				"string.prototype.matchall": "^4.0.12",
+				"string.prototype.repeat": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			},
+			"peerDependencies": {
+				"eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+			}
+		},
+		"node_modules/eslint-plugin-obsidianmd/node_modules/eslint-plugin-react/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/eslint-plugin-obsidianmd/node_modules/eslint-scope": {
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+			"integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"esrecurse": "^4.3.0",
+				"estraverse": "^5.2.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint-plugin-obsidianmd/node_modules/eslint-visitor-keys": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint-plugin-obsidianmd/node_modules/espree": {
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+			"integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"acorn": "^8.15.0",
+				"acorn-jsx": "^5.3.2",
+				"eslint-visitor-keys": "^4.2.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint-plugin-obsidianmd/node_modules/globals": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+			"integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint-plugin-obsidianmd/node_modules/safe-regex": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"integrity": "sha512-aJXcif4xnaNUzvUuC5gcb46oTS7zvg4jpMTnuqtrEPlR3vFr4pxtdTwaF1Qs3Enjn9HK+ZlwQui+a7z0SywIzg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ret": "~0.1.10"
+			}
+		},
+		"node_modules/eslint-plugin-obsidianmd/node_modules/typescript": {
+			"version": "5.4.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+			"integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/eslint-plugin-prettier": {
+			"version": "5.5.5",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.5.tgz",
+			"integrity": "sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"prettier-linter-helpers": "^1.0.1",
+				"synckit": "^0.11.12"
+			},
+			"engines": {
+				"node": "^14.18.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint-plugin-prettier"
+			},
+			"peerDependencies": {
+				"@types/eslint": ">=8.0.0",
+				"eslint": ">=8.0.0",
+				"eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0",
+				"prettier": ">=3.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/eslint": {
+					"optional": true
+				},
+				"eslint-config-prettier": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/eslint-plugin-prettier/node_modules/@pkgr/core": {
+			"version": "0.2.9",
+			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
+			"integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/pkgr"
+			}
+		},
+		"node_modules/eslint-plugin-prettier/node_modules/synckit": {
+			"version": "0.11.12",
+			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
+			"integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@pkgr/core": "^0.2.9"
+			},
+			"engines": {
+				"node": "^14.18.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/synckit"
+			}
+		},
+		"node_modules/eslint-plugin-security": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-2.1.1.tgz",
+			"integrity": "sha512-7cspIGj7WTfR3EhaILzAPcfCo5R9FbeWvbgsPYWivSurTBKW88VQxtP3c4aWMG9Hz/GfJlJVdXEJ3c8LqS+u2w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"safe-regex": "^2.1.1"
+			}
+		},
+		"node_modules/eslint-scope": {
+			"version": "9.1.2",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+			"integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"@types/esrecurse": "^4.3.1",
+				"@types/estree": "^1.0.8",
+				"esrecurse": "^4.3.0",
+				"estraverse": "^5.2.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint-visitor-keys": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+			"dev": true,
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint/node_modules/@eslint/core": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+			"integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@types/json-schema": "^7.0.15"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/eslint/node_modules/@eslint/plugin-kit": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+			"integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/core": "^1.2.1",
+				"levn": "^0.4.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/eslint/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/eslint/node_modules/brace-expansion": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/eslint/node_modules/eslint-visitor-keys": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint/node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/espree": {
+			"version": "11.2.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+			"integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"acorn": "^8.16.0",
+				"acorn-jsx": "^5.3.2",
+				"eslint-visitor-keys": "^5.0.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/espree/node_modules/eslint-visitor-keys": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/esprima": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"bin": {
+				"esparse": "bin/esparse.js",
+				"esvalidate": "bin/esvalidate.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/esquery": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+			"integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"estraverse": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/esrecurse": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"estraverse": "^5.2.0"
+			},
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/estraverse": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/esutils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/execa": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+			"integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cross-spawn": "^7.0.3",
+				"get-stream": "^6.0.0",
+				"human-signals": "^2.1.0",
+				"is-stream": "^2.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^4.0.1",
+				"onetime": "^5.1.2",
+				"signal-exit": "^3.0.3",
+				"strip-final-newline": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
+		"node_modules/exit-x": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz",
+			"integrity": "sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/expect": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
+			"integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/expect-utils": "30.4.1",
+				"@jest/get-type": "30.1.0",
+				"jest-matcher-utils": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-mock": "30.4.1",
+				"jest-util": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/fast-diff": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+			"integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/fast-json-stable-stringify": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+			"dev": true
+		},
+		"node_modules/fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+			"dev": true
+		},
+		"node_modules/fast-uri": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/fb-watchman": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+			"integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"bser": "2.1.1"
+			}
+		},
+		"node_modules/file-entry-cache": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+			"integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"flat-cache": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/find-up": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"dev": true,
+			"dependencies": {
+				"locate-path": "^6.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/flat-cache": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+			"integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"flatted": "^3.2.9",
+				"keyv": "^4.5.4"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/flatted": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+			"integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/for-each": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+			"integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-callable": "^1.2.7"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/foreground-child": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+			"integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"cross-spawn": "^7.0.6",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/foreground-child/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/function-bind": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/function.prototype.name": {
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+			"integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.3",
+				"define-properties": "^1.2.1",
+				"functions-have-names": "^1.2.3",
+				"hasown": "^2.0.2",
+				"is-callable": "^1.2.7"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/functions-have-names": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+			"integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/generator-function": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+			"integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/gensync": {
+			"version": "1.0.0-beta.2",
+			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "6.* || 8.* || >= 10.*"
+			}
+		},
+		"node_modules/get-intrinsic": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.1.1",
+				"function-bind": "^1.1.2",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-symbols": "^1.1.0",
+				"hasown": "^2.0.2",
+				"math-intrinsics": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-package-type": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+			"integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/get-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"dunder-proto": "^1.0.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/get-stream": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/get-symbol-description": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+			"integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.3",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.6"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-tsconfig": {
+			"version": "4.14.0",
+			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+			"integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"resolve-pkg-maps": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+			}
+		},
+		"node_modules/glob": {
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/glob-parent": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+			"dev": true,
+			"dependencies": {
+				"is-glob": "^4.0.3"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/glob/node_modules/brace-expansion": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+			"integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/glob/node_modules/minimatch": {
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/globals": {
+			"version": "16.5.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+			"integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/globalthis": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+			"integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"define-properties": "^1.2.1",
+				"gopd": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/gopd": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/handlebars": {
+			"version": "4.7.9",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+			"integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"minimist": "^1.2.5",
+				"neo-async": "^2.6.2",
+				"source-map": "^0.6.1",
+				"wordwrap": "^1.0.0"
+			},
+			"bin": {
+				"handlebars": "bin/handlebars"
+			},
+			"engines": {
+				"node": ">=0.4.7"
+			},
+			"optionalDependencies": {
+				"uglify-js": "^3.1.4"
+			}
+		},
+		"node_modules/has-bigints": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+			"integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/has-property-descriptors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-define-property": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-proto": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+			"integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"dunder-proto": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-symbols": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-tostringtag": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-symbols": "^1.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/hasown": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+			"integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/html-encoding-sniffer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+			"integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"whatwg-encoding": "^3.1.1"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/html-escaper": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/human-signals": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+			"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.17.0"
+			}
+		},
+		"node_modules/husky": {
+			"version": "9.1.7",
+			"resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+			"integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"husky": "bin.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/typicode"
+			}
+		},
+		"node_modules/iconv-lite": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/ignore": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+			"dev": true,
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/import-fresh": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+			"integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"parent-module": "^1.0.0",
+				"resolve-from": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/import-local": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+			"integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"pkg-dir": "^4.2.0",
+				"resolve-cwd": "^3.0.0"
+			},
+			"bin": {
+				"import-local-fixture": "fixtures/cli.js"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/imurmurhash": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.8.19"
+			}
+		},
+		"node_modules/inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+			"deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/internal-slot": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+			"integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"hasown": "^2.0.2",
+				"side-channel": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/is-array-buffer": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+			"integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.3",
+				"get-intrinsic": "^1.2.6"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-arrayish": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/is-async-function": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+			"integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"async-function": "^1.0.0",
+				"call-bound": "^1.0.3",
+				"get-proto": "^1.0.1",
+				"has-tostringtag": "^1.0.2",
+				"safe-regex-test": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-bigint": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+			"integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-bigints": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-boolean-object": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+			"integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.3",
+				"has-tostringtag": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-callable": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-core-module": {
+			"version": "2.16.2",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+			"integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"hasown": "^2.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-data-view": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+			"integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"get-intrinsic": "^1.2.6",
+				"is-typed-array": "^1.1.13"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-date-object": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+			"integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"has-tostringtag": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-extglob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-finalizationregistry": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+			"integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-generator-fn": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+			"integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/is-generator-function": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+			"integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.4",
+				"generator-function": "^2.0.0",
+				"get-proto": "^1.0.1",
+				"has-tostringtag": "^1.0.2",
+				"safe-regex-test": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-glob": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+			"dev": true,
+			"dependencies": {
+				"is-extglob": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-map": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+			"integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-negative-zero": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+			"integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-number-object": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+			"integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.3",
+				"has-tostringtag": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-potential-custom-element-name": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/is-regex": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+			"integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"gopd": "^1.2.0",
+				"has-tostringtag": "^1.0.2",
+				"hasown": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-set": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+			"integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-shared-array-buffer": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+			"integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-string": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+			"integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.3",
+				"has-tostringtag": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-symbol": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+			"integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"has-symbols": "^1.1.0",
+				"safe-regex-test": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-typed-array": {
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+			"integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"which-typed-array": "^1.1.16"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-weakmap": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+			"integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-weakref": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+			"integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-weakset": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+			"integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.3",
+				"get-intrinsic": "^1.2.6"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/isarray": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"dev": true
+		},
+		"node_modules/istanbul-lib-coverage": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+			"integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/istanbul-lib-instrument": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+			"integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@babel/core": "^7.23.9",
+				"@babel/parser": "^7.23.9",
+				"@istanbuljs/schema": "^0.1.3",
+				"istanbul-lib-coverage": "^3.2.0",
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/istanbul-lib-report": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+			"integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"istanbul-lib-coverage": "^3.0.0",
+				"make-dir": "^4.0.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/istanbul-lib-source-maps": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+			"integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.23",
+				"debug": "^4.1.1",
+				"istanbul-lib-coverage": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/istanbul-reports": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+			"integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"html-escaper": "^2.0.0",
+				"istanbul-lib-report": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/iterator.prototype": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
+			"integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"define-data-property": "^1.1.4",
+				"es-object-atoms": "^1.0.0",
+				"get-intrinsic": "^1.2.6",
+				"get-proto": "^1.0.0",
+				"has-symbols": "^1.1.0",
+				"set-function-name": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/jackspeak": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/cliui": "^8.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			},
+			"optionalDependencies": {
+				"@pkgjs/parseargs": "^0.11.0"
+			}
+		},
+		"node_modules/jest": {
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-30.4.2.tgz",
+			"integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/core": "30.4.2",
+				"@jest/types": "30.4.1",
+				"import-local": "^3.2.0",
+				"jest-cli": "30.4.2"
+			},
+			"bin": {
+				"jest": "bin/jest.js"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+			},
+			"peerDependenciesMeta": {
+				"node-notifier": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/jest-changed-files": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.4.1.tgz",
+			"integrity": "sha512-IuctmYrxi21iOSOaIXpJWalHyPAsVv0GeBHKDn8C1CA4W5htHn7INL+wdnL4Bo0+olEndvAFkmb++tIQJG+vvg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"execa": "^5.1.1",
+				"jest-util": "30.4.1",
+				"p-limit": "^3.1.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-circus": {
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.4.2.tgz",
+			"integrity": "sha512-rvHH7VlY6LgbJXJTQ87GW62g1FntOtbhh0zT+v04kC+pgL6aBKyYINXxWukCpj3dcIBMw5/XUbtDS9dU9JTXeQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/environment": "30.4.1",
+				"@jest/expect": "30.4.1",
+				"@jest/test-result": "30.4.1",
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"co": "^4.6.0",
+				"dedent": "^1.6.0",
+				"is-generator-fn": "^2.1.0",
+				"jest-each": "30.4.1",
+				"jest-matcher-utils": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-runtime": "30.4.2",
+				"jest-snapshot": "30.4.1",
+				"jest-util": "30.4.1",
+				"p-limit": "^3.1.0",
+				"pretty-format": "30.4.1",
+				"pure-rand": "^7.0.0",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.6"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-cli": {
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.4.2.tgz",
+			"integrity": "sha512-jfA2ocvVHMXS2QijrJ0d31ektP+d/W0T5RpcTX2Pq+3sVqHlsXVCM2+FmwpL+bdY8OfHpIg9xMxLF17Zg0U49Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/core": "30.4.2",
+				"@jest/test-result": "30.4.1",
+				"@jest/types": "30.4.1",
+				"chalk": "^4.1.2",
+				"exit-x": "^0.2.2",
+				"import-local": "^3.2.0",
+				"jest-config": "30.4.2",
+				"jest-util": "30.4.1",
+				"jest-validate": "30.4.1",
+				"yargs": "^17.7.2"
+			},
+			"bin": {
+				"jest": "bin/jest.js"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+			},
+			"peerDependenciesMeta": {
+				"node-notifier": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/jest-config": {
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.4.2.tgz",
+			"integrity": "sha512-rNHAShJQqQwFNoL0hbf3BphSBOWnpOUAKvidLS/AjNVLPfoj5mSf4jQMfW3cYOs6hXeZC7nF7mDHaBnbxELOzg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/core": "^7.27.4",
+				"@jest/get-type": "30.1.0",
+				"@jest/pattern": "30.4.0",
+				"@jest/test-sequencer": "30.4.1",
+				"@jest/types": "30.4.1",
+				"babel-jest": "30.4.1",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"deepmerge": "^4.3.1",
+				"glob": "^10.5.0",
+				"graceful-fs": "^4.2.11",
+				"jest-circus": "30.4.2",
+				"jest-docblock": "30.4.0",
+				"jest-environment-node": "30.4.1",
+				"jest-regex-util": "30.4.0",
+				"jest-resolve": "30.4.1",
+				"jest-runner": "30.4.2",
+				"jest-util": "30.4.1",
+				"jest-validate": "30.4.1",
+				"parse-json": "^5.2.0",
+				"pretty-format": "30.4.1",
+				"slash": "^3.0.0",
+				"strip-json-comments": "^3.1.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"@types/node": "*",
+				"esbuild-register": ">=3.4.0",
+				"ts-node": ">=9.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"esbuild-register": {
+					"optional": true
+				},
+				"ts-node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/jest-diff": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
+			"integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/diff-sequences": "30.4.0",
+				"@jest/get-type": "30.1.0",
+				"chalk": "^4.1.2",
+				"pretty-format": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-docblock": {
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.4.0.tgz",
+			"integrity": "sha512-ZPMabUZCx5MpbZ2eBYSvZ0J8fvo3dR9oM+eeUpb3aKNQFuS2tu3Duw1TNlMoP8k3WQgKGJuhcMFvwcVuq6T7oA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"detect-newline": "^3.1.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-each": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.4.1.tgz",
+			"integrity": "sha512-/8MJbH6fuj48TstjrMf+u/pd06Qezz5xOXvZA6442heNOWr8bdeoGZX2d9fCn028CoMgYmroH9//zky5GfyYmA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/get-type": "30.1.0",
+				"@jest/types": "30.4.1",
+				"chalk": "^4.1.2",
+				"jest-util": "30.4.1",
+				"pretty-format": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-environment-jsdom": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.4.1.tgz",
+			"integrity": "sha512-o3nfaN4zej7qgk2X0j8Jhq/S9nAVKs2xK3QeQxeHVvpkEPxaA1yxDGydR+iVI7zPy7Cp62Aq2h3Ja46QvfWHGA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/environment": "30.4.1",
+				"@jest/environment-jsdom-abstract": "30.4.1",
+				"jsdom": "^26.1.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"canvas": "^3.0.0"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/jest-environment-node": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.4.1.tgz",
+			"integrity": "sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/environment": "30.4.1",
+				"@jest/fake-timers": "30.4.1",
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"jest-mock": "30.4.1",
+				"jest-util": "30.4.1",
+				"jest-validate": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-haste-map": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.4.1.tgz",
+			"integrity": "sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"anymatch": "^3.1.3",
+				"fb-watchman": "^2.0.2",
+				"graceful-fs": "^4.2.11",
+				"jest-regex-util": "30.4.0",
+				"jest-util": "30.4.1",
+				"jest-worker": "30.4.1",
+				"picomatch": "^4.0.3",
+				"walker": "^1.0.8"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "^2.3.3"
+			}
+		},
+		"node_modules/jest-haste-map/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/jest-leak-detector": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.4.1.tgz",
+			"integrity": "sha512-IpmyiioeHxiWDhesHnUFmOxcTzwCwKpgACgWajtAP+nYQXiY7DakTxB6Bx9JFiRMljr0AX1PvnQdaU1KFoz6NQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/get-type": "30.1.0",
+				"pretty-format": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-matcher-utils": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
+			"integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/get-type": "30.1.0",
+				"chalk": "^4.1.2",
+				"jest-diff": "30.4.1",
+				"pretty-format": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-message-util": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
+			"integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.27.1",
+				"@jest/types": "30.4.1",
+				"@types/stack-utils": "^2.0.3",
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"jest-util": "30.4.1",
+				"picomatch": "^4.0.3",
+				"pretty-format": "30.4.1",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.6"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-message-util/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/jest-mock": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
+			"integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"jest-util": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-pnp-resolver": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+			"integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			},
+			"peerDependencies": {
+				"jest-resolve": "*"
+			},
+			"peerDependenciesMeta": {
+				"jest-resolve": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/jest-regex-util": {
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+			"integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-resolve": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.4.1.tgz",
+			"integrity": "sha512-Zry8Yq/yJcNAZ7dJ5F2heic8AheXvbFZ7XI5V+h28nrYZ7Qoyy4dItq8OodjnYD270mvX+ZudmrNV9cysqhW5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^4.1.2",
+				"graceful-fs": "^4.2.11",
+				"jest-haste-map": "30.4.1",
+				"jest-pnp-resolver": "^1.2.3",
+				"jest-util": "30.4.1",
+				"jest-validate": "30.4.1",
+				"slash": "^3.0.0",
+				"unrs-resolver": "^1.7.11"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-resolve-dependencies": {
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.4.2.tgz",
+			"integrity": "sha512-gDiVh1I+GxYzz9oXlyw+1wv6VOYX1WYxMOfjsA3iGKePV2oxmbHhwxfkALxNxYy1ciw6APWwkW2zZONwP97aEQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"jest-regex-util": "30.4.0",
+				"jest-snapshot": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-runner": {
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.4.2.tgz",
+			"integrity": "sha512-2dw0PslVYXxffXGpLo+Ejad+KcI1Qkjn7f4X4619gf21oCUmL+SPfjqIa/losUem3yEOvfNZe/F1HWUcNpODcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/console": "30.4.1",
+				"@jest/environment": "30.4.1",
+				"@jest/test-result": "30.4.1",
+				"@jest/transform": "30.4.1",
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"emittery": "^0.13.1",
+				"exit-x": "^0.2.2",
+				"graceful-fs": "^4.2.11",
+				"jest-docblock": "30.4.0",
+				"jest-environment-node": "30.4.1",
+				"jest-haste-map": "30.4.1",
+				"jest-leak-detector": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-resolve": "30.4.1",
+				"jest-runtime": "30.4.2",
+				"jest-util": "30.4.1",
+				"jest-watcher": "30.4.1",
+				"jest-worker": "30.4.1",
+				"p-limit": "^3.1.0",
+				"source-map-support": "0.5.13"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-runtime": {
+			"version": "30.4.2",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.4.2.tgz",
+			"integrity": "sha512-3/5e8iPz2k/VLqlr8DgTftYyLUv8Su3FkCAO2/Od81UsUTpSxOrS6O5x5KkoQwyUjmpYyDJKeyAvg2T2nvpNkQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/environment": "30.4.1",
+				"@jest/fake-timers": "30.4.1",
+				"@jest/globals": "30.4.1",
+				"@jest/source-map": "30.0.1",
+				"@jest/test-result": "30.4.1",
+				"@jest/transform": "30.4.1",
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"cjs-module-lexer": "^2.1.0",
+				"collect-v8-coverage": "^1.0.2",
+				"glob": "^10.5.0",
+				"graceful-fs": "^4.2.11",
+				"jest-haste-map": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-mock": "30.4.1",
+				"jest-regex-util": "30.4.0",
+				"jest-resolve": "30.4.1",
+				"jest-snapshot": "30.4.1",
+				"jest-util": "30.4.1",
+				"slash": "^3.0.0",
+				"strip-bom": "^4.0.0"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-snapshot": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.4.1.tgz",
+			"integrity": "sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/core": "^7.27.4",
+				"@babel/generator": "^7.27.5",
+				"@babel/plugin-syntax-jsx": "^7.27.1",
+				"@babel/plugin-syntax-typescript": "^7.27.1",
+				"@babel/types": "^7.27.3",
+				"@jest/expect-utils": "30.4.1",
+				"@jest/get-type": "30.1.0",
+				"@jest/snapshot-utils": "30.4.1",
+				"@jest/transform": "30.4.1",
+				"@jest/types": "30.4.1",
+				"babel-preset-current-node-syntax": "^1.2.0",
+				"chalk": "^4.1.2",
+				"expect": "30.4.1",
+				"graceful-fs": "^4.2.11",
+				"jest-diff": "30.4.1",
+				"jest-matcher-utils": "30.4.1",
+				"jest-message-util": "30.4.1",
+				"jest-util": "30.4.1",
+				"pretty-format": "30.4.1",
+				"semver": "^7.7.2",
+				"synckit": "^0.11.8"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-snapshot/node_modules/@pkgr/core": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
+			"integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^14.18.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/pkgr"
+			}
+		},
+		"node_modules/jest-snapshot/node_modules/synckit": {
+			"version": "0.11.13",
+			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
+			"integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@pkgr/core": "^0.3.6"
+			},
+			"engines": {
+				"node": "^14.18.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/synckit"
+			}
+		},
+		"node_modules/jest-util": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+			"integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"chalk": "^4.1.2",
+				"ci-info": "^4.2.0",
+				"graceful-fs": "^4.2.11",
+				"picomatch": "^4.0.3"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-util/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/jest-validate": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.4.1.tgz",
+			"integrity": "sha512-PDWi4SOwLnwqNDfHZjOcsEFyZ4fc/2W2gVL3DEoyqnB6jCQMLRtfBong8s6omIw3lI0HWOus12xfnFmQtjW3fw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/get-type": "30.1.0",
+				"@jest/types": "30.4.1",
+				"camelcase": "^6.3.0",
+				"chalk": "^4.1.2",
+				"leven": "^3.1.0",
+				"pretty-format": "30.4.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-validate/node_modules/camelcase": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/jest-watcher": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.4.1.tgz",
+			"integrity": "sha512-/l9UonmvCwjHH7d2h3iAwIloLc1H0S8mJZ/LNK3i86hqwPAz8otUJjP9MfYtz9Tt77Su5FD2xGjZn8d31IZHlw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/test-result": "30.4.1",
+				"@jest/types": "30.4.1",
+				"@types/node": "*",
+				"ansi-escapes": "^4.3.2",
+				"chalk": "^4.1.2",
+				"emittery": "^0.13.1",
+				"jest-util": "30.4.1",
+				"string-length": "^4.0.2"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-worker": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.4.1.tgz",
+			"integrity": "sha512-SHynN/q/QD++iNyvMdy+WMmbCGk8jIsNcRxycXbWubSOhvo6T+j2afcfUSl+3hYsiBebOTo0cT7c2H7CXugu1g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*",
+				"@ungap/structured-clone": "^1.3.0",
+				"jest-util": "30.4.1",
+				"merge-stream": "^2.0.0",
+				"supports-color": "^8.1.1"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/jest-worker/node_modules/supports-color": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-color?sponsor=1"
+			}
+		},
+		"node_modules/js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/js-yaml": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+			"integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"argparse": "^2.0.1"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/jsdom": {
+			"version": "26.1.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+			"integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cssstyle": "^4.2.1",
+				"data-urls": "^5.0.0",
+				"decimal.js": "^10.5.0",
+				"html-encoding-sniffer": "^4.0.0",
+				"http-proxy-agent": "^7.0.2",
+				"https-proxy-agent": "^7.0.6",
+				"is-potential-custom-element-name": "^1.0.1",
+				"nwsapi": "^2.2.16",
+				"parse5": "^7.2.1",
+				"rrweb-cssom": "^0.8.0",
+				"saxes": "^6.0.0",
+				"symbol-tree": "^3.2.4",
+				"tough-cookie": "^5.1.1",
+				"w3c-xmlserializer": "^5.0.0",
+				"webidl-conversions": "^7.0.0",
+				"whatwg-encoding": "^3.1.1",
+				"whatwg-mimetype": "^4.0.0",
+				"whatwg-url": "^14.1.1",
+				"ws": "^8.18.0",
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"canvas": "^3.0.0"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/jsesc": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+			"integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"jsesc": "bin/jsesc"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/json-buffer": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/json-parse-even-better-errors": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/json-schema-migrate": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-migrate/-/json-schema-migrate-2.0.0.tgz",
+			"integrity": "sha512-r38SVTtojDRp4eD6WsCqiE0eNDt4v1WalBXb9cyZYw9ai5cGtBwzRNWjHzJl38w6TxFkXAIA7h+fyX3tnrAFhQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ajv": "^8.0.0"
+			}
+		},
+		"node_modules/json-schema-migrate/node_modules/ajv": {
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/json-schema-migrate/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/json-schema-traverse": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/json-stable-stringify-without-jsonify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+			"dev": true
+		},
+		"node_modules/json5": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"json5": "lib/cli.js"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/jsonc-eslint-parser": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-2.4.2.tgz",
+			"integrity": "sha512-1e4qoRgnn448pRuMvKGsFFymUCquZV0mpGgOyIKNgD3JVDTsVJyRBGH/Fm0tBb8WsWGgmB1mDe6/yJMQM37DUA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"acorn": "^8.5.0",
+				"eslint-visitor-keys": "^3.0.0",
+				"espree": "^9.0.0",
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ota-meshi"
+			}
+		},
+		"node_modules/jsonc-eslint-parser/node_modules/espree": {
+			"version": "9.6.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+			"integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"acorn": "^8.9.0",
+				"acorn-jsx": "^5.3.2",
+				"eslint-visitor-keys": "^3.4.1"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/jsx-ast-utils": {
+			"version": "3.3.5",
+			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+			"integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"array-includes": "^3.1.6",
+				"array.prototype.flat": "^1.3.1",
+				"object.assign": "^4.1.4",
+				"object.values": "^1.1.6"
+			},
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/keyv": {
+			"version": "4.5.4",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+			"integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"json-buffer": "3.0.1"
+			}
+		},
+		"node_modules/leven": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+			"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/levn": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+			"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+			"dev": true,
+			"dependencies": {
+				"prelude-ls": "^1.2.1",
+				"type-check": "~0.4.0"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/lines-and-columns": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/locate-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"dev": true,
+			"dependencies": {
+				"p-locate": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/lodash.memoize": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+			"integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lodash.merge": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/loose-envify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"js-tokens": "^3.0.0 || ^4.0.0"
+			},
+			"bin": {
+				"loose-envify": "cli.js"
+			}
+		},
+		"node_modules/lru-cache": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"yallist": "^3.0.2"
+			}
+		},
+		"node_modules/make-dir": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+			"integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"semver": "^7.5.3"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/make-error": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/makeerror": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+			"integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"tmpl": "1.0.5"
+			}
+		},
+		"node_modules/math-intrinsics": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/mediabunny": {
+			"version": "1.50.4",
+			"resolved": "https://registry.npmjs.org/mediabunny/-/mediabunny-1.50.4.tgz",
+			"integrity": "sha512-RcJ3xt839gopNTHVl+dLypKdABDL3KYtRszIXjaCmwG/rGglKpEKWcdaXN2tWiaubQguibK5Uem1aLy2+aEUaw==",
+			"license": "MPL-2.0",
+			"workspaces": [
+				".",
+				"packages/*"
+			],
+			"dependencies": {
+				"@types/dom-mediacapture-transform": "^0.1.11",
+				"@types/dom-webcodecs": "0.1.13"
+			},
+			"funding": {
+				"type": "individual",
+				"url": "https://github.com/sponsors/Vanilagy"
+			}
+		},
+		"node_modules/merge-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/mimic-fn": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/minimist": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/minipass": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/module-replacements": {
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/module-replacements/-/module-replacements-2.11.0.tgz",
+			"integrity": "sha512-j5sNQm3VCpQQ7nTqGeOZtoJtV3uKERgCBm9QRhmGRiXiqkf7iRFOkfxdJRZWLkqYY8PNf4cDQF/WfXUYLENrRA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/moment": {
+			"version": "2.29.4",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+			"integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+			"dev": true,
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/nano-staged": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/nano-staged/-/nano-staged-0.8.0.tgz",
+			"integrity": "sha512-QSEqPGTCJbkHU2yLvfY6huqYPjdBrOaTMKatO1F8nCSrkQGXeKwtCiCnsdxnuMhbg3DTVywKaeWLGCE5oJpq0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"picocolors": "^1.0.0"
+			},
+			"bin": {
+				"nano-staged": "lib/bin.js"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			}
+		},
+		"node_modules/napi-postinstall": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+			"integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"napi-postinstall": "lib/cli.js"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/napi-postinstall"
+			}
+		},
+		"node_modules/natural-compare": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+			"dev": true
+		},
+		"node_modules/neo-async": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/node-exports-info": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
+			"integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"array.prototype.flatmap": "^1.3.3",
+				"es-errors": "^1.3.0",
+				"object.entries": "^1.1.9",
+				"semver": "^6.3.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/node-exports-info/node_modules/semver": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/node-int64": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+			"integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/node-releases": {
+			"version": "2.0.27",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+			"integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/normalize-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npm-run-path": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/nwsapi": {
+			"version": "2.2.24",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+			"integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/object-inspect": {
+			"version": "1.13.4",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+			"integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/object-keys": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/object.assign": {
+			"version": "4.1.7",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+			"integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.3",
+				"define-properties": "^1.2.1",
+				"es-object-atoms": "^1.0.0",
+				"has-symbols": "^1.1.0",
+				"object-keys": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/object.entries": {
+			"version": "1.1.9",
+			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+			"integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.4",
+				"define-properties": "^1.2.1",
+				"es-object-atoms": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/object.fromentries": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+			"integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.2",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/object.groupby": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
+			"integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/object.values": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+			"integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.3",
+				"define-properties": "^1.2.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/obsidian": {
+			"version": "1.12.3",
+			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.12.3.tgz",
+			"integrity": "sha512-HxWqe763dOqzXjnNiHmAJTRERN8KILBSqxDSEqbeSr7W8R8Jxezzbca+nz1LiiqXnMpM8lV2jzAezw3CZ4xNUw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/codemirror": "5.60.8",
+				"moment": "2.29.4"
+			},
+			"peerDependencies": {
+				"@codemirror/state": "6.5.0",
+				"@codemirror/view": "6.38.6"
+			}
+		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/onetime": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mimic-fn": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/optionator": {
+			"version": "0.9.4",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+			"integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+			"dev": true,
+			"dependencies": {
+				"deep-is": "^0.1.3",
+				"fast-levenshtein": "^2.0.6",
+				"levn": "^0.4.1",
+				"prelude-ls": "^1.2.1",
+				"type-check": "^0.4.0",
+				"word-wrap": "^1.2.5"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/own-keys": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+			"integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"get-intrinsic": "^1.2.6",
+				"object-keys": "^1.1.1",
+				"safe-push-apply": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/p-limit": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"dev": true,
+			"dependencies": {
+				"yocto-queue": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-locate": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"dev": true,
+			"dependencies": {
+				"p-limit": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-try": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/package-json-from-dist": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0"
+		},
+		"node_modules/parent-module": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"callsites": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/parse-json": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+			"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.0.0",
+				"error-ex": "^1.3.1",
+				"json-parse-even-better-errors": "^2.3.0",
+				"lines-and-columns": "^1.1.6"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/parse5": {
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+			"integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"entities": "^6.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
+		},
+		"node_modules/path-exists": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/path-parse": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/path-scurry": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^10.2.0",
+				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/path-scurry/node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/picocolors": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/picomatch": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/pirates": {
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+			"integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/pkg-dir": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+			"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"find-up": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/pkg-dir/node_modules/find-up": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"locate-path": "^5.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/pkg-dir/node_modules/locate-path": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-locate": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/pkg-dir/node_modules/p-limit": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-try": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/pkg-dir/node_modules/p-locate": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-limit": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/possible-typed-array-names": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+			"integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/prelude-ls": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/prettier": {
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+			"integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"prettier": "bin/prettier.cjs"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/prettier/prettier?sponsor=1"
+			}
+		},
+		"node_modules/prettier-linter-helpers": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.1.tgz",
+			"integrity": "sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-diff": "^1.1.2"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/pretty-format": {
+			"version": "30.4.1",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+			"integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/schemas": "30.4.1",
+				"ansi-styles": "^5.2.0",
+				"react-is-18": "npm:react-is@^18.3.1",
+				"react-is-19": "npm:react-is@^19.2.5"
+			},
+			"engines": {
+				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+			}
+		},
+		"node_modules/pretty-format/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/prop-types": {
+			"version": "15.8.1",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+			"integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"loose-envify": "^1.4.0",
+				"object-assign": "^4.1.1",
+				"react-is": "^16.13.1"
+			}
+		},
+		"node_modules/punycode": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/pure-rand": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+			"integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/dubzzz"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fast-check"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/react-is": {
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/react-is-18": {
+			"name": "react-is",
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/react-is-19": {
+			"name": "react-is",
+			"version": "19.2.7",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+			"integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/reflect.getprototypeof": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+			"integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.9",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.0.0",
+				"get-intrinsic": "^1.2.7",
+				"get-proto": "^1.0.1",
+				"which-builtin-type": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/regexp-tree": {
+			"version": "0.1.27",
+			"resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+			"integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"regexp-tree": "bin/regexp-tree"
+			}
+		},
+		"node_modules/regexp.prototype.flags": {
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+			"integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"define-properties": "^1.2.1",
+				"es-errors": "^1.3.0",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"set-function-name": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/resolve": {
+			"version": "2.0.0-next.7",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
+			"integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"is-core-module": "^2.16.2",
+				"node-exports-info": "^1.6.0",
+				"object-keys": "^1.1.1",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/resolve-cwd": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+			"integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"resolve-from": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/resolve-cwd/node_modules/resolve-from": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/resolve-from": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/resolve-pkg-maps": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+			"integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+			}
+		},
+		"node_modules/ret": {
+			"version": "0.1.15",
+			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.12"
+			}
+		},
+		"node_modules/rrweb-cssom": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+			"integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/safe-array-concat": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+			"integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.2",
+				"get-intrinsic": "^1.2.6",
+				"has-symbols": "^1.1.0",
+				"isarray": "^2.0.5"
+			},
+			"engines": {
+				"node": ">=0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/safe-push-apply": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+			"integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"isarray": "^2.0.5"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/safe-regex": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+			"integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"regexp-tree": "~0.1.1"
+			}
+		},
+		"node_modules/safe-regex-test": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+			"integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"is-regex": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/saxes": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+			"integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"xmlchars": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=v12.22.7"
+			}
+		},
+		"node_modules/semver": {
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+			"integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/set-function-length": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"define-data-property": "^1.1.4",
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.4",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/set-function-name": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+			"integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"define-data-property": "^1.1.4",
+				"es-errors": "^1.3.0",
+				"functions-have-names": "^1.2.3",
+				"has-property-descriptors": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/set-proto": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+			"integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"dunder-proto": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/side-channel": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+			"integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.3",
+				"side-channel-list": "^1.0.0",
+				"side-channel-map": "^1.0.1",
+				"side-channel-weakmap": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-list": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+			"integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-map": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+			"integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-weakmap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+			"integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3",
+				"side-channel-map": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/slash": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/source-map-support": {
+			"version": "0.5.13",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+			"integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
+			}
+		},
+		"node_modules/sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/stack-utils": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+			"integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"escape-string-regexp": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/stack-utils/node_modules/escape-string-regexp": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+			"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/stop-iteration-iterator": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+			"integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"internal-slot": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/string-length": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+			"integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"char-regex": "^1.0.2",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/string-length/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-length/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"eastasianwidth": "^0.2.0",
+				"emoji-regex": "^9.2.2",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/string-width-cjs": {
+			"name": "string-width",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width-cjs/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width-cjs/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/string-width-cjs/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string.prototype.matchall": {
+			"version": "4.0.12",
+			"resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+			"integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.3",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.6",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.0.0",
+				"get-intrinsic": "^1.2.6",
+				"gopd": "^1.2.0",
+				"has-symbols": "^1.1.0",
+				"internal-slot": "^1.1.0",
+				"regexp.prototype.flags": "^1.5.3",
+				"set-function-name": "^2.0.2",
+				"side-channel": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/string.prototype.repeat": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+			"integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.5"
+			}
+		},
+		"node_modules/string.prototype.trim": {
+			"version": "1.2.10",
+			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+			"integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.2",
+				"define-data-property": "^1.1.4",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.5",
+				"es-object-atoms": "^1.0.0",
+				"has-property-descriptors": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/string.prototype.trimend": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+			"integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.2",
+				"define-properties": "^1.2.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/string.prototype.trimstart": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+			"integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/strip-ansi-cjs": {
+			"name": "strip-ansi",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-bom": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+			"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-final-newline": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/strip-json-comments": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/style-mod": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+			"integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/symbol-tree": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/synckit": {
+			"version": "0.9.3",
+			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.3.tgz",
+			"integrity": "sha512-JJoOEKTfL1urb1mDoEblhD9NhEbWmq9jHEMEnxoC4ujUaZ4itA8vKgwkFAyNClgxplLi9tsUKX+EduK0p/l7sg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@pkgr/core": "^0.1.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": "^14.18.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/unts"
+			}
+		},
+		"node_modules/tapable": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+			"integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
+			}
+		},
+		"node_modules/test-exclude": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+			"integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"@istanbuljs/schema": "^0.1.2",
+				"glob": "^7.1.4",
+				"minimatch": "^3.0.4"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/test-exclude/node_modules/glob": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/tinyglobby": {
+			"version": "0.2.15",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+			"integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.3"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/tinyglobby/node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/tinyglobby/node_modules/picomatch": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/tldts": {
+			"version": "6.1.86",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+			"integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tldts-core": "^6.1.86"
+			},
+			"bin": {
+				"tldts": "bin/cli.js"
+			}
+		},
+		"node_modules/tldts-core": {
+			"version": "6.1.86",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+			"integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tmpl": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+			"integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/toml-eslint-parser": {
+			"version": "0.9.3",
+			"resolved": "https://registry.npmjs.org/toml-eslint-parser/-/toml-eslint-parser-0.9.3.tgz",
+			"integrity": "sha512-moYoCvkNUAPCxSW9jmHmRElhm4tVJpHL8ItC/+uYD0EpPSFXbck7yREz9tNdJVTSpHVod8+HoipcpbQ0oE6gsw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"eslint-visitor-keys": "^3.0.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ota-meshi"
+			}
+		},
+		"node_modules/tough-cookie": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+			"integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"tldts": "^6.1.32"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/tr46": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+			"integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"punycode": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/ts-api-utils": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+			"integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.12"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4"
+			}
+		},
+		"node_modules/ts-jest": {
+			"version": "29.4.11",
+			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",
+			"integrity": "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bs-logger": "^0.2.6",
+				"fast-json-stable-stringify": "^2.1.0",
+				"handlebars": "^4.7.9",
+				"json5": "^2.2.3",
+				"lodash.memoize": "^4.1.2",
+				"make-error": "^1.3.6",
+				"semver": "^7.8.0",
+				"type-fest": "^4.41.0",
+				"yargs-parser": "^21.1.1"
+			},
+			"bin": {
+				"ts-jest": "cli.js"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+			},
+			"peerDependencies": {
+				"@babel/core": ">=7.0.0-beta.0 <8",
+				"@jest/transform": "^29.0.0 || ^30.0.0",
+				"@jest/types": "^29.0.0 || ^30.0.0",
+				"babel-jest": "^29.0.0 || ^30.0.0",
+				"jest": "^29.0.0 || ^30.0.0",
+				"jest-util": "^29.0.0 || ^30.0.0",
+				"typescript": ">=4.3 <7"
+			},
+			"peerDependenciesMeta": {
+				"@babel/core": {
+					"optional": true
+				},
+				"@jest/transform": {
+					"optional": true
+				},
+				"@jest/types": {
+					"optional": true
+				},
+				"babel-jest": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
+				"jest-util": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/ts-jest/node_modules/type-fest": {
+			"version": "4.41.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/tsconfig-paths": {
+			"version": "3.15.0",
+			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+			"integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/json5": "^0.0.29",
+				"json5": "^1.0.2",
+				"minimist": "^1.2.6",
+				"strip-bom": "^3.0.0"
+			}
+		},
+		"node_modules/tsconfig-paths/node_modules/json5": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+			"integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"minimist": "^1.2.0"
+			},
+			"bin": {
+				"json5": "lib/cli.js"
+			}
+		},
+		"node_modules/tsconfig-paths/node_modules/strip-bom": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+			"integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true,
+			"license": "0BSD"
+		},
+		"node_modules/tunnel-agent": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/type-check": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+			"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+			"dev": true,
+			"dependencies": {
+				"prelude-ls": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/type-detect": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/type-fest": {
+			"version": "0.21.3",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+			"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/typed-array-buffer": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+			"integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.3",
+				"es-errors": "^1.3.0",
+				"is-typed-array": "^1.1.14"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/typed-array-byte-length": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+			"integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"for-each": "^0.3.3",
+				"gopd": "^1.2.0",
+				"has-proto": "^1.2.0",
+				"is-typed-array": "^1.1.14"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/typed-array-byte-offset": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+			"integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"available-typed-arrays": "^1.0.7",
+				"call-bind": "^1.0.8",
+				"for-each": "^0.3.3",
+				"gopd": "^1.2.0",
+				"has-proto": "^1.2.0",
+				"is-typed-array": "^1.1.15",
+				"reflect.getprototypeof": "^1.0.9"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/typed-array-length": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+			"integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"for-each": "^0.3.3",
+				"gopd": "^1.0.1",
+				"is-typed-array": "^1.1.13",
+				"possible-typed-array-names": "^1.0.0",
+				"reflect.getprototypeof": "^1.0.6"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/typescript": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/typescript-eslint": {
+			"version": "8.61.0",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.61.0.tgz",
+			"integrity": "sha512-8y31Rd0eGTrDKqhy6vT0HtzhN+YLjQizwX3aA3hPXP/ynSfnrBXcQY5IzsP9/DM7+klX4IUncZZjkchP0z+rUw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/eslint-plugin": "8.61.0",
+				"@typescript-eslint/parser": "8.61.0",
+				"@typescript-eslint/typescript-estree": "8.61.0",
+				"@typescript-eslint/utils": "8.61.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/uglify-js": {
+			"version": "3.19.3",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+			"integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"optional": true,
+			"bin": {
+				"uglifyjs": "bin/uglifyjs"
+			},
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/unbox-primitive": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+			"integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.3",
+				"has-bigints": "^1.0.2",
+				"has-symbols": "^1.1.0",
+				"which-boxed-primitive": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/undici-types": {
+			"version": "5.26.5",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/unrs-resolver": {
+			"version": "1.12.2",
+			"resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
+			"integrity": "sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"dependencies": {
+				"napi-postinstall": "^0.3.4"
+			},
+			"funding": {
+				"url": "https://opencollective.com/unrs-resolver"
+			},
+			"optionalDependencies": {
+				"@unrs/resolver-binding-android-arm-eabi": "1.12.2",
+				"@unrs/resolver-binding-android-arm64": "1.12.2",
+				"@unrs/resolver-binding-darwin-arm64": "1.12.2",
+				"@unrs/resolver-binding-darwin-x64": "1.12.2",
+				"@unrs/resolver-binding-freebsd-x64": "1.12.2",
+				"@unrs/resolver-binding-linux-arm-gnueabihf": "1.12.2",
+				"@unrs/resolver-binding-linux-arm-musleabihf": "1.12.2",
+				"@unrs/resolver-binding-linux-arm64-gnu": "1.12.2",
+				"@unrs/resolver-binding-linux-arm64-musl": "1.12.2",
+				"@unrs/resolver-binding-linux-loong64-gnu": "1.12.2",
+				"@unrs/resolver-binding-linux-loong64-musl": "1.12.2",
+				"@unrs/resolver-binding-linux-ppc64-gnu": "1.12.2",
+				"@unrs/resolver-binding-linux-riscv64-gnu": "1.12.2",
+				"@unrs/resolver-binding-linux-riscv64-musl": "1.12.2",
+				"@unrs/resolver-binding-linux-s390x-gnu": "1.12.2",
+				"@unrs/resolver-binding-linux-x64-gnu": "1.12.2",
+				"@unrs/resolver-binding-linux-x64-musl": "1.12.2",
+				"@unrs/resolver-binding-openharmony-arm64": "1.12.2",
+				"@unrs/resolver-binding-wasm32-wasi": "1.12.2",
+				"@unrs/resolver-binding-win32-arm64-msvc": "1.12.2",
+				"@unrs/resolver-binding-win32-ia32-msvc": "1.12.2",
+				"@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
+			}
+		},
+		"node_modules/update-browserslist-db": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+			"integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"escalade": "^3.2.0",
+				"picocolors": "^1.1.1"
+			},
+			"bin": {
+				"update-browserslist-db": "cli.js"
+			},
+			"peerDependencies": {
+				"browserslist": ">= 4.21.0"
+			}
+		},
+		"node_modules/uri-js": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"punycode": "^2.1.0"
+			}
+		},
+		"node_modules/v8-to-istanbul": {
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+			"integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.12",
+				"@types/istanbul-lib-coverage": "^2.0.1",
+				"convert-source-map": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10.12.0"
+			}
+		},
+		"node_modules/w3c-keyname": {
+			"version": "2.2.8",
+			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+			"integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/w3c-xmlserializer": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+			"integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/walker": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+			"integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"makeerror": "1.0.12"
+			}
+		},
+		"node_modules/webidl-conversions": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+			"integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/whatwg-encoding": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+			"integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+			"deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"iconv-lite": "0.6.3"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/whatwg-mimetype": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+			"integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/whatwg-url": {
+			"version": "14.2.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+			"integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tr46": "^5.1.0",
+				"webidl-conversions": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/which-boxed-primitive": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+			"integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-bigint": "^1.1.0",
+				"is-boolean-object": "^1.2.1",
+				"is-number-object": "^1.1.1",
+				"is-string": "^1.1.1",
+				"is-symbol": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/which-builtin-type": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+			"integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"function.prototype.name": "^1.1.6",
+				"has-tostringtag": "^1.0.2",
+				"is-async-function": "^2.0.0",
+				"is-date-object": "^1.1.0",
+				"is-finalizationregistry": "^1.1.0",
+				"is-generator-function": "^1.0.10",
+				"is-regex": "^1.2.1",
+				"is-weakref": "^1.0.2",
+				"isarray": "^2.0.5",
+				"which-boxed-primitive": "^1.1.0",
+				"which-collection": "^1.0.2",
+				"which-typed-array": "^1.1.16"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/which-collection": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+			"integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-map": "^2.0.3",
+				"is-set": "^2.0.3",
+				"is-weakmap": "^2.0.2",
+				"is-weakset": "^2.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/which-typed-array": {
+			"version": "1.1.20",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+			"integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"available-typed-arrays": "^1.0.7",
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.4",
+				"for-each": "^0.3.5",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-tostringtag": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/word-wrap": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+			"integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/wordwrap": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+			"integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/wrap-ansi": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.1.0",
+				"string-width": "^5.0.1",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi-cjs": {
+			"name": "wrap-ansi",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/ansi-styles": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/write-file-atomic": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+			"integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/write-file-atomic/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/ws": {
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+			"integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/xml-name-validator": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+			"integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/xmlchars": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yallist": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/yaml": {
+			"version": "2.8.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+			"integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
+		},
+		"node_modules/yaml-eslint-parser": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/yaml-eslint-parser/-/yaml-eslint-parser-1.3.2.tgz",
+			"integrity": "sha512-odxVsHAkZYYglR30aPYRY4nUGJnoJ2y1ww2HDvZALo0BDETv9kWbi16J52eHs+PWRNmF4ub6nZqfVOeesOvntg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"eslint-visitor-keys": "^3.0.0",
+				"yaml": "^2.0.0"
+			},
+			"engines": {
+				"node": "^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ota-meshi"
+			}
+		},
+		"node_modules/yargs": {
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/yargs-parser": {
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/yargs/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/yargs/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/yargs/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/yargs/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		}
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,104 +1,104 @@
 {
-  "name": "advanced-audio-recorder",
-  "version": "1.5.0",
-  "description": "Advanced audio recording with input device and folder configuration.",
-  "main": "main.js",
-  "scripts": {
-    "dev": "node esbuild.config.mjs",
-    "build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
-    "test": "jest",
-    "test:coverage": "jest --coverage",
-    "lint": "eslint .",
-    "lint:fix": "eslint . --fix",
-    "version": "node scripts/version-bump.mjs && git add manifest.json versions.json",
-    "prepare": "husky"
-  },
-  "keywords": [
-    "obsidian",
-    "obsidian-plugin",
-    "audio",
-    "audio-recorder",
-    "voice-recorder",
-    "recording",
-    "microphone",
-    "multi-track",
-    "audio-converter",
-    "wav",
-    "mp3",
-    "flac",
-    "ogg",
-    "webm"
-  ],
-  "author": "Anatol Khmialeuski",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/akhmialeuski/advanced-audio-recorder"
-  },
-  "license": "MIT",
-  "devDependencies": {
-    "@types/jest": "30.0.0",
-    "@types/node": "22.19.21",
-    "esbuild": "0.28.1",
-    "eslint": "10.4.1",
-    "eslint-config-prettier": "10.1.8",
-    "eslint-plugin-obsidianmd": "0.3.0",
-    "eslint-plugin-prettier": "^5.5.4",
-    "globals": "^16.5.0",
-    "husky": "^9.0.0",
-    "jest": "30.4.2",
-    "jest-environment-jsdom": "30.4.1",
-    "nano-staged": "0.8.0",
-    "obsidian": "1.12.3",
-    "prettier": "3.8.1",
-    "ts-jest": "29.4.11",
-    "tslib": "2.8.1",
-    "typescript": "^5.9.3",
-    "typescript-eslint": "8.61.0"
-  },
-  "nano-staged": {
-    "*.ts": "eslint --fix",
-    "*.json": "prettier --write"
-  },
-  "jest": {
-    "moduleNameMapper": {
-      "^obsidian$": "<rootDir>/tests/mocks/obsidian.ts",
-      "^@mediabunny/flac-encoder$": "<rootDir>/tests/mocks/flac-encoder.ts",
-      "^@mediabunny/mp3-encoder$": "<rootDir>/tests/mocks/mp3-encoder.ts",
-      "^src/(.*)$": "<rootDir>/src/$1"
-    },
-    "moduleFileExtensions": [
-      "js",
-      "ts",
-      "d.ts"
-    ],
-    "transform": {
-      "^.+\\.ts$": "ts-jest"
-    },
-    "testEnvironment": "jsdom",
-    "testMatch": [
-      "<rootDir>/tests/**/*.test.ts"
-    ],
-    "clearMocks": true,
-    "restoreMocks": true,
-    "collectCoverageFrom": [
-      "src/**/*.ts",
-      "!src/**/*.d.ts"
-    ],
-    "coverageThreshold": {
-      "global": {
-        "statements": 80,
-        "branches": 71,
-        "functions": 70,
-        "lines": 80
-      }
-    },
-    "setupFiles": [
-      "<rootDir>/tests/setup.ts"
-    ]
-  },
-  "dependencies": {
-    "@mediabunny/flac-encoder": "1.50.4",
-    "@mediabunny/mp3-encoder": "1.50.4",
-    "mediabunny": "1.50.4"
-  }
+	"name": "advanced-audio-recorder",
+	"version": "1.5.0",
+	"description": "Advanced audio recording with input device and folder configuration.",
+	"main": "main.js",
+	"scripts": {
+		"dev": "node esbuild.config.mjs",
+		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
+		"test": "jest",
+		"test:coverage": "jest --coverage",
+		"lint": "eslint .",
+		"lint:fix": "eslint . --fix",
+		"version": "node scripts/version-bump.mjs && git add manifest.json versions.json",
+		"prepare": "husky"
+	},
+	"keywords": [
+		"obsidian",
+		"obsidian-plugin",
+		"audio",
+		"audio-recorder",
+		"voice-recorder",
+		"recording",
+		"microphone",
+		"multi-track",
+		"audio-converter",
+		"wav",
+		"mp3",
+		"flac",
+		"ogg",
+		"webm"
+	],
+	"author": "Anatol Khmialeuski",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/akhmialeuski/advanced-audio-recorder"
+	},
+	"license": "MIT",
+	"devDependencies": {
+		"@types/jest": "30.0.0",
+		"@types/node": "22.19.21",
+		"esbuild": "0.28.1",
+		"eslint": "10.4.1",
+		"eslint-config-prettier": "10.1.8",
+		"eslint-plugin-obsidianmd": "0.3.0",
+		"eslint-plugin-prettier": "^5.5.4",
+		"globals": "^16.5.0",
+		"husky": "^9.0.0",
+		"jest": "30.4.2",
+		"jest-environment-jsdom": "30.4.1",
+		"nano-staged": "0.8.0",
+		"obsidian": "1.12.3",
+		"prettier": "3.8.1",
+		"ts-jest": "29.4.11",
+		"tslib": "2.8.1",
+		"typescript": "6.0.3",
+		"typescript-eslint": "8.61.0"
+	},
+	"nano-staged": {
+		"*.ts": "eslint --fix",
+		"*.json": "prettier --write"
+	},
+	"jest": {
+		"moduleNameMapper": {
+			"^obsidian$": "<rootDir>/tests/mocks/obsidian.ts",
+			"^@mediabunny/flac-encoder$": "<rootDir>/tests/mocks/flac-encoder.ts",
+			"^@mediabunny/mp3-encoder$": "<rootDir>/tests/mocks/mp3-encoder.ts",
+			"^src/(.*)$": "<rootDir>/src/$1"
+		},
+		"moduleFileExtensions": [
+			"js",
+			"ts",
+			"d.ts"
+		],
+		"transform": {
+			"^.+\\.ts$": "ts-jest"
+		},
+		"testEnvironment": "jsdom",
+		"testMatch": [
+			"<rootDir>/tests/**/*.test.ts"
+		],
+		"clearMocks": true,
+		"restoreMocks": true,
+		"collectCoverageFrom": [
+			"src/**/*.ts",
+			"!src/**/*.d.ts"
+		],
+		"coverageThreshold": {
+			"global": {
+				"statements": 80,
+				"branches": 71,
+				"functions": 70,
+				"lines": 80
+			}
+		},
+		"setupFiles": [
+			"<rootDir>/tests/setup.ts"
+		]
+	},
+	"dependencies": {
+		"@mediabunny/flac-encoder": "1.50.4",
+		"@mediabunny/mp3-encoder": "1.50.4",
+		"mediabunny": "1.50.4"
+	}
 }

--- a/src/actions/PluginAction.ts
+++ b/src/actions/PluginAction.ts
@@ -8,7 +8,7 @@
  */
 
 import type { App, TFile } from 'obsidian';
-import type { AudioRecorderSettings } from '../settings/Settings';
+import type { AudioRecorderSettings } from '../settings/settingsSchema';
 import type { TranscriptionModalOptions } from '../ui/TranscriptionModal';
 import type { EncodingWorkerClient } from '../audio/EncodingWorkerClient';
 

--- a/src/audio/AudioCapabilityDetector.ts
+++ b/src/audio/AudioCapabilityDetector.ts
@@ -263,9 +263,7 @@ export function detectCapabilities(): AudioCapabilities {
 		? FORMAT_WEBM
 		: supportedFormats.includes(FORMAT_MP4)
 			? FORMAT_MP4
-			: supportedFormats.length > 0
-				? supportedFormats[0]
-				: FORMAT_WEBM;
+			: (supportedFormats[0] ?? FORMAT_WEBM);
 
 	return {
 		supportedFormats,

--- a/src/audio/AudioCapabilityDetector.ts
+++ b/src/audio/AudioCapabilityDetector.ts
@@ -25,10 +25,12 @@ const CANDIDATE_FORMATS = MEDIA_RECORDER_CANDIDATE_FORMATS;
 
 const COMPRESSED_INTERMEDIATES = COMPRESSED_INTERMEDIATE_FORMATS;
 
-const CANDIDATE_SAMPLE_RATES = [8000, 16000, 22050, 44100, 48000];
+const CANDIDATE_SAMPLE_RATES = [
+	8000, 16000, 22050, 44100, 48000,
+] as const satisfies readonly number[];
 const CANDIDATE_BITRATES_BPS = [
 	64000, 96000, 128000, 160000, 192000, 256000, 320000,
-];
+] as const satisfies readonly number[];
 
 /**
  * Result of a full capability detection.

--- a/src/audio/AudioEncoder.ts
+++ b/src/audio/AudioEncoder.ts
@@ -11,14 +11,10 @@ import {
 	AudioBufferSource,
 	canEncodeAudio,
 } from 'mediabunny';
-import type { OutputFormat, AudioCodec } from 'mediabunny';
+import type { OutputFormat } from 'mediabunny';
 import { EncodingError } from '../errors';
 import { FORMAT_MP3, FORMAT_FLAC } from '../constants';
-import {
-	AUDIO_FORMAT_IDS,
-	FORMAT_REGISTRY,
-	getFormatDescriptor,
-} from './formatRegistry';
+import { FORMAT_REGISTRY, getFormatDescriptor } from './formatRegistry';
 
 /**
  * Options for offline audio encoding.
@@ -34,15 +30,6 @@ export interface EncodingOptions {
  * Progress callback receiving percentage (0-100).
  */
 export type ProgressCallback = (percent: number) => void;
-
-/**
- * Codec used per format in Mediabunny AudioBufferSource. A view over
- * the format registry, kept as an export because the streaming
- * conversion pipeline (and its worker) resolve codecs through it.
- */
-export const FORMAT_CODEC_MAP: Record<string, AudioCodec> = Object.fromEntries(
-	AUDIO_FORMAT_IDS.map((id) => [id, FORMAT_REGISTRY[id].codec]),
-);
 
 /**
  * Creates the appropriate Mediabunny OutputFormat for the given format.

--- a/src/audio/AudioEncoder.ts
+++ b/src/audio/AudioEncoder.ts
@@ -177,12 +177,3 @@ export function isOfflineEncodingSupported(format: string): boolean {
 	}
 	return true;
 }
-
-/**
- * Returns a human-readable description of the encoder used for the format.
- * @param format - Audio format
- * @returns Encoder description string
- */
-export function getEncoderDescription(format: string): string {
-	return getFormatDescriptor(format)?.encoderDescription ?? 'Unknown';
-}

--- a/src/audio/AudioFormatConverter.ts
+++ b/src/audio/AudioFormatConverter.ts
@@ -98,6 +98,27 @@ export async function convertBlobToWav(
 }
 
 /**
+ * Like {@link convertBlobToWav} but returns the raw bytes, for callers
+ * that hand the result straight to vault.createBinary. On the streaming
+ * path this skips a Blob wrap plus a full read-back of the converted
+ * audio (two whole-file copies).
+ * @param recordedBlob - Compressed audio blob
+ * @returns WAV bytes
+ */
+export async function convertBlobToWavBuffer(
+	recordedBlob: Blob,
+	options: BlobConversionOptions = {},
+): Promise<ArrayBuffer> {
+	return convertBlobToFormatBuffer(
+		recordedBlob,
+		FORMAT_WAV,
+		0,
+		undefined,
+		options,
+	);
+}
+
+/**
  * Decodes compressed audio bytes into an AudioBuffer.
  * Decodes exactly once: decodeAudioData resamples to the context rate
  * by spec, so the previous probe-then-redecode-at-native-rate approach
@@ -241,6 +262,75 @@ export async function convertBlobToFormat(
 }
 
 /**
+ * Like {@link convertBlobToFormat} but returns the raw bytes, for callers
+ * that hand the result straight to vault.createBinary. The streaming path
+ * returns its buffer directly instead of wrapping it in a Blob that the
+ * caller would immediately read back out - two avoided copies of the
+ * whole converted file. The worker and decode fallbacks still produce a
+ * Blob internally and read it once, exactly as the Blob-returning path's
+ * callers did before.
+ * @param recordedBlob - Intermediate compressed blob
+ * @param targetFormat - Desired output format
+ * @param bitrate - Bitrate in bits per second
+ * @param onProgress - Optional encoding progress callback (0-100)
+ * @param options - Conversion behavior options
+ * @returns Re-encoded bytes in the target format
+ */
+export async function convertBlobToFormatBuffer(
+	recordedBlob: Blob,
+	targetFormat: string,
+	bitrate: number,
+	onProgress?: FormatProgressCallback,
+	options: BlobConversionOptions = {},
+): Promise<ArrayBuffer> {
+	const workerClient =
+		options.workerClient && options.workerClient.isAvailable()
+			? options.workerClient
+			: null;
+	if (workerClient) {
+		try {
+			const converted = await workerClient.convertBlob(
+				recordedBlob,
+				targetFormat,
+				bitrate,
+				options.allowRemux ?? false,
+				onProgress,
+			);
+			return await converted.arrayBuffer();
+		} catch (error) {
+			console.warn(
+				`${PLUGIN_LOG_PREFIX} Worker conversion failed, falling back to the main thread:`,
+				error,
+			);
+		}
+	}
+
+	try {
+		return await runStreamingConversion(
+			recordedBlob,
+			targetFormat,
+			bitrate,
+			options.allowRemux ?? false,
+			onProgress,
+		);
+	} catch (error) {
+		console.warn(
+			`${PLUGIN_LOG_PREFIX} Streaming conversion failed, falling back to decode and re-encode:`,
+			error,
+		);
+	}
+
+	const arrayBuffer = await recordedBlob.arrayBuffer();
+	const decodedBuffer = await decodeAudioBlob(arrayBuffer);
+	const encoded = await encodeAudioBuffer(
+		decodedBuffer,
+		{ format: targetFormat, bitrate },
+		onProgress,
+	);
+	return encoded.arrayBuffer();
+}
+
+/**
  * Combines buffered chunks into a single blob, optionally converting
  * to WAV if the recording format requires it.
  * @param chunks - Buffered audio chunks
@@ -267,6 +357,13 @@ export async function buildOutputBlob(
  * live settings - a settings change during the potentially long mix
  * could otherwise make the file extension and the encoded content
  * diverge.
+ *
+ * Memory: every track is decoded to a full AudioBuffer and mixed through
+ * an OfflineAudioContext, so peak memory scales with total session PCM
+ * (audit finding 6.4). This path is a deliberate fallback - it is reached
+ * only when the streaming mix cannot apply (tryStreamMixToWav covers PCM
+ * tracks with matching sample rates) - and should be revisited if the
+ * streaming mixer ever grows resampling support for mismatched rates.
  * @param chunkTargets - Recording targets for each track
  * @param targetFormat - Resolved encodable output format
  * @param bitrate - Encoder bitrate in bits per second

--- a/src/audio/AudioFormatConverter.ts
+++ b/src/audio/AudioFormatConverter.ts
@@ -5,7 +5,7 @@
  */
 
 import type { RecordingTarget } from '../types';
-import type { AudioRecorderSettings } from '../settings/Settings';
+import type { AudioRecorderSettings } from '../settings/settingsSchema';
 import { encodeAudioBuffer, isOfflineEncodingSupported } from './AudioEncoder';
 import { runStreamingConversion } from './streamingConversion';
 import {

--- a/src/audio/AudioFormatConverter.ts
+++ b/src/audio/AudioFormatConverter.ts
@@ -8,6 +8,7 @@ import type { RecordingTarget } from '../types';
 import type { AudioRecorderSettings } from '../settings/settingsSchema';
 import { encodeAudioBuffer, isOfflineEncodingSupported } from './AudioEncoder';
 import { runStreamingConversion } from './streamingConversion';
+import { autoClosing } from '../utils/disposables';
 import {
 	MIME_TYPE_AUDIO_PREFIX,
 	PLUGIN_LOG_PREFIX,
@@ -130,14 +131,10 @@ export async function convertBlobToWavBuffer(
 export async function decodeAudioBlob(
 	arrayBuffer: ArrayBuffer,
 ): Promise<AudioBuffer> {
-	const audioContext = new AudioContext();
-	try {
-		return await audioContext.decodeAudioData(arrayBuffer);
-	} finally {
-		// Close even when decoding fails (corrupted/unsupported input),
-		// otherwise the AudioContext leaks
-		await audioContext.close();
-	}
+	// Closed even when decoding fails (corrupted/unsupported input),
+	// otherwise the AudioContext leaks
+	await using audioContext = autoClosing(new AudioContext());
+	return await audioContext.decodeAudioData(arrayBuffer);
 }
 
 /**

--- a/src/audio/EncodingWorkerClient.ts
+++ b/src/audio/EncodingWorkerClient.ts
@@ -93,6 +93,10 @@ export class EncodingWorkerClient {
 	 */
 	terminate(): void {
 		if (this.worker) {
+			// Detach the handlers before terminating so a message already
+			// queued cannot fire into a client that is tearing down.
+			this.worker.onmessage = null;
+			this.worker.onerror = null;
 			this.worker.terminate();
 			this.worker = null;
 		}

--- a/src/audio/RecordingFileManager.ts
+++ b/src/audio/RecordingFileManager.ts
@@ -6,7 +6,7 @@
 
 import { normalizePath } from 'obsidian';
 import type { App } from 'obsidian';
-import type { AudioRecorderSettings } from '../settings/Settings';
+import type { AudioRecorderSettings } from '../settings/settingsSchema';
 import type { RecordingTarget } from '../types';
 import { PLUGIN_LOG_PREFIX } from '../constants';
 

--- a/src/audio/WavEncoder.ts
+++ b/src/audio/WavEncoder.ts
@@ -49,6 +49,12 @@ export const WAV_HEADER_SIZE = 44;
  */
 const BITS_PER_SAMPLE = 16;
 
+/** Size in bytes of the PCM "fmt " subchunk body (WAV spec). */
+const WAV_FMT_CHUNK_SIZE = 16;
+
+/** WAV format tag for uncompressed integer PCM (WAV spec). */
+const WAV_FORMAT_PCM = 1;
+
 /**
  * Creates a 44-byte WAV file header for raw int16 PCM data.
  * @param numChannels - Number of audio channels
@@ -78,9 +84,9 @@ export function createWavHeader(
 	// fmt subchunk
 	writeString(view, offset, 'fmt ');
 	offset += 4;
-	view.setUint32(offset, 16, true); // Subchunk1Size
+	view.setUint32(offset, WAV_FMT_CHUNK_SIZE, true);
 	offset += 4;
-	view.setUint16(offset, 1, true); // AudioFormat (PCM)
+	view.setUint16(offset, WAV_FORMAT_PCM, true);
 	offset += 2;
 	view.setUint16(offset, numChannels, true);
 	offset += 2;

--- a/src/audio/formatRegistry.ts
+++ b/src/audio/formatRegistry.ts
@@ -64,8 +64,6 @@ export interface AudioFormatDescriptor {
 	readonly mime: string;
 	/** Codec label shown in the audio file info modal. */
 	readonly codecLabel: string;
-	/** Encoder description shown in settings and the conversion dialog. */
-	readonly encoderDescription: string;
 }
 
 /**
@@ -84,7 +82,6 @@ export const FORMAT_REGISTRY = {
 		probeCodecs: [],
 		mime: `${MIME_TYPE_AUDIO_PREFIX}wav`,
 		codecLabel: 'pcm',
-		encoderDescription: 'PCM (built-in)',
 	},
 	[FORMAT_WEBM]: {
 		codec: 'opus',
@@ -97,7 +94,6 @@ export const FORMAT_REGISTRY = {
 		probeCodecs: ['opus', 'vorbis', 'pcm'],
 		mime: `${MIME_TYPE_AUDIO_PREFIX}webm`,
 		codecLabel: 'opus',
-		encoderDescription: 'AudioEncoder (Opus) + Mediabunny',
 	},
 	[FORMAT_OGG]: {
 		codec: 'opus',
@@ -110,7 +106,6 @@ export const FORMAT_REGISTRY = {
 		probeCodecs: ['opus', 'vorbis'],
 		mime: `${MIME_TYPE_AUDIO_PREFIX}ogg`,
 		codecLabel: 'opus/vorbis',
-		encoderDescription: 'AudioEncoder (Opus) + Mediabunny',
 	},
 	[FORMAT_MP3]: {
 		codec: 'mp3',
@@ -123,7 +118,6 @@ export const FORMAT_REGISTRY = {
 		probeCodecs: ['mp3'],
 		mime: `${MIME_TYPE_AUDIO_PREFIX}mpeg`,
 		codecLabel: 'mp3',
-		encoderDescription: 'Mediabunny MP3 Encoder',
 	},
 	[FORMAT_M4A]: {
 		codec: 'aac',
@@ -136,7 +130,6 @@ export const FORMAT_REGISTRY = {
 		probeCodecs: ['mp4a.40.2', 'mp4a.40.5'],
 		mime: `${MIME_TYPE_AUDIO_PREFIX}mp4`,
 		codecLabel: 'aac',
-		encoderDescription: 'AudioEncoder (AAC) + Mediabunny',
 	},
 	[FORMAT_MP4]: {
 		codec: 'aac',
@@ -149,7 +142,6 @@ export const FORMAT_REGISTRY = {
 		probeCodecs: ['mp4a.40.2', 'mp4a.40.5', 'opus'],
 		mime: `${MIME_TYPE_AUDIO_PREFIX}mp4`,
 		codecLabel: 'aac',
-		encoderDescription: 'AudioEncoder (AAC) + Mediabunny',
 	},
 	[FORMAT_FLAC]: {
 		codec: 'flac',
@@ -162,7 +154,6 @@ export const FORMAT_REGISTRY = {
 		probeCodecs: [],
 		mime: `${MIME_TYPE_AUDIO_PREFIX}flac`,
 		codecLabel: 'flac',
-		encoderDescription: 'Mediabunny FLAC Encoder',
 	},
 	[FORMAT_AAC]: {
 		codec: 'aac',
@@ -175,7 +166,6 @@ export const FORMAT_REGISTRY = {
 		probeCodecs: [],
 		mime: `${MIME_TYPE_AUDIO_PREFIX}aac`,
 		codecLabel: 'aac',
-		encoderDescription: 'AudioEncoder (AAC) + Mediabunny',
 	},
 } as const satisfies Record<string, AudioFormatDescriptor>;
 

--- a/src/audio/streamingConversion.ts
+++ b/src/audio/streamingConversion.ts
@@ -17,11 +17,9 @@ import {
 	Conversion,
 } from 'mediabunny';
 import type { AudioCodec } from 'mediabunny';
-import {
-	ensureEncoderRegistered,
-	createOutputFormat,
-	FORMAT_CODEC_MAP,
-} from './AudioEncoder';
+import { ensureEncoderRegistered, createOutputFormat } from './AudioEncoder';
+import { getFormatDescriptor } from './formatRegistry';
+import { disposableOf } from '../utils/disposables';
 
 /**
  * Converts a compressed audio blob to the target format using the
@@ -46,31 +44,30 @@ export async function runStreamingConversion(
 	allowRemux: boolean,
 	onProgress?: (percent: number) => void,
 ): Promise<ArrayBuffer> {
-	const codec: AudioCodec | undefined = FORMAT_CODEC_MAP[targetFormat];
+	const codec: AudioCodec | undefined =
+		getFormatDescriptor(targetFormat)?.codec;
 	if (!codec) {
 		throw new Error(`No codec mapping for format "${targetFormat}"`);
 	}
 
 	await ensureEncoderRegistered(targetFormat);
 
-	const input = new Input({
-		source: new BlobSource(recordedBlob),
-		formats: ALL_FORMATS,
-	});
-	try {
-		return await convertWithInput(
-			input,
-			targetFormat,
-			codec,
-			bitrate,
-			allowRemux,
-			onProgress,
-		);
-	} finally {
-		// The Input holds readers over the blob; free them on success
-		// and on every throw path alike
-		input.dispose();
-	}
+	// The Input holds readers over the blob; `using` frees them on
+	// success and on every throw path alike
+	using input = disposableOf(
+		new Input({
+			source: new BlobSource(recordedBlob),
+			formats: ALL_FORMATS,
+		}),
+	);
+	return await convertWithInput(
+		input,
+		targetFormat,
+		codec,
+		bitrate,
+		allowRemux,
+		onProgress,
+	);
 }
 
 /**

--- a/src/cleanup/AudioProcessingModal.ts
+++ b/src/cleanup/AudioProcessingModal.ts
@@ -33,7 +33,7 @@ import {
 	resolveAudioDspConfig,
 	type AudioDspConfig,
 } from './audioDsp';
-import type { AudioRecorderSettings } from '../settings/Settings';
+import type { AudioRecorderSettings } from '../settings/settingsSchema';
 
 /**
  * Audio-cleanup dialog for a single file.

--- a/src/cleanup/AudioProcessingService.ts
+++ b/src/cleanup/AudioProcessingService.ts
@@ -48,7 +48,7 @@ function writeWavSegment(
 		for (let channel = 0; channel < numChannels; channel++) {
 			pcm.setInt16(
 				offset,
-				floatToInt16(channels[channel][srcFrom + frame]),
+				floatToInt16(channels[channel]?.[srcFrom + frame] ?? 0),
 				true,
 			);
 			offset += 2;
@@ -97,7 +97,8 @@ export class AudioProcessingService {
 		const data = await this.app.vault.readBinary(file);
 		const { sampleRate, data: channels } = await this.decodeChannels(data);
 		const numChannels = channels.length;
-		const numFrames = channels[0].length;
+		// decodeChannels rejects empty audio, so the first channel exists
+		const numFrames = channels[0]?.length ?? 0;
 
 		// Allocate the full interleaved 16-bit WAV output once and fill it a
 		// segment at a time. Only the decoded input and this output live at full
@@ -217,7 +218,7 @@ export class AudioProcessingService {
 			for (let i = 0; i < decoded.numberOfChannels; i++) {
 				channels.push(Float32Array.from(decoded.getChannelData(i)));
 			}
-			if (channels.length === 0 || channels[0].length === 0) {
+			if ((channels[0]?.length ?? 0) === 0) {
 				throw new Error('The file contains no decodable audio data.');
 			}
 			return { sampleRate: decoded.sampleRate, data: channels };
@@ -249,7 +250,10 @@ export class AudioProcessingService {
 		);
 		const buffer = offline.createBuffer(numChannels, length, sampleRate);
 		for (let i = 0; i < numChannels; i++) {
-			buffer.getChannelData(i).set(channels[i]);
+			const channel = channels[i];
+			if (channel) {
+				buffer.getChannelData(i).set(channel);
+			}
 		}
 		const source = offline.createBufferSource();
 		source.buffer = buffer;

--- a/src/cleanup/audioDsp.ts
+++ b/src/cleanup/audioDsp.ts
@@ -172,7 +172,8 @@ export function applyNoiseGateToChannel(
 		const end = Math.min(samples.length, start + windowSize);
 		let sumSquares = 0;
 		for (let i = start; i < end; i++) {
-			sumSquares += samples[i] * samples[i];
+			const sample = samples[i] ?? 0;
+			sumSquares += sample * sample;
 		}
 		const rms = Math.sqrt(sumSquares / (end - start));
 		const rmsDb = rms > 0 ? 20 * Math.log10(rms) : -Infinity;
@@ -181,7 +182,7 @@ export function applyNoiseGateToChannel(
 		for (let i = start; i < end; i++) {
 			const coef = target > gain ? attackCoef : releaseCoef;
 			gain = target + (gain - target) * coef;
-			out[i] = samples[i] * gain;
+			out[i] = (samples[i] ?? 0) * gain;
 		}
 	}
 	return out;

--- a/src/cleanup/audioDsp.ts
+++ b/src/cleanup/audioDsp.ts
@@ -17,7 +17,7 @@ import {
 	MIN_CLEANUP_HIGHPASS_HZ,
 	MIN_CLEANUP_LEVELING_MAKEUP_DB,
 } from '../constants';
-import type { AudioRecorderSettings } from '../settings/Settings';
+import type { AudioRecorderSettings } from '../settings/settingsSchema';
 
 /** Resolved, clamped audio-cleanup configuration. */
 export interface AudioDspConfig {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,6 +47,9 @@ export const RECORDER_STOP_TIMEOUT_MS = 5000;
  */
 export const PCM_FLUSH_TIMEOUT_MS = 5000;
 
+/** Bytes in one megabyte (binary), for size settings expressed in MB. */
+export const BYTES_PER_MB = 1024 * 1024;
+
 /** Maximum in-memory buffer size for mobile recordings before flushing to disk. */
 export const MOBILE_BUFFER_LIMIT_BYTES = 50 * 1024 * 1024;
 

--- a/src/diagnostics/SystemDiagnostics.ts
+++ b/src/diagnostics/SystemDiagnostics.ts
@@ -4,6 +4,7 @@
  * @module diagnostics/SystemDiagnostics
  */
 
+import { apiVersion } from 'obsidian';
 import type { App } from 'obsidian';
 import type { AudioRecorderSettings } from '../settings/settingsSchema';
 import { serializeTrackAudioSources } from '../settings/settingsSerialization';
@@ -132,12 +133,13 @@ export class SystemDiagnostics {
 
 	/**
 	 * Collects Obsidian and runtime environment information.
-	 * @param app - The Obsidian App instance
+	 * @param _app - The Obsidian App instance (kept for signature stability;
+	 *   the API version now comes from obsidian's module-level export)
 	 * @returns Environment info object
 	 */
-	static collectEnvironment(app: App): DiagnosticsEnvironment {
-		const apiVersion =
-			(app as unknown as { apiVersion?: string }).apiVersion ?? 'unknown';
+	static collectEnvironment(_app: App): DiagnosticsEnvironment {
+		// The API version ships as a module-level export; the old cast read a
+		// non-existent app property and always fell back to 'unknown'.
 		const proc = (typeof process !== 'undefined' ? process : null) as {
 			type?: string;
 			versions?: {

--- a/src/diagnostics/SystemDiagnostics.ts
+++ b/src/diagnostics/SystemDiagnostics.ts
@@ -5,8 +5,8 @@
  */
 
 import type { App } from 'obsidian';
-import type { AudioRecorderSettings } from '../settings/Settings';
-import { serializeTrackAudioSources } from '../settings/Settings';
+import type { AudioRecorderSettings } from '../settings/settingsSchema';
+import { serializeTrackAudioSources } from '../settings/settingsSerialization';
 import {
 	detectCapabilities,
 	detectCodecSupport,

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -8,3 +8,11 @@
  * define. Undefined in environments that bypass the bundler (tests).
  */
 declare const __ENCODING_WORKER_SOURCE__: string | undefined;
+
+/**
+ * Prefixed AudioContext constructor still shipped by older WebKit;
+ * probed as a fallback where a context is created from window.
+ */
+interface Window {
+	webkitAudioContext?: typeof AudioContext;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@
  * @module main
  */
 
-import { Notice, Platform, Plugin, TFile } from 'obsidian';
+import { Notice, Platform, Plugin } from 'obsidian';
 import { RecordingStatus } from './types';
 import type {
 	SaveProgress,
@@ -679,8 +679,8 @@ export default class AudioRecorderPlugin extends Plugin {
 		) {
 			return;
 		}
-		const file = this.app.vault.getAbstractFileByPath(result.audioPaths[0]);
-		if (!(file instanceof TFile)) {
+		const file = this.app.vault.getFileByPath(result.audioPaths[0]);
+		if (!file) {
 			return;
 		}
 		// Open the transcription modal and auto-run it: the user gets visible

--- a/src/main.ts
+++ b/src/main.ts
@@ -679,7 +679,11 @@ export default class AudioRecorderPlugin extends Plugin {
 		) {
 			return;
 		}
-		const file = this.app.vault.getFileByPath(result.audioPaths[0]);
+		const [firstAudioPath] = result.audioPaths;
+		if (!firstAudioPath) {
+			return;
+		}
+		const file = this.app.vault.getFileByPath(firstAudioPath);
 		if (!file) {
 			return;
 		}

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,11 +11,11 @@ import type {
 	RecordingSaveResult,
 } from './types';
 import { PLUGIN_LOG_PREFIX } from './constants';
+import { AudioRecorderSettings } from './settings/settingsSchema';
 import {
-	AudioRecorderSettings,
 	mergeSettingsAsync,
 	serializeSettings,
-} from './settings/Settings';
+} from './settings/settingsSerialization';
 import { AudioRecorderSettingTab } from './settings/SettingsTab';
 import { RecordingManager } from './recording/RecordingManager';
 import { SessionJournal, JOURNAL_FILE_NAME } from './recording/SessionJournal';

--- a/src/markers/markerFactory.ts
+++ b/src/markers/markerFactory.ts
@@ -7,6 +7,7 @@
  */
 
 import { MARKER_KIND, type MarkerKind } from './markerModel';
+import { randomToken } from '../utils/ids';
 
 /**
  * Generates a short, collision-resistant marker id. Uses crypto.randomUUID
@@ -19,7 +20,7 @@ export function generateMarkerId(): string {
 	if (cryptoApi?.randomUUID) {
 		return cryptoApi.randomUUID();
 	}
-	return `${String(Date.now())}-${Math.random().toString(36).slice(2)}`;
+	return `${String(Date.now())}-${randomToken()}`;
 }
 
 /**

--- a/src/markers/markerModel.ts
+++ b/src/markers/markerModel.ts
@@ -295,7 +295,11 @@ export function activeMarkerIndex(
 ): number {
 	let index = -1;
 	for (let i = 0; i < sortedMarkers.length; i++) {
-		if (sortedMarkers[i].time <= time + TIME_EPSILON_SECONDS) {
+		const marker = sortedMarkers[i];
+		if (!marker) {
+			break;
+		}
+		if (marker.time <= time + TIME_EPSILON_SECONDS) {
 			index = i;
 		} else {
 			break;

--- a/src/player/AudioPlayer.ts
+++ b/src/player/AudioPlayer.ts
@@ -711,6 +711,7 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 			return;
 		}
 		let attempts = PLAYER_ATTACH_WAIT_FRAMES;
+		let rafId = 0;
 		const tick = (): void => {
 			if (this.unloaded) {
 				return;
@@ -722,9 +723,14 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 			if (attempts-- <= 0) {
 				return;
 			}
-			window.requestAnimationFrame(tick);
+			rafId = window.requestAnimationFrame(tick);
 		};
-		window.requestAnimationFrame(tick);
+		rafId = window.requestAnimationFrame(tick);
+		// Cancel outright on re-render/unload instead of relying on the
+		// unloaded flag alone to fizzle the loop.
+		this.registerRenderCleanup(() => {
+			window.cancelAnimationFrame(rafId);
+		});
 	}
 
 	/**

--- a/src/player/AudioPlayer.ts
+++ b/src/player/AudioPlayer.ts
@@ -7,26 +7,24 @@
  * element, registry registration, observers) is torn down automatically
  * when the note re-renders or the leaf closes.
  *
- * The class is a coordinator: the waveform rendering lives in WaveformCanvas
- * and the marker/chapter UI in MarkerListView, leaving this file focused on
- * the audio element, controls, seeking, mode, and persistence wiring.
+ * The class is a coordinator: it owns the embed-takeover lifecycle, the
+ * shared audio element, and the #t= start hint, and wires the
+ * collaborators that do the rest - PlayerControlsView (control row),
+ * SeekController (pointer/keyboard seeking), DurationProbe
+ * (initially-unknown durations), WaveformController (progressive decode
+ * and drawing), PlayerMarkerController (marker CRUD and persistence),
+ * plus WaveformCanvas and MarkerListView for the rendered surfaces.
  * @module player/AudioPlayer
  */
 
-import { MarkdownRenderChild, Menu, Notice, setIcon } from 'obsidian';
+import { MarkdownRenderChild, Menu, Notice } from 'obsidian';
 import type { App, TFile } from 'obsidian';
 import {
 	PLUGIN_LOG_PREFIX,
 	PLAYER_PLAYBACK_RATE_PRESETS,
-	WAVEFORM_CACHE_BUCKETS,
-	WAVEFORM_MAX_DECODE_BYTES,
 	PLAYER_LOOP,
 	PLAYER_PLAYBACK_RATE,
-	PLAYER_SKIP_SECONDS,
-	PLAYER_SEEK_KEYBOARD_STEP_SECONDS,
 	PLAYER_ATTACH_WAIT_FRAMES,
-	PLAYER_WAVEFORM_REDRAW_RETRIES,
-	PLAYER_WAVEFORM_PREFETCH_MARGIN_PX,
 } from '../constants';
 import { formatTimecode } from '../utils/TimeUtils';
 import { playbackProgress } from './playbackProgress';
@@ -34,58 +32,31 @@ import {
 	playerSettingsEqual,
 	type ResolvedPlayerSettings,
 } from '../player/playerSettings';
-import {
-	computeWaveformPeaksProgressive,
-	waveformCacheKey,
-	WaveformPeakCache,
-	type AudioDecoder,
-} from './WaveformData';
+import { WaveformPeakCache, type AudioDecoder } from './WaveformData';
 import { playbackKey } from './AudioPlayerRegistry';
 import type {
 	AudioPlayerRegistry,
 	SeekablePlayer,
 } from './AudioPlayerRegistry';
 import type { MarkerStore } from '../markers/MarkerStore';
-import {
-	addMarker,
-	chapters,
-	MARKER_KIND,
-	nextChapterTime,
-	previousChapterTime,
-	removeMarker,
-	updateMarker,
-	type MarkerKind,
-	type PlayerMarker,
-} from '../markers/markerModel';
-import { defaultMarkerLabel, generateMarkerId } from '../markers/markerFactory';
-import { formatPlaybackRate, speedMenuItems } from './playbackRate';
+import type { MarkerKind } from '../markers/markerModel';
+import { speedMenuItems } from './playbackRate';
 import { isEditableContext } from './playerMode';
 import {
 	setPlayerEmbedActions,
 	clearPlayerEmbedActions,
 	type PlayerEmbedActions,
 } from './playerEmbedActions';
-import { WaveformCanvas } from './views/WaveformCanvas';
+import { DurationProbe } from './DurationProbe';
+import { SeekController } from './SeekController';
+import { WaveformController } from './WaveformController';
+import { PlayerMarkerController } from './PlayerMarkerController';
+import { PlayerControlsView } from './views/PlayerControlsView';
 import {
 	MarkerListView,
 	type MarkerListCallbacks,
 	type MarkerListHost,
 } from './views/MarkerListView';
-
-/**
- * A very large finite time used to coax browsers into computing the
- * real duration of a stream (notably MediaRecorder WebM) that initially
- * reports Infinity. Seeking near the end triggers a durationchange with
- * the true value, after which playback is reset to the start.
- */
-const DURATION_PROBE_SECONDS = 1e101;
-
-/**
- * How long to wait for a probed stream to report its real duration
- * before giving up, so playback is not left stranded at the probe seek
- * position when the corrected duration never arrives.
- */
-const DURATION_PROBE_TIMEOUT_MS = 5000;
 
 /**
  * Fallback delay before rendering the player when Obsidian never signals
@@ -134,17 +105,20 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 	 * has no #t= offset.
 	 */
 	private startHint: number | null = null;
-	private playButton!: HTMLElement;
 	private seekEl!: HTMLElement;
-	/** Waveform renderer, or null when the plain bar is shown. */
-	private waveform: WaveformCanvas | null = null;
+	/** Control row for the current render, or null before the first render. */
+	private controls: PlayerControlsView | null = null;
 	/** Marker/chapter UI, or null when markers are disabled. */
 	private markerView: MarkerListView | null = null;
 	private progressFillEl: HTMLElement | null = null;
-	private timeEl: HTMLElement | null = null;
-	private speedButton: HTMLElement | null = null;
-	private isSeeking = false;
-	private durationProbeActive = false;
+	/** Pointer/keyboard seeking and the clientX-to-time mapping. */
+	private readonly seekCtl: SeekController;
+	/** Progressive waveform decode and rendering. */
+	private readonly waveformCtl: WaveformController;
+	/** Marker data, persistence, and chapter navigation. */
+	private readonly markerCtl: PlayerMarkerController;
+	/** Probe for sources that load without a usable duration. */
+	private durationProbe: DurationProbe | null = null;
 	/**
 	 * Guards the one-time render so onload (Reading view) and Obsidian's
 	 * loadFile (Live Preview embed widget) never both render this player.
@@ -165,12 +139,6 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 	 * in Reading view - the regression this guards against.
 	 */
 	private editable = false;
-	private resizeObserver: ResizeObserver | null = null;
-	/** Observer that defers the waveform decode until the player is on screen. */
-	private waveformObserver: IntersectionObserver | null = null;
-	private muteButton: HTMLElement | null = null;
-	/** Authoritative marker list for this file; the view renders from it. */
-	private markers: PlayerMarker[] = [];
 	/**
 	 * Cleanups scoped to the CURRENT render pass (not the component lifetime).
 	 * Run at the start of every renderUi and on unload, so observers and
@@ -196,13 +164,60 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 		private readonly file: TFile,
 		private settings: ResolvedPlayerSettings,
 		private readonly registry: AudioPlayerRegistry,
-		private readonly peakCache: WaveformPeakCache,
-		private readonly decoder: AudioDecoder,
-		private readonly markerStore: MarkerStore,
+		peakCache: WaveformPeakCache,
+		decoder: AudioDecoder,
+		markerStore: MarkerStore,
 		private readonly options: AudioPlayerOptions,
 	) {
 		super(containerEl);
 		this.audioKey = playbackKey(file.path, options.startSeconds);
+		this.seekCtl = new SeekController(
+			{
+				registerDomEvent: (el, type, handler) => {
+					this.registerRenderDomEvent(el, type, handler);
+				},
+			},
+			{
+				onSeekToTime: (seconds) => {
+					// A user seek engages the shared timeline
+					this.engageTimeline();
+					this.audio.currentTime = seconds;
+					this.updateProgress();
+				},
+				onSkip: (deltaSeconds) => {
+					this.skip(deltaSeconds);
+				},
+				onEngageTimeline: () => {
+					this.engageTimeline();
+				},
+				duration: () => this.audio.duration,
+			},
+		);
+		this.waveformCtl = new WaveformController(
+			app,
+			file,
+			decoder,
+			peakCache,
+			{
+				registerRenderCleanup: (cleanup) => {
+					this.registerRenderCleanup(cleanup);
+				},
+				isUnloaded: () => this.unloaded,
+			},
+		);
+		this.markerCtl = new PlayerMarkerController(markerStore, file.path, {
+			isUnloaded: () => this.unloaded,
+			renderMarkers: () => {
+				this.renderMarkers();
+			},
+			refreshTicks: () => {
+				this.markerView?.setMarkers(this.markerCtl.all);
+				this.markerView?.refreshTicks(this.knownDuration());
+			},
+			notifyOthers: () => {
+				this.registry.reloadMarkers(this.file.path, this);
+			},
+		});
 	}
 
 	/**
@@ -376,6 +391,14 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 			this.registry.releaseAudio(this.audioKey);
 		});
 
+		this.durationProbe = new DurationProbe(this.audio, () => {
+			this.renderMarkers();
+			this.updateProgress();
+		});
+		this.register(() => {
+			this.durationProbe?.cancel();
+		});
+
 		this.registerAudioEvents();
 
 		this.registry.register(this.file.path, this);
@@ -401,8 +424,7 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 	private renderUi(): void {
 		// Tear down the previous render pass before rebuilding, so an in-place
 		// settings re-render never accumulates observers or listeners on the
-		// component lifetime (each is registered per render, see below). The
-		// observers' own cleanups null these fields.
+		// component lifetime (each is registered per render, see below).
 		this.runRenderCleanups();
 
 		this.containerEl.empty();
@@ -413,12 +435,12 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 		this.guardAgainstDefaultEmbed();
 
 		// A fresh marker view per render (the DOM it owns is recreated by
-		// empty()); the authoritative markers stay on this player
+		// empty()); the authoritative markers stay on the marker controller
 		this.markerView = this.settings.enableMarkers
 			? this.createMarkerView()
 			: null;
 		this.markerView?.setEditable(this.editable);
-		this.markerView?.setMarkers(this.markers);
+		this.markerView?.setMarkers(this.markerCtl.all);
 
 		this.buildControls();
 		this.buildSeekArea();
@@ -427,9 +449,9 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 		}
 
 		if (this.settings.enableMarkers) {
-			void this.loadMarkers();
+			void this.markerCtl.load();
 		} else {
-			this.markers = [];
+			this.markerCtl.clear();
 		}
 
 		// Publish now with the default (read-only) mode; applyMode
@@ -445,7 +467,7 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 		});
 
 		if (this.shouldShowWaveform()) {
-			this.scheduleWaveformLoad();
+			this.waveformCtl.scheduleLoad(this.containerEl);
 		}
 
 		this.updateProgress();
@@ -520,13 +542,13 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 	 */
 	reloadMarkers(): void {
 		if (this.settings.enableMarkers) {
-			void this.loadMarkers();
+			void this.markerCtl.load();
 		}
 	}
 
 	/**
 	 * Builds the marker view with this player's lifecycle hooks and the
-	 * callbacks that keep marker data and persistence owned by the player.
+	 * callbacks that route marker edits through the marker controller.
 	 */
 	private createMarkerView(): MarkerListView {
 		const host: MarkerListHost = {
@@ -543,15 +565,15 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 				this.seekTo(time, false);
 			},
 			onDelete: (id) => {
-				void this.deleteMarker(id);
+				void this.markerCtl.remove(id);
 			},
 			onRename: (id, label) => {
-				void this.renameMarker(id, label);
+				void this.markerCtl.rename(id, label);
 			},
 			onAddAt: (time, kind) => {
-				void this.addMarkerAt(time, kind);
+				void this.markerCtl.addAt(time, kind);
 			},
-			timeAtClientX: (clientX) => this.timeAtClientX(clientX),
+			timeAtClientX: (clientX) => this.seekCtl.timeAtClientX(clientX),
 		};
 		return new MarkerListView(host, callbacks);
 	}
@@ -580,157 +602,76 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 	}
 
 	/**
-	 * Builds the control row (play/pause, skip, speed, volume, loop,
-	 * time, copy-timestamp). Every control is fixed; only the marker
-	 * controls depend on the markers window being enabled.
+	 * Builds the control row for the current render, reflecting the shared
+	 * audio's live state (a player re-rendered while playback is running
+	 * must not show stale defaults).
 	 */
 	private buildControls(): void {
-		const controls = this.containerEl.createDiv({
-			cls: 'aar-player-controls',
-		});
-
-		this.playButton = this.createIconButton(
-			controls,
-			// Reflect the shared audio's current state, so a player rendered
-			// while playback is already running (e.g. after a mode switch)
-			// shows the pause icon rather than a stale play icon
-			this.audio.paused ? 'play' : 'pause',
-			'Play / pause',
-			() => {
-				this.togglePlay();
-			},
-		);
-
-		this.createIconButton(
-			controls,
-			'rewind',
-			`Back ${String(PLAYER_SKIP_SECONDS)}s`,
-			() => {
-				this.skip(-PLAYER_SKIP_SECONDS);
-			},
-		);
-		this.createIconButton(
-			controls,
-			'fast-forward',
-			`Forward ${String(PLAYER_SKIP_SECONDS)}s`,
-			() => {
-				this.skip(PLAYER_SKIP_SECONDS);
-			},
-		);
-
-		this.speedButton = controls.createEl('button', {
-			cls: 'aar-player-btn aar-player-speed',
-			// Reflect the shared audio's current rate, not the default, so a
-			// re-render after a mode switch keeps showing the chosen speed
-			text: formatPlaybackRate(this.audio.playbackRate),
-		});
-		this.speedButton.setAttribute('aria-label', 'Playback speed');
-		this.registerRenderDomEvent(this.speedButton, 'click', (event) => {
-			this.showSpeedMenu(event);
-		});
-
-		this.muteButton = this.createIconButton(
-			controls,
-			'volume-2',
-			'Mute / unmute',
-			() => {
-				this.toggleMute();
-			},
-		);
-		this.updateMuteIcon();
-
-		const volume = controls.createEl('input', {
-			cls: 'aar-player-volume',
-			attr: {
-				type: 'range',
-				min: '0',
-				max: '1',
-				step: '0.05',
-				// Reflect the shared audio's current volume on re-render
-				value: String(this.audio.volume),
-				'aria-label': 'Volume',
-			},
-		});
-		this.registerRenderDomEvent(volume, 'input', () => {
-			this.audio.volume = Number(volume.value);
-			if (this.audio.muted && Number(volume.value) > 0) {
-				this.audio.muted = false;
-				this.updateMuteIcon();
-			}
-		});
-
-		const loopButton = this.createIconButton(
-			controls,
-			'repeat',
-			'Loop',
-			() => {
-				this.audio.loop = !this.audio.loop;
-				loopButton.toggleClass('is-active', this.audio.loop);
-			},
-		);
-		loopButton.toggleClass('is-active', this.audio.loop);
-
-		if (this.settings.enableMarkers) {
-			// Adding markers/chapters is edit-only; hidden in reading view
-			this.createIconButton(
-				controls,
-				'bookmark-plus',
-				'Add marker at current position',
-				() => {
-					void this.addMarkerAt(
-						this.audio.currentTime,
-						MARKER_KIND.bookmark,
-					);
+		this.controls = new PlayerControlsView(
+			{
+				registerDomEvent: (el, type, handler) => {
+					this.registerRenderDomEvent(el, type, handler);
 				},
-			).addClass('aar-player-edit-only');
-			this.createIconButton(
-				controls,
-				'list-plus',
-				'Add chapter at current position',
-				() => {
-					void this.addMarkerAt(
-						this.audio.currentTime,
-						MARKER_KIND.chapter,
-					);
+			},
+			{
+				onTogglePlay: () => {
+					this.togglePlay();
 				},
-			).addClass('aar-player-edit-only');
-			this.createIconButton(
-				controls,
-				'chevron-first',
-				'Previous chapter',
-				() => {
+				onSkip: (deltaSeconds) => {
+					this.skip(deltaSeconds);
+				},
+				onSpeedMenu: (event) => {
+					this.showSpeedMenu(event);
+				},
+				onToggleMute: () => {
+					this.toggleMute();
+				},
+				onVolumeInput: (volume) => {
+					this.audio.volume = volume;
+					if (this.audio.muted && volume > 0) {
+						this.audio.muted = false;
+						this.controls?.setMuted(false);
+					}
+				},
+				onToggleLoop: () => {
+					this.audio.loop = !this.audio.loop;
+					return this.audio.loop;
+				},
+				onAddMarker: (kind: MarkerKind) => {
+					void this.markerCtl.addAt(this.audio.currentTime, kind);
+				},
+				onPreviousChapter: () => {
 					this.jumpToPreviousChapter();
 				},
-			);
-			this.createIconButton(
-				controls,
-				'chevron-last',
-				'Next chapter',
-				() => {
+				onNextChapter: () => {
 					this.jumpToNextChapter();
 				},
-			);
-		}
-
-		this.timeEl = controls.createDiv({ cls: 'aar-player-time' });
-		this.timeEl.setText('0:00 / 0:00');
-
-		this.createIconButton(controls, 'link', 'Copy timestamp link', () => {
-			void this.copyTimestampLink();
+				onCopyTimestampLink: () => {
+					void this.copyTimestampLink();
+				},
+			},
+		);
+		this.controls.mount(this.containerEl, {
+			paused: this.audio.paused,
+			playbackRate: this.audio.playbackRate,
+			volume: this.audio.volume,
+			muted: this.audio.muted,
+			loop: this.audio.loop,
+			markersEnabled: this.settings.enableMarkers,
 		});
 	}
 
 	/**
 	 * Builds the seek area: a waveform when enabled (and the file is small
 	 * enough), otherwise a linear progress bar. Both support click and drag
-	 * seeking through the same pointer handlers.
+	 * seeking through the same seek controller.
 	 */
 	private buildSeekArea(): void {
 		this.seekEl = this.containerEl.createDiv({ cls: 'aar-player-seek' });
 		// Reset the renderer refs every render. Without this, toggling the
 		// waveform off would leave a stale renderer so updateProgress would
 		// target the dead canvas and never update the new progress bar.
-		this.waveform = null;
+		this.waveformCtl.reset();
 		this.progressFillEl = null;
 		// Expose the seek area as a keyboard-operable slider so seeking is
 		// not mouse-only (the native audio element offered this for free)
@@ -740,17 +681,7 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 		this.seekEl.setAttribute('aria-valuemin', '0');
 		if (this.shouldShowWaveform()) {
 			this.seekEl.addClass('aar-player-seek-waveform');
-			this.waveform = new WaveformCanvas(this.seekEl);
-			this.resizeObserver = new ResizeObserver(() => {
-				// Re-read theme colors in case the theme changed, then redraw
-				this.waveform?.invalidateColors();
-				this.waveform?.redraw();
-			});
-			this.resizeObserver.observe(this.seekEl);
-			this.registerRenderCleanup(() => {
-				this.resizeObserver?.disconnect();
-				this.resizeObserver = null;
-			});
+			this.waveformCtl.mount(this.seekEl);
 		} else {
 			// Plain progress bar: a filled track (played, high contrast) over
 			// a muted track (remaining), with a thumb marking the position
@@ -764,105 +695,7 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 			// Ticks/dblclick overlay sits on top of the seek area
 			this.markerView.mountOverlay(this.seekEl);
 		}
-		this.registerSeekPointer();
-		this.registerSeekKeyboard();
-	}
-
-	/**
-	 * Wires keyboard seeking on the slider-role seek area: arrow keys
-	 * nudge by a few seconds, Home/End jump to the bounds.
-	 */
-	private registerSeekKeyboard(): void {
-		this.registerRenderDomEvent(this.seekEl, 'keydown', (event) => {
-			switch (event.key) {
-				case 'ArrowRight':
-				case 'ArrowUp':
-					this.skip(PLAYER_SEEK_KEYBOARD_STEP_SECONDS);
-					break;
-				case 'ArrowLeft':
-				case 'ArrowDown':
-					this.skip(-PLAYER_SEEK_KEYBOARD_STEP_SECONDS);
-					break;
-				case 'Home':
-					this.engageTimeline();
-					this.audio.currentTime = 0;
-					this.updateProgress();
-					break;
-				case 'End':
-					this.engageTimeline();
-					if (Number.isFinite(this.audio.duration)) {
-						this.audio.currentTime = this.audio.duration;
-						this.updateProgress();
-					}
-					break;
-				default:
-					return;
-			}
-			event.preventDefault();
-		});
-	}
-
-	/**
-	 * Wires pointer events for click/drag seeking on the seek area. The
-	 * seek area captures the pointer on press so a drag that leaves it
-	 * still tracks, without a document-wide listener per player instance.
-	 */
-	private registerSeekPointer(): void {
-		this.registerRenderDomEvent(this.seekEl, 'pointerdown', (event) => {
-			// Ignore non-primary buttons so a right-click opens the
-			// context menu instead of seeking
-			if (event.button !== 0) {
-				return;
-			}
-			this.isSeeking = true;
-			// Route subsequent pointer events to the seek area even when
-			// the cursor leaves it during the drag
-			this.seekEl.setPointerCapture(event.pointerId);
-			this.seekToPointer(event);
-		});
-		this.registerRenderDomEvent(this.seekEl, 'pointermove', (event) => {
-			if (this.isSeeking) {
-				this.seekToPointer(event);
-			}
-		});
-		this.registerRenderDomEvent(this.seekEl, 'pointerup', (event) => {
-			this.isSeeking = false;
-			if (this.seekEl.hasPointerCapture(event.pointerId)) {
-				this.seekEl.releasePointerCapture(event.pointerId);
-			}
-		});
-		this.registerRenderDomEvent(this.seekEl, 'pointercancel', () => {
-			this.isSeeking = false;
-		});
-	}
-
-	/**
-	 * Converts a pointer event's horizontal position into a playback
-	 * offset along the seek area, or null when the duration is unknown.
-	 * @param event - Pointer or mouse event over the seek area
-	 */
-	private pointerTime(event: PointerEvent | MouseEvent): number | null {
-		return this.timeAtClientX(event.clientX);
-	}
-
-	/**
-	 * Converts a client X coordinate to a playback offset along the seek
-	 * area, or null when the duration is unknown or the area has no width.
-	 * @param clientX - Horizontal viewport coordinate
-	 */
-	private timeAtClientX(clientX: number): number | null {
-		if (!Number.isFinite(this.audio.duration) || this.audio.duration <= 0) {
-			return null;
-		}
-		const rect = this.seekEl.getBoundingClientRect();
-		if (rect.width === 0) {
-			return null;
-		}
-		const fraction = Math.min(
-			1,
-			Math.max(0, (clientX - rect.left) / rect.width),
-		);
-		return fraction * this.audio.duration;
+		this.seekCtl.attach(this.seekEl);
 	}
 
 	/**
@@ -919,9 +752,10 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 			markersEnabled: this.settings.enableMarkers && this.editable,
 			// The copy-timestamp action is a fixed control, always available
 			timestampLinksEnabled: true,
-			timeAtClientX: (clientX: number) => this.timeAtClientX(clientX),
+			timeAtClientX: (clientX: number) =>
+				this.seekCtl.timeAtClientX(clientX),
 			addMarkerAtTime: (time: number, kind: MarkerKind) => {
-				void this.addMarkerAt(time, kind);
+				void this.markerCtl.addAt(time, kind);
 			},
 			copyTimestampAtTime: (time: number) => {
 				void this.copyTimestampLink(time);
@@ -934,21 +768,6 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 		this.registerRenderCleanup(() => {
 			clearPlayerEmbedActions(this.containerEl);
 		});
-	}
-
-	/**
-	 * Seeks to the position under the pointer along the seek area.
-	 * @param event - Pointer event from the seek interaction
-	 */
-	private seekToPointer(event: PointerEvent): void {
-		const time = this.pointerTime(event);
-		if (time === null) {
-			return;
-		}
-		// A user drag engages the shared timeline
-		this.engageTimeline();
-		this.audio.currentTime = time;
-		this.updateProgress();
 	}
 
 	/**
@@ -965,7 +784,7 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 				!Number.isFinite(this.audio.duration) ||
 				this.audio.duration <= 0
 			) {
-				this.resolveInfiniteDuration();
+				this.durationProbe?.probe();
 			} else {
 				this.renderMarkers();
 			}
@@ -979,72 +798,14 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 			// makes the timeline live, so the #t= start hint must not
 			// reappear afterwards
 			this.engageTimeline();
-			setIcon(this.playButton, 'pause');
+			this.controls?.setPlaying(true);
 		});
 		this.registerDomEvent(this.audio, 'pause', () => {
-			setIcon(this.playButton, 'play');
+			this.controls?.setPlaying(false);
 		});
 		this.registerDomEvent(this.audio, 'ended', () => {
-			setIcon(this.playButton, 'play');
+			this.controls?.setPlaying(false);
 		});
-	}
-
-	/**
-	 * Resolves a duration the browser does not report up front - Infinity/NaN
-	 * (common for MediaRecorder WebM) or a finite 0 (some multitrack mp4 whose
-	 * container lacks a stamped length) - by probing a far seek position and
-	 * waiting for a real, positive value, then restoring the start. When the
-	 * seek yields no usable length the watchdog gives up and the bar stays
-	 * unseekable, so a truly length-less file degrades rather than hangs.
-	 */
-	private resolveInfiniteDuration(): void {
-		if (this.durationProbeActive) {
-			return;
-		}
-		this.durationProbeActive = true;
-		let watchdog = 0;
-		const finish = (): void => {
-			this.audio.removeEventListener('durationchange', onDurationChange);
-			window.clearTimeout(watchdog);
-			this.durationProbeActive = false;
-			// Restore the start position; leaving currentTime near the probe
-			// value would strand playback at the end of the file. The #t= start
-			// (if any) is shown via the display hint, not by moving the shared
-			// element here.
-			this.audio.currentTime = 0;
-			this.renderMarkers();
-			this.updateProgress();
-		};
-		const onDurationChange = (): void => {
-			// Wait for a real, positive length: a file that loaded at 0 reports a
-			// finite-but-useless 0, so finishing on "finite" alone would lock in
-			// the bogus zero instead of the corrected duration.
-			if (
-				Number.isFinite(this.audio.duration) &&
-				this.audio.duration > 0
-			) {
-				finish();
-			}
-		};
-		this.audio.addEventListener('durationchange', onDurationChange);
-		// Give up if the corrected duration never arrives, so the probe
-		// seek position is not left stranded at the end of the stream
-		watchdog = window.setTimeout(() => {
-			if (this.durationProbeActive) {
-				finish();
-			}
-		}, DURATION_PROBE_TIMEOUT_MS);
-		this.register(() => {
-			this.audio.removeEventListener('durationchange', onDurationChange);
-			window.clearTimeout(watchdog);
-		});
-		try {
-			this.audio.currentTime = DURATION_PROBE_SECONDS;
-		} catch {
-			// Some sources reject the probe seek; give up immediately and
-			// fall back to a non-seekable display
-			finish();
-		}
 	}
 
 	/**
@@ -1099,146 +860,6 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 	}
 
 	/**
-	 * Decodes the waveform lazily: a long note with several recordings must not
-	 * decode every embed up front. Waits until the player is near the viewport
-	 * (IntersectionObserver), then decodes once. Environments without
-	 * IntersectionObserver decode immediately so the waveform still appears. The
-	 * observer is torn down on re-render and on unload.
-	 */
-	private scheduleWaveformLoad(): void {
-		// typeof is safe even where IntersectionObserver is undeclared (tests,
-		// non-DOM hosts); there, decode immediately so the waveform still shows
-		if (typeof IntersectionObserver === 'undefined') {
-			void this.loadWaveform();
-			return;
-		}
-		const observer = new IntersectionObserver(
-			(entries) => {
-				if (!entries.some((entry) => entry.isIntersecting)) {
-					return;
-				}
-				// One-shot: ignore any later callback for a consumed/replaced
-				// observer, then decode once and stop observing
-				if (this.waveformObserver !== observer) {
-					return;
-				}
-				observer.disconnect();
-				this.waveformObserver = null;
-				void this.loadWaveform();
-			},
-			{ rootMargin: `${String(PLAYER_WAVEFORM_PREFETCH_MARGIN_PX)}px` },
-		);
-		this.waveformObserver = observer;
-		observer.observe(this.containerEl);
-		// Scoped to this render: a re-render or unload disconnects it, so a
-		// stale observer never decodes into a replaced player
-		this.registerRenderCleanup(() => {
-			observer.disconnect();
-			if (this.waveformObserver === observer) {
-				this.waveformObserver = null;
-			}
-		});
-	}
-
-	/**
-	 * Decodes the file and computes (or reuses cached) waveform peaks. The
-	 * peaks are computed progressively off the main thread's hot path and the
-	 * waveform is drawn as they fill in. A decode failure falls back silently
-	 * to the plain, still-seekable bar.
-	 */
-	private async loadWaveform(): Promise<void> {
-		// Cache at a fixed resolution independent of width, so resizing or
-		// switching view modes redraws from cache instead of re-decoding
-		const cacheKey = waveformCacheKey(
-			this.file.path,
-			this.file.stat.mtime,
-			this.file.stat.size,
-		);
-		const cached = this.peakCache.get(cacheKey);
-		if (cached) {
-			this.applyWaveformPeaks(cached);
-			return;
-		}
-		try {
-			const data = await this.app.vault.readBinary(this.file);
-			if (this.unloaded) {
-				return;
-			}
-			const audioBuffer = await this.decoder.decode(data);
-			if (this.unloaded) {
-				return;
-			}
-			const channels: Float32Array[] = [];
-			for (let i = 0; i < audioBuffer.numberOfChannels; i++) {
-				channels.push(audioBuffer.getChannelData(i));
-			}
-			const peaks = await computeWaveformPeaksProgressive(
-				channels,
-				WAVEFORM_CACHE_BUCKETS,
-				{
-					// Draw each partial result so the waveform fills in
-					onProgress: (snapshot) => {
-						if (!this.unloaded) {
-							this.waveform?.setPeaks(snapshot);
-						}
-					},
-					shouldAbort: () => this.unloaded,
-				},
-			);
-			if (this.unloaded) {
-				return;
-			}
-			this.peakCache.set(cacheKey, peaks);
-			this.applyWaveformPeaks(peaks);
-		} catch (error) {
-			// Leave the (still seekable) bar without a waveform; no visible
-			// error - the player keeps working
-			console.warn(
-				`${PLUGIN_LOG_PREFIX} Failed to build waveform for ${this.file.path}:`,
-				error,
-			);
-		}
-	}
-
-	/**
-	 * Hands final peaks to the waveform and ensures they are drawn once the
-	 * seek area has a measurable width.
-	 * @param peaks - Normalized peaks
-	 */
-	private applyWaveformPeaks(peaks: number[]): void {
-		if (!this.waveform || this.unloaded) {
-			return;
-		}
-		this.waveform.setPeaks(peaks);
-		this.redrawWaveformWhenSized();
-	}
-
-	/**
-	 * Draws the waveform once the seek area has a measurable width. On first
-	 * render the canvas can be laid out a frame or two after the peaks are
-	 * ready (width still 0), so a plain draw would no-op. Retry across a few
-	 * animation frames until the width settles.
-	 * @param attempts - Remaining retries before giving up
-	 */
-	private redrawWaveformWhenSized(
-		attempts = PLAYER_WAVEFORM_REDRAW_RETRIES,
-	): void {
-		if (!this.waveform || !this.waveform.hasPeaks() || this.unloaded) {
-			return;
-		}
-		if (this.seekEl.clientWidth > 0) {
-			this.waveform.redraw();
-			return;
-		}
-		if (attempts <= 0) {
-			return;
-		}
-		window.requestAnimationFrame(() => {
-			this.redrawWaveformWhenSized(attempts - 1);
-		});
-	}
-
-	/**
 	 * Updates the seek visuals and time display from the current
 	 * playback position.
 	 */
@@ -1247,9 +868,9 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 		// else the real shared position) so each embed reflects its own start
 		const position = this.currentPosition();
 		const fraction = playbackProgress(position, this.audio.duration);
-		if (this.waveform) {
+		if (this.waveformCtl.isMounted()) {
 			// Cheap: only moves the clip variable, no canvas work
-			this.waveform.setProgress(fraction);
+			this.waveformCtl.setProgress(fraction);
 		} else if (this.progressFillEl) {
 			// Set on the seek area so both the fill (width) and the thumb
 			// (left) read the same position via the inherited variable
@@ -1261,12 +882,10 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 			Number.isFinite(this.audio.duration) && this.audio.duration > 0
 				? this.audio.duration
 				: 0;
-		if (this.timeEl) {
-			// Format elapsed against the total so both sides share one width
-			this.timeEl.setText(
-				`${formatTimecode(position, total)} / ${formatTimecode(total, total)}`,
-			);
-		}
+		// Format elapsed against the total so both sides share one width
+		this.controls?.setTime(
+			`${formatTimecode(position, total)} / ${formatTimecode(total, total)}`,
+		);
 		// Keep the slider's accessible value in sync for screen readers
 		this.seekEl.setAttribute('aria-valuemax', String(Math.floor(total)));
 		this.seekEl.setAttribute('aria-valuenow', String(Math.floor(position)));
@@ -1345,9 +964,7 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 	 */
 	private setPlaybackRate(rate: number): void {
 		this.audio.playbackRate = rate;
-		if (this.speedButton) {
-			this.speedButton.setText(formatPlaybackRate(rate));
-		}
+		this.controls?.setPlaybackRate(rate);
 	}
 
 	/**
@@ -1355,83 +972,7 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 	 */
 	private toggleMute(): void {
 		this.audio.muted = !this.audio.muted;
-		this.updateMuteIcon();
-	}
-
-	/**
-	 * Reflects the current muted state on the mute button.
-	 */
-	private updateMuteIcon(): void {
-		if (this.muteButton) {
-			setIcon(
-				this.muteButton,
-				this.audio.muted ? 'volume-x' : 'volume-2',
-			);
-			this.muteButton.toggleClass('is-active', this.audio.muted);
-		}
-	}
-
-	/**
-	 * Loads persisted markers for this file and renders them.
-	 */
-	private async loadMarkers(): Promise<void> {
-		try {
-			const stored = await this.markerStore.get(this.file.path);
-			if (this.unloaded) {
-				return;
-			}
-			this.markers = stored;
-			this.renderMarkers();
-		} catch (error) {
-			console.warn(
-				`${PLUGIN_LOG_PREFIX} Failed to load markers for ${this.file.path}:`,
-				error,
-			);
-		}
-	}
-
-	/**
-	 * Adds a marker or chapter at the given time with a default label,
-	 * persists it, and re-renders. The user can rename it afterwards in
-	 * the marker list.
-	 * @param time - Offset in seconds
-	 * @param kind - Whether to add a bookmark or a chapter
-	 */
-	private async addMarkerAt(time: number, kind: MarkerKind): Promise<void> {
-		const safeTime = Math.max(0, time);
-		const label = defaultMarkerLabel(this.markers, kind);
-		this.markers = addMarker(this.markers, {
-			id: generateMarkerId(),
-			time: safeTime,
-			label,
-			kind,
-		});
-		this.renderMarkers();
-		await this.persistMarkers();
-		new Notice(`${label} added at ${formatTimecode(safeTime)}`);
-	}
-
-	/**
-	 * Removes a marker by id, persists, and re-renders.
-	 * @param id - Marker identifier
-	 */
-	private async deleteMarker(id: string): Promise<void> {
-		this.markers = removeMarker(this.markers, id);
-		this.renderMarkers();
-		await this.persistMarkers();
-	}
-
-	/**
-	 * Renames a marker, persists, and refreshes the ticks. The list is not
-	 * rebuilt so the input the user is typing in keeps focus.
-	 * @param id - Marker identifier
-	 * @param label - New label
-	 */
-	private async renameMarker(id: string, label: string): Promise<void> {
-		this.markers = updateMarker(this.markers, id, { label });
-		this.markerView?.setMarkers(this.markers);
-		this.markerView?.refreshTicks(this.knownDuration());
-		await this.persistMarkers();
+		this.controls?.setMuted(this.audio.muted);
 	}
 
 	/**
@@ -1439,10 +980,7 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 	 * preserving the play/pause state.
 	 */
 	private jumpToNextChapter(): void {
-		const target = nextChapterTime(
-			chapters(this.markers),
-			this.audio.currentTime,
-		);
+		const target = this.markerCtl.nextChapter(this.audio.currentTime);
 		if (target !== null) {
 			this.seekTo(target, false);
 		}
@@ -1453,28 +991,8 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 	 * one shortly after its boundary), preserving the play/pause state.
 	 */
 	private jumpToPreviousChapter(): void {
-		const target = previousChapterTime(
-			chapters(this.markers),
-			this.audio.currentTime,
-		);
+		const target = this.markerCtl.previousChapter(this.audio.currentTime);
 		this.seekTo(target ?? 0, false);
-	}
-
-	/**
-	 * Persists the current markers for this file.
-	 */
-	private async persistMarkers(): Promise<void> {
-		try {
-			await this.markerStore.set(this.file.path, this.markers);
-			// Refresh other live players of this file (e.g. the reading-view
-			// copy) so the change shows everywhere without re-opening
-			this.registry.reloadMarkers(this.file.path, this);
-		} catch (error) {
-			console.warn(
-				`${PLUGIN_LOG_PREFIX} Failed to save markers for ${this.file.path}:`,
-				error,
-			);
-		}
 	}
 
 	/**
@@ -1485,7 +1003,7 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 		if (!this.settings.enableMarkers) {
 			return;
 		}
-		this.markerView?.setMarkers(this.markers);
+		this.markerView?.setMarkers(this.markerCtl.all);
 		this.markerView?.render(this.knownDuration(), this.audio.currentTime);
 	}
 
@@ -1523,29 +1041,6 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 			);
 			new Notice('Could not copy timestamp link to the clipboard.');
 		}
-	}
-
-	/**
-	 * Creates an icon button in a container and wires its click handler.
-	 * @param container - Parent element
-	 * @param icon - Obsidian icon id
-	 * @param label - Accessible label / tooltip
-	 * @param onClick - Click handler
-	 * @returns The created button element
-	 */
-	private createIconButton(
-		container: HTMLElement,
-		icon: string,
-		label: string,
-		onClick: () => void,
-	): HTMLElement {
-		const button = container.createEl('button', {
-			cls: 'aar-player-btn',
-			attr: { 'aria-label': label },
-		});
-		setIcon(button, icon);
-		this.registerRenderDomEvent(button, 'click', onClick);
-		return button;
 	}
 
 	/**
@@ -1590,16 +1085,10 @@ export class AudioPlayer extends MarkdownRenderChild implements SeekablePlayer {
 	}
 
 	/**
-	 * Whether the waveform should be drawn for this file. It is shown for files
-	 * up to a high safety ceiling; a pathological multi-gigabyte file falls back
-	 * to the plain (still seekable) bar instead, because decoding it for a
-	 * cosmetic waveform would risk an out-of-memory spike. Realistic recordings
-	 * stay well under the ceiling and are still drawn progressively.
+	 * Whether the waveform should be drawn for this file (window toggle on
+	 * and the file below the decode safety ceiling).
 	 */
 	private shouldShowWaveform(): boolean {
-		return (
-			this.settings.showWaveform &&
-			this.file.stat.size <= WAVEFORM_MAX_DECODE_BYTES
-		);
+		return this.waveformCtl.shouldRender(this.settings.showWaveform);
 	}
 }

--- a/src/player/AudioPlayerRegistry.ts
+++ b/src/player/AudioPlayerRegistry.ts
@@ -139,7 +139,10 @@ export class AudioPlayerRegistry {
 		if (!entry) {
 			return;
 		}
-		entry.refs -= 1;
+		// Clamp at zero so a double release (a defensive caller running its
+		// cleanup twice) cannot push the count negative and make the next
+		// acquire/release pairing skip the actual teardown.
+		entry.refs = Math.max(0, entry.refs - 1);
 		if (entry.refs > 0) {
 			return;
 		}

--- a/src/player/DurationProbe.ts
+++ b/src/player/DurationProbe.ts
@@ -1,0 +1,111 @@
+/**
+ * Resolves an initially-unknown media duration on the shared audio element.
+ * Some sources load with no usable length - Infinity/NaN (common for
+ * MediaRecorder WebM) or a finite 0 (some multitrack mp4 whose container
+ * never got its real length stamped) - and need a probe seek to coax the
+ * browser into computing the true duration.
+ * @module player/DurationProbe
+ */
+
+/**
+ * A very large finite time used to coax browsers into computing the
+ * real duration of a stream (notably MediaRecorder WebM) that initially
+ * reports Infinity. Seeking near the end triggers a durationchange with
+ * the true value, after which playback is reset to the start.
+ */
+const DURATION_PROBE_SECONDS = 1e101;
+
+/**
+ * How long to wait for a probed stream to report its real duration
+ * before giving up, so playback is not left stranded at the probe seek
+ * position when the corrected duration never arrives.
+ */
+const DURATION_PROBE_TIMEOUT_MS = 5000;
+
+/**
+ * Probes the shared audio element for its real duration. One instance per
+ * player; re-probing while a probe is active is a no-op.
+ */
+export class DurationProbe {
+	private active = false;
+	/** Detaches the in-flight probe's listener and watchdog, if any. */
+	private detach: (() => void) | null = null;
+
+	/**
+	 * @param audio - The shared audio element to probe
+	 * @param onResolved - Called after every probe ends (resolved or given
+	 *   up), with playback restored to the start, so the caller can refresh
+	 *   its markers and progress display
+	 */
+	constructor(
+		private readonly audio: HTMLAudioElement,
+		private readonly onResolved: () => void,
+	) {}
+
+	/**
+	 * Resolves a duration the browser does not report up front by probing a
+	 * far seek position and waiting for a real, positive value, then
+	 * restoring the start. When the seek yields no usable length the
+	 * watchdog gives up and the bar stays unseekable, so a truly
+	 * length-less file degrades rather than hangs.
+	 */
+	probe(): void {
+		if (this.active) {
+			return;
+		}
+		this.active = true;
+		let watchdog = 0;
+		const finish = (): void => {
+			this.audio.removeEventListener('durationchange', onDurationChange);
+			window.clearTimeout(watchdog);
+			this.active = false;
+			this.detach = null;
+			// Restore the start position; leaving currentTime near the probe
+			// value would strand playback at the end of the file. The #t= start
+			// (if any) is shown via the display hint, not by moving the shared
+			// element here.
+			this.audio.currentTime = 0;
+			this.onResolved();
+		};
+		const onDurationChange = (): void => {
+			// Wait for a real, positive length: a file that loaded at 0 reports a
+			// finite-but-useless 0, so finishing on "finite" alone would lock in
+			// the bogus zero instead of the corrected duration.
+			if (
+				Number.isFinite(this.audio.duration) &&
+				this.audio.duration > 0
+			) {
+				finish();
+			}
+		};
+		this.audio.addEventListener('durationchange', onDurationChange);
+		// Give up if the corrected duration never arrives, so the probe
+		// seek position is not left stranded at the end of the stream
+		watchdog = window.setTimeout(() => {
+			if (this.active) {
+				finish();
+			}
+		}, DURATION_PROBE_TIMEOUT_MS);
+		this.detach = () => {
+			this.audio.removeEventListener('durationchange', onDurationChange);
+			window.clearTimeout(watchdog);
+		};
+		try {
+			this.audio.currentTime = DURATION_PROBE_SECONDS;
+		} catch {
+			// Some sources reject the probe seek; give up immediately and
+			// fall back to a non-seekable display
+			finish();
+		}
+	}
+
+	/**
+	 * Cancels an in-flight probe without touching playback. Called on
+	 * player unload so the listener and watchdog never outlive the player.
+	 */
+	cancel(): void {
+		this.detach?.();
+		this.detach = null;
+		this.active = false;
+	}
+}

--- a/src/player/EnhancedPlayerRegistrar.ts
+++ b/src/player/EnhancedPlayerRegistrar.ts
@@ -253,8 +253,8 @@ export class EnhancedPlayerRegistrar {
 			return;
 		}
 		for (const audioPath of audioPaths) {
-			const file = this.app.vault.getAbstractFileByPath(audioPath);
-			if (!(file instanceof TFile) || !isAudioFile(file)) {
+			const file = this.app.vault.getFileByPath(audioPath);
+			if (!file || !isAudioFile(file)) {
 				continue;
 			}
 			void this.probeKind(file);

--- a/src/player/EnhancedPlayerRegistrar.ts
+++ b/src/player/EnhancedPlayerRegistrar.ts
@@ -37,7 +37,7 @@ import type {
 	WorkspaceLeaf,
 } from 'obsidian';
 import { AUDIO_EXTENSIONS, PLUGIN_LOG_PREFIX } from '../constants';
-import { type AudioRecorderSettings } from '../settings/Settings';
+import type { AudioRecorderSettings } from '../settings/settingsSchema';
 import {
 	resolvePlayerSettings,
 	playerSettingsEqual,

--- a/src/player/PlayerMarkerController.ts
+++ b/src/player/PlayerMarkerController.ts
@@ -1,0 +1,161 @@
+/**
+ * Marker CRUD for one player: the authoritative marker list for the file,
+ * its persistence to the sidecar store, and chapter navigation lookups.
+ * How markers are displayed (ticks, list, active highlight) stays with the
+ * player and its MarkerListView.
+ * @module player/PlayerMarkerController
+ */
+
+import { Notice } from 'obsidian';
+import { PLUGIN_LOG_PREFIX } from '../constants';
+import { formatTimecode } from '../utils/TimeUtils';
+import type { MarkerStore } from '../markers/MarkerStore';
+import {
+	addMarker,
+	chapters,
+	nextChapterTime,
+	previousChapterTime,
+	removeMarker,
+	updateMarker,
+	type MarkerKind,
+	type PlayerMarker,
+} from '../markers/markerModel';
+import { defaultMarkerLabel, generateMarkerId } from '../markers/markerFactory';
+
+/** Lifecycle and display hooks the controller needs from the player. */
+export interface PlayerMarkerHost {
+	/** True once the player is torn down; async work must stop. */
+	isUnloaded(): boolean;
+	/** Re-renders the marker ticks and list from the current data. */
+	renderMarkers(): void;
+	/**
+	 * Refreshes the ticks only, leaving the list untouched so the input
+	 * the user is typing in keeps focus (the rename path).
+	 */
+	refreshTicks(): void;
+	/**
+	 * Refreshes other live players of this file (e.g. the reading-view
+	 * copy) so a change shows everywhere without re-opening.
+	 */
+	notifyOthers(): void;
+}
+
+/**
+ * Owns the marker data and persistence for one player.
+ */
+export class PlayerMarkerController {
+	/** Authoritative marker list for this file; the view renders from it. */
+	private markers: PlayerMarker[] = [];
+
+	constructor(
+		private readonly markerStore: MarkerStore,
+		private readonly filePath: string,
+		private readonly host: PlayerMarkerHost,
+	) {}
+
+	/** The current markers (rendered by the player's view). */
+	get all(): PlayerMarker[] {
+		return this.markers;
+	}
+
+	/** Drops the in-memory markers (markers window disabled). */
+	clear(): void {
+		this.markers = [];
+	}
+
+	/**
+	 * Loads persisted markers for this file and renders them.
+	 */
+	async load(): Promise<void> {
+		try {
+			const stored = await this.markerStore.get(this.filePath);
+			if (this.host.isUnloaded()) {
+				return;
+			}
+			this.markers = stored;
+			this.host.renderMarkers();
+		} catch (error) {
+			console.warn(
+				`${PLUGIN_LOG_PREFIX} Failed to load markers for ${this.filePath}:`,
+				error,
+			);
+		}
+	}
+
+	/**
+	 * Adds a marker or chapter at the given time with a default label,
+	 * persists it, and re-renders. The user can rename it afterwards in
+	 * the marker list.
+	 * @param time - Offset in seconds
+	 * @param kind - Whether to add a bookmark or a chapter
+	 */
+	async addAt(time: number, kind: MarkerKind): Promise<void> {
+		const safeTime = Math.max(0, time);
+		const label = defaultMarkerLabel(this.markers, kind);
+		this.markers = addMarker(this.markers, {
+			id: generateMarkerId(),
+			time: safeTime,
+			label,
+			kind,
+		});
+		this.host.renderMarkers();
+		await this.persist();
+		new Notice(`${label} added at ${formatTimecode(safeTime)}`);
+	}
+
+	/**
+	 * Removes a marker by id, persists, and re-renders.
+	 * @param id - Marker identifier
+	 */
+	async remove(id: string): Promise<void> {
+		this.markers = removeMarker(this.markers, id);
+		this.host.renderMarkers();
+		await this.persist();
+	}
+
+	/**
+	 * Renames a marker, persists, and refreshes the ticks. The list is not
+	 * rebuilt so the input the user is typing in keeps focus.
+	 * @param id - Marker identifier
+	 * @param label - New label
+	 */
+	async rename(id: string, label: string): Promise<void> {
+		this.markers = updateMarker(this.markers, id, { label });
+		this.host.refreshTicks();
+		await this.persist();
+	}
+
+	/**
+	 * The next chapter boundary after the given position, or null.
+	 * @param currentTime - Current playback position in seconds
+	 */
+	nextChapter(currentTime: number): number | null {
+		return nextChapterTime(chapters(this.markers), currentTime);
+	}
+
+	/**
+	 * The previous chapter boundary before the given position (or the
+	 * start of the current one shortly after its boundary), or null.
+	 * @param currentTime - Current playback position in seconds
+	 */
+	previousChapter(currentTime: number): number | null {
+		return previousChapterTime(chapters(this.markers), currentTime);
+	}
+
+	/**
+	 * Persists the current markers for this file.
+	 */
+	private async persist(): Promise<void> {
+		try {
+			await this.markerStore.set(this.filePath, this.markers);
+			// Refresh other live players of this file (e.g. the reading-view
+			// copy) so the change shows everywhere without re-opening
+			this.host.notifyOthers();
+		} catch (error) {
+			console.warn(
+				`${PLUGIN_LOG_PREFIX} Failed to save markers for ${this.filePath}:`,
+				error,
+			);
+		}
+	}
+}

--- a/src/player/SeekController.ts
+++ b/src/player/SeekController.ts
@@ -1,0 +1,167 @@
+/**
+ * Pointer and keyboard seeking on the player's seek area, plus the
+ * client-X-to-time mapping shared with the marker overlay and the
+ * context-menu actions. Owns only the interaction; what a seek does to
+ * the shared audio element stays with the player.
+ * @module player/SeekController
+ */
+
+import { PLAYER_SEEK_KEYBOARD_STEP_SECONDS } from '../constants';
+
+/** Render-scoped listener registration provided by the player. */
+export interface SeekHost {
+	/** Adds a DOM listener torn down with the current render pass. */
+	registerDomEvent<K extends keyof HTMLElementEventMap>(
+		el: HTMLElement,
+		type: K,
+		handler: (event: HTMLElementEventMap[K]) => void,
+	): void;
+}
+
+/** What the seek interactions do to playback (owned by the player). */
+export interface SeekCallbacks {
+	/**
+	 * Engages the shared timeline and moves playback to an absolute
+	 * offset (pointer drag/click, Home, End).
+	 */
+	onSeekToTime(seconds: number): void;
+	/** Relative skip (arrow keys), engaging the #t= start first. */
+	onSkip(deltaSeconds: number): void;
+	/**
+	 * Consumes the #t= start hint without moving playback. Used by End
+	 * when the duration is unknown, matching a seek that cannot land.
+	 */
+	onEngageTimeline(): void;
+	/** Current duration of the shared audio (may be Infinity/NaN). */
+	duration(): number;
+}
+
+/**
+ * Wires click/drag and keyboard seeking on the seek area.
+ */
+export class SeekController {
+	private seekEl: HTMLElement | null = null;
+	private isSeeking = false;
+
+	constructor(
+		private readonly host: SeekHost,
+		private readonly callbacks: SeekCallbacks,
+	) {}
+
+	/**
+	 * Attaches the pointer and keyboard handlers to a (re)built seek area.
+	 * The listeners are render-scoped: a re-render tears them down with the
+	 * rest of the pass, so attach is called once per render.
+	 * @param seekEl - The seek area element for the current render
+	 */
+	attach(seekEl: HTMLElement): void {
+		this.seekEl = seekEl;
+		this.isSeeking = false;
+		this.registerPointer(seekEl);
+		this.registerKeyboard(seekEl);
+	}
+
+	/**
+	 * Converts a client X coordinate to a playback offset along the seek
+	 * area, or null when the duration is unknown or the area has no width.
+	 * @param clientX - Horizontal viewport coordinate
+	 */
+	timeAtClientX(clientX: number): number | null {
+		const duration = this.callbacks.duration();
+		if (!Number.isFinite(duration) || duration <= 0) {
+			return null;
+		}
+		if (!this.seekEl) {
+			return null;
+		}
+		const rect = this.seekEl.getBoundingClientRect();
+		if (rect.width === 0) {
+			return null;
+		}
+		const fraction = Math.min(
+			1,
+			Math.max(0, (clientX - rect.left) / rect.width),
+		);
+		return fraction * duration;
+	}
+
+	/**
+	 * Wires pointer events for click/drag seeking on the seek area. The
+	 * seek area captures the pointer on press so a drag that leaves it
+	 * still tracks, without a document-wide listener per player instance.
+	 */
+	private registerPointer(seekEl: HTMLElement): void {
+		this.host.registerDomEvent(seekEl, 'pointerdown', (event) => {
+			// Ignore non-primary buttons so a right-click opens the
+			// context menu instead of seeking
+			if (event.button !== 0) {
+				return;
+			}
+			this.isSeeking = true;
+			// Route subsequent pointer events to the seek area even when
+			// the cursor leaves it during the drag
+			seekEl.setPointerCapture(event.pointerId);
+			this.seekToPointer(event);
+		});
+		this.host.registerDomEvent(seekEl, 'pointermove', (event) => {
+			if (this.isSeeking) {
+				this.seekToPointer(event);
+			}
+		});
+		this.host.registerDomEvent(seekEl, 'pointerup', (event) => {
+			this.isSeeking = false;
+			if (seekEl.hasPointerCapture(event.pointerId)) {
+				seekEl.releasePointerCapture(event.pointerId);
+			}
+		});
+		this.host.registerDomEvent(seekEl, 'pointercancel', () => {
+			this.isSeeking = false;
+		});
+	}
+
+	/**
+	 * Wires keyboard seeking on the slider-role seek area: arrow keys
+	 * nudge by a few seconds, Home/End jump to the bounds.
+	 */
+	private registerKeyboard(seekEl: HTMLElement): void {
+		this.host.registerDomEvent(seekEl, 'keydown', (event) => {
+			switch (event.key) {
+				case 'ArrowRight':
+				case 'ArrowUp':
+					this.callbacks.onSkip(PLAYER_SEEK_KEYBOARD_STEP_SECONDS);
+					break;
+				case 'ArrowLeft':
+				case 'ArrowDown':
+					this.callbacks.onSkip(-PLAYER_SEEK_KEYBOARD_STEP_SECONDS);
+					break;
+				case 'Home':
+					this.callbacks.onSeekToTime(0);
+					break;
+				case 'End': {
+					const duration = this.callbacks.duration();
+					if (Number.isFinite(duration)) {
+						this.callbacks.onSeekToTime(duration);
+					} else {
+						this.callbacks.onEngageTimeline();
+					}
+					break;
+				}
+				default:
+					return;
+			}
+			event.preventDefault();
+		});
+	}
+
+	/**
+	 * Seeks to the position under the pointer along the seek area.
+	 * @param event - Pointer event from the seek interaction
+	 */
+	private seekToPointer(event: PointerEvent): void {
+		const time = this.timeAtClientX(event.clientX);
+		if (time === null) {
+			return;
+		}
+		this.callbacks.onSeekToTime(time);
+	}
+}

--- a/src/player/WaveformController.ts
+++ b/src/player/WaveformController.ts
@@ -1,0 +1,247 @@
+/**
+ * Progressive waveform decode and rendering for one player: decides when
+ * the waveform applies, defers the decode until the player is near the
+ * viewport, computes (or reuses cached) peaks, and drives the canvas as
+ * they fill in. The seek area itself and what seeking does stay with the
+ * player.
+ * @module player/WaveformController
+ */
+
+import type { App, TFile } from 'obsidian';
+import {
+	PLUGIN_LOG_PREFIX,
+	WAVEFORM_CACHE_BUCKETS,
+	WAVEFORM_MAX_DECODE_BYTES,
+	PLAYER_WAVEFORM_REDRAW_RETRIES,
+	PLAYER_WAVEFORM_PREFETCH_MARGIN_PX,
+} from '../constants';
+import {
+	computeWaveformPeaksProgressive,
+	waveformCacheKey,
+	WaveformPeakCache,
+	type AudioDecoder,
+} from './WaveformData';
+import { WaveformCanvas } from './views/WaveformCanvas';
+
+/** Lifecycle hooks the controller needs from the player. */
+export interface WaveformHost {
+	/** Registers a cleanup tied to the current render pass. */
+	registerRenderCleanup(cleanup: () => void): void;
+	/** True once the player is torn down; async work must stop. */
+	isUnloaded(): boolean;
+}
+
+/**
+ * Owns the waveform canvas and its decode pipeline for one player.
+ */
+export class WaveformController {
+	/** Waveform renderer, or null when the plain bar is shown. */
+	private canvas: WaveformCanvas | null = null;
+	/** Observer that defers the waveform decode until the player is on screen. */
+	private observer: IntersectionObserver | null = null;
+	/** The seek area hosting the canvas for the current render. */
+	private seekEl: HTMLElement | null = null;
+
+	constructor(
+		private readonly app: App,
+		private readonly file: TFile,
+		private readonly decoder: AudioDecoder,
+		private readonly peakCache: WaveformPeakCache,
+		private readonly host: WaveformHost,
+	) {}
+
+	/**
+	 * Whether the waveform should be drawn for this file. It is shown for files
+	 * up to a high safety ceiling; a pathological multi-gigabyte file falls back
+	 * to the plain (still seekable) bar instead, because decoding it for a
+	 * cosmetic waveform would risk an out-of-memory spike. Realistic recordings
+	 * stay well under the ceiling and are still drawn progressively.
+	 * @param showWaveform - The waveform window toggle from settings
+	 */
+	shouldRender(showWaveform: boolean): boolean {
+		return showWaveform && this.file.stat.size <= WAVEFORM_MAX_DECODE_BYTES;
+	}
+
+	/**
+	 * Drops the canvas and seek-area refs at the start of a render pass.
+	 * Without this, toggling the waveform off would leave a stale renderer
+	 * so progress updates would target the dead canvas and never update the
+	 * new progress bar. The observers themselves are torn down by the
+	 * render-scoped cleanups.
+	 */
+	reset(): void {
+		this.canvas = null;
+		this.seekEl = null;
+	}
+
+	/**
+	 * Creates the canvas inside the seek area and keeps it redrawn on
+	 * resize (re-reading theme colors in case the theme changed).
+	 * @param seekEl - The seek area element for the current render
+	 */
+	mount(seekEl: HTMLElement): void {
+		this.seekEl = seekEl;
+		this.canvas = new WaveformCanvas(seekEl);
+		const resizeObserver = new ResizeObserver(() => {
+			// Re-read theme colors in case the theme changed, then redraw
+			this.canvas?.invalidateColors();
+			this.canvas?.redraw();
+		});
+		resizeObserver.observe(seekEl);
+		this.host.registerRenderCleanup(() => {
+			resizeObserver.disconnect();
+		});
+	}
+
+	/** Whether the waveform canvas is mounted for the current render. */
+	isMounted(): boolean {
+		return this.canvas !== null;
+	}
+
+	/**
+	 * Moves the played-portion clip on the canvas (cheap; no canvas work).
+	 * @param fraction - Playback progress in [0, 1]
+	 */
+	setProgress(fraction: number): void {
+		this.canvas?.setProgress(fraction);
+	}
+
+	/**
+	 * Decodes the waveform lazily: a long note with several recordings must not
+	 * decode every embed up front. Waits until the player is near the viewport
+	 * (IntersectionObserver), then decodes once. Environments without
+	 * IntersectionObserver decode immediately so the waveform still appears. The
+	 * observer is torn down on re-render and on unload.
+	 * @param observeEl - The player container to watch for visibility
+	 */
+	scheduleLoad(observeEl: HTMLElement): void {
+		// typeof is safe even where IntersectionObserver is undeclared (tests,
+		// non-DOM hosts); there, decode immediately so the waveform still shows
+		if (typeof IntersectionObserver === 'undefined') {
+			void this.load();
+			return;
+		}
+		const observer = new IntersectionObserver(
+			(entries) => {
+				if (!entries.some((entry) => entry.isIntersecting)) {
+					return;
+				}
+				// One-shot: ignore any later callback for a consumed/replaced
+				// observer, then decode once and stop observing
+				if (this.observer !== observer) {
+					return;
+				}
+				observer.disconnect();
+				this.observer = null;
+				void this.load();
+			},
+			{ rootMargin: `${String(PLAYER_WAVEFORM_PREFETCH_MARGIN_PX)}px` },
+		);
+		this.observer = observer;
+		observer.observe(observeEl);
+		// Scoped to this render: a re-render or unload disconnects it, so a
+		// stale observer never decodes into a replaced player
+		this.host.registerRenderCleanup(() => {
+			observer.disconnect();
+			if (this.observer === observer) {
+				this.observer = null;
+			}
+		});
+	}
+
+	/**
+	 * Decodes the file and computes (or reuses cached) waveform peaks. The
+	 * peaks are computed progressively off the main thread's hot path and the
+	 * waveform is drawn as they fill in. A decode failure falls back silently
+	 * to the plain, still-seekable bar.
+	 */
+	private async load(): Promise<void> {
+		// Cache at a fixed resolution independent of width, so resizing or
+		// switching view modes redraws from cache instead of re-decoding
+		const cacheKey = waveformCacheKey(
+			this.file.path,
+			this.file.stat.mtime,
+			this.file.stat.size,
+		);
+		const cached = this.peakCache.get(cacheKey);
+		if (cached) {
+			this.applyPeaks(cached);
+			return;
+		}
+		try {
+			const data = await this.app.vault.readBinary(this.file);
+			if (this.host.isUnloaded()) {
+				return;
+			}
+			const audioBuffer = await this.decoder.decode(data);
+			if (this.host.isUnloaded()) {
+				return;
+			}
+			const channels: Float32Array[] = [];
+			for (let i = 0; i < audioBuffer.numberOfChannels; i++) {
+				channels.push(audioBuffer.getChannelData(i));
+			}
+			const peaks = await computeWaveformPeaksProgressive(
+				channels,
+				WAVEFORM_CACHE_BUCKETS,
+				{
+					// Draw each partial result so the waveform fills in
+					onProgress: (snapshot) => {
+						if (!this.host.isUnloaded()) {
+							this.canvas?.setPeaks(snapshot);
+						}
+					},
+					shouldAbort: () => this.host.isUnloaded(),
+				},
+			);
+			if (this.host.isUnloaded()) {
+				return;
+			}
+			this.peakCache.set(cacheKey, peaks);
+			this.applyPeaks(peaks);
+		} catch (error) {
+			// Leave the (still seekable) bar without a waveform; no visible
+			// error - the player keeps working
+			console.warn(
+				`${PLUGIN_LOG_PREFIX} Failed to build waveform for ${this.file.path}:`,
+				error,
+			);
+		}
+	}
+
+	/**
+	 * Hands final peaks to the waveform and ensures they are drawn once the
+	 * seek area has a measurable width.
+	 * @param peaks - Normalized peaks
+	 */
+	private applyPeaks(peaks: number[]): void {
+		if (!this.canvas || this.host.isUnloaded()) {
+			return;
+		}
+		this.canvas.setPeaks(peaks);
+		this.redrawWhenSized();
+	}
+
+	/**
+	 * Draws the waveform once the seek area has a measurable width. On first
+	 * render the canvas can be laid out a frame or two after the peaks are
+	 * ready (width still 0), so a plain draw would no-op. Retry across a few
+	 * animation frames until the width settles.
+	 * @param attempts - Remaining retries before giving up
+	 */
+	private redrawWhenSized(attempts = PLAYER_WAVEFORM_REDRAW_RETRIES): void {
+		if (!this.canvas || !this.canvas.hasPeaks() || this.host.isUnloaded()) {
+			return;
+		}
+		if (this.seekEl && this.seekEl.clientWidth > 0) {
+			this.canvas.redraw();
+			return;
+		}
+		if (attempts <= 0) {
+			return;
+		}
+		window.requestAnimationFrame(() => {
+			this.redrawWhenSized(attempts - 1);
+		});
+	}
+}

--- a/src/player/WaveformController.ts
+++ b/src/player/WaveformController.ts
@@ -240,8 +240,13 @@ export class WaveformController {
 		if (attempts <= 0) {
 			return;
 		}
-		window.requestAnimationFrame(() => {
+		const rafId = window.requestAnimationFrame(() => {
 			this.redrawWhenSized(attempts - 1);
+		});
+		// Cancel outright on re-render/unload instead of relying on the
+		// unloaded flag alone to fizzle the retry chain.
+		this.host.registerRenderCleanup(() => {
+			window.cancelAnimationFrame(rafId);
 		});
 	}
 }

--- a/src/player/WaveformData.ts
+++ b/src/player/WaveformData.ts
@@ -57,10 +57,11 @@ export async function computeWaveformPeaksProgressive(
 		options.chunkBuckets ?? WAVEFORM_PROGRESSIVE_CHUNK_BUCKETS;
 	const yieldControl = options.yieldControl ?? defaultYield;
 
-	if (bucketCount <= 0 || channels.length === 0) {
+	const firstChannel = channels[0];
+	if (bucketCount <= 0 || !firstChannel) {
 		return [];
 	}
-	const frameCount = channels[0].length;
+	const frameCount = firstChannel.length;
 	if (frameCount === 0) {
 		return new Array<number>(bucketCount).fill(0);
 	}
@@ -131,7 +132,7 @@ function bucketPeak(
 	for (let frame = start; frame < end; frame++) {
 		let mixed = 0;
 		for (let channel = 0; channel < channelCount; channel++) {
-			mixed += channels[channel][frame];
+			mixed += channels[channel]?.[frame] ?? 0;
 		}
 		const amplitude = Math.abs(mixed / channelCount);
 		if (amplitude > maxAmplitude) {
@@ -148,7 +149,7 @@ function bucketPeak(
 function normalizePeaks(peaks: number[], max: number): number[] {
 	if (max > 0) {
 		for (let i = 0; i < peaks.length; i++) {
-			peaks[i] /= max;
+			peaks[i] = (peaks[i] ?? 0) / max;
 		}
 	}
 	return peaks;
@@ -207,8 +208,9 @@ export function downsamplePeaks(peaks: number[], target: number): number[] {
 			i === target - 1 ? peaks.length : Math.floor((i + 1) * perBucket);
 		let max = 0;
 		for (let j = start; j < end; j++) {
-			if (peaks[j] > max) {
-				max = peaks[j];
+			const peak = peaks[j] ?? 0;
+			if (peak > max) {
+				max = peak;
 			}
 		}
 		result[i] = max;

--- a/src/player/playerSettings.ts
+++ b/src/player/playerSettings.ts
@@ -5,7 +5,7 @@
  * @module player/playerSettings
  */
 
-import type { AudioRecorderSettings } from '../settings/Settings';
+import type { AudioRecorderSettings } from '../settings/settingsSchema';
 
 /**
  * Render-ready view of the enhanced player's two user-toggleable windows.

--- a/src/player/views/PlayerControlsView.ts
+++ b/src/player/views/PlayerControlsView.ts
@@ -1,0 +1,264 @@
+/**
+ * The enhanced player's control row: play/pause, skip, speed, mute,
+ * volume, loop, optional marker/chapter buttons, the time display, and
+ * the copy-timestamp action. Pure DOM: state changes are reported through
+ * callbacks and reflected back via the set* methods, so the player keeps
+ * ownership of the shared audio element.
+ * @module player/views/PlayerControlsView
+ */
+
+import { setIcon } from 'obsidian';
+import { PLAYER_SKIP_SECONDS } from '../../constants';
+import { MARKER_KIND, type MarkerKind } from '../../markers/markerModel';
+import { formatPlaybackRate } from '../playbackRate';
+
+/**
+ * Snapshot of the shared audio's state at mount time, so a player
+ * re-rendered while playback is already running (e.g. after a mode
+ * switch) reflects the live state instead of the defaults.
+ */
+export interface PlayerControlsState {
+	paused: boolean;
+	playbackRate: number;
+	volume: number;
+	muted: boolean;
+	loop: boolean;
+	/** Render the marker/chapter buttons. */
+	markersEnabled: boolean;
+}
+
+/** What each control does (owned by the player). */
+export interface PlayerControlsCallbacks {
+	onTogglePlay(): void;
+	onSkip(deltaSeconds: number): void;
+	onSpeedMenu(event: MouseEvent): void;
+	onToggleMute(): void;
+	/** The volume slider moved; the player applies it to the audio. */
+	onVolumeInput(volume: number): void;
+	/** Toggles looping; returns the new loop state for the button. */
+	onToggleLoop(): boolean;
+	onAddMarker(kind: MarkerKind): void;
+	onPreviousChapter(): void;
+	onNextChapter(): void;
+	onCopyTimestampLink(): void;
+}
+
+/** Render-scoped listener registration provided by the player. */
+export interface PlayerControlsHost {
+	/** Adds a DOM listener torn down with the current render pass. */
+	registerDomEvent<K extends keyof HTMLElementEventMap>(
+		el: HTMLElement,
+		type: K,
+		handler: (event: HTMLElementEventMap[K]) => void,
+	): void;
+}
+
+/**
+ * Builds and updates the control row. One instance per render pass; the
+ * DOM it owns is recreated by the player's containerEl.empty().
+ */
+export class PlayerControlsView {
+	private playButton: HTMLElement | null = null;
+	private speedButton: HTMLElement | null = null;
+	private muteButton: HTMLElement | null = null;
+	private timeEl: HTMLElement | null = null;
+
+	constructor(
+		private readonly host: PlayerControlsHost,
+		private readonly callbacks: PlayerControlsCallbacks,
+	) {}
+
+	/**
+	 * Builds the control row into the container. Every control is fixed;
+	 * only the marker controls depend on the markers window being enabled.
+	 * @param container - The player's container element
+	 * @param state - Live audio state to reflect on the controls
+	 */
+	mount(container: HTMLElement, state: PlayerControlsState): void {
+		const controls = container.createDiv({
+			cls: 'aar-player-controls',
+		});
+
+		this.playButton = this.createIconButton(
+			controls,
+			// Reflect the shared audio's current state, so a player rendered
+			// while playback is already running (e.g. after a mode switch)
+			// shows the pause icon rather than a stale play icon
+			state.paused ? 'play' : 'pause',
+			'Play / pause',
+			() => {
+				this.callbacks.onTogglePlay();
+			},
+		);
+
+		this.createIconButton(
+			controls,
+			'rewind',
+			`Back ${String(PLAYER_SKIP_SECONDS)}s`,
+			() => {
+				this.callbacks.onSkip(-PLAYER_SKIP_SECONDS);
+			},
+		);
+		this.createIconButton(
+			controls,
+			'fast-forward',
+			`Forward ${String(PLAYER_SKIP_SECONDS)}s`,
+			() => {
+				this.callbacks.onSkip(PLAYER_SKIP_SECONDS);
+			},
+		);
+
+		this.speedButton = controls.createEl('button', {
+			cls: 'aar-player-btn aar-player-speed',
+			// Reflect the shared audio's current rate, not the default, so a
+			// re-render after a mode switch keeps showing the chosen speed
+			text: formatPlaybackRate(state.playbackRate),
+		});
+		this.speedButton.setAttribute('aria-label', 'Playback speed');
+		this.host.registerDomEvent(this.speedButton, 'click', (event) => {
+			this.callbacks.onSpeedMenu(event);
+		});
+
+		this.muteButton = this.createIconButton(
+			controls,
+			'volume-2',
+			'Mute / unmute',
+			() => {
+				this.callbacks.onToggleMute();
+			},
+		);
+		this.setMuted(state.muted);
+
+		const volume = controls.createEl('input', {
+			cls: 'aar-player-volume',
+			attr: {
+				type: 'range',
+				min: '0',
+				max: '1',
+				step: '0.05',
+				// Reflect the shared audio's current volume on re-render
+				value: String(state.volume),
+				'aria-label': 'Volume',
+			},
+		});
+		this.host.registerDomEvent(volume, 'input', () => {
+			this.callbacks.onVolumeInput(Number(volume.value));
+		});
+
+		const loopButton = this.createIconButton(
+			controls,
+			'repeat',
+			'Loop',
+			() => {
+				loopButton.toggleClass(
+					'is-active',
+					this.callbacks.onToggleLoop(),
+				);
+			},
+		);
+		loopButton.toggleClass('is-active', state.loop);
+
+		if (state.markersEnabled) {
+			// Adding markers/chapters is edit-only; hidden in reading view
+			this.createIconButton(
+				controls,
+				'bookmark-plus',
+				'Add marker at current position',
+				() => {
+					this.callbacks.onAddMarker(MARKER_KIND.bookmark);
+				},
+			).addClass('aar-player-edit-only');
+			this.createIconButton(
+				controls,
+				'list-plus',
+				'Add chapter at current position',
+				() => {
+					this.callbacks.onAddMarker(MARKER_KIND.chapter);
+				},
+			).addClass('aar-player-edit-only');
+			this.createIconButton(
+				controls,
+				'chevron-first',
+				'Previous chapter',
+				() => {
+					this.callbacks.onPreviousChapter();
+				},
+			);
+			this.createIconButton(
+				controls,
+				'chevron-last',
+				'Next chapter',
+				() => {
+					this.callbacks.onNextChapter();
+				},
+			);
+		}
+
+		this.timeEl = controls.createDiv({ cls: 'aar-player-time' });
+		this.timeEl.setText('0:00 / 0:00');
+
+		this.createIconButton(controls, 'link', 'Copy timestamp link', () => {
+			this.callbacks.onCopyTimestampLink();
+		});
+	}
+
+	/**
+	 * Reflects the playing state on the play/pause button.
+	 * @param playing - True while the shared audio is playing
+	 */
+	setPlaying(playing: boolean): void {
+		if (this.playButton) {
+			setIcon(this.playButton, playing ? 'pause' : 'play');
+		}
+	}
+
+	/**
+	 * Reflects a playback rate on the speed button.
+	 * @param rate - Playback rate multiplier
+	 */
+	setPlaybackRate(rate: number): void {
+		this.speedButton?.setText(formatPlaybackRate(rate));
+	}
+
+	/**
+	 * Reflects the muted state on the mute button.
+	 * @param muted - True while the shared audio is muted
+	 */
+	setMuted(muted: boolean): void {
+		if (this.muteButton) {
+			setIcon(this.muteButton, muted ? 'volume-x' : 'volume-2');
+			this.muteButton.toggleClass('is-active', muted);
+		}
+	}
+
+	/**
+	 * Updates the elapsed/total time display.
+	 * @param text - Preformatted "elapsed / total" text
+	 */
+	setTime(text: string): void {
+		this.timeEl?.setText(text);
+	}
+
+	/**
+	 * Creates an icon button in a container and wires its click handler.
+	 * @param container - Parent element
+	 * @param icon - Obsidian icon id
+	 * @param label - Accessible label / tooltip
+	 * @param onClick - Click handler
+	 * @returns The created button element
+	 */
+	private createIconButton(
+		container: HTMLElement,
+		icon: string,
+		label: string,
+		onClick: () => void,
+	): HTMLElement {
+		const button = container.createEl('button', {
+			cls: 'aar-player-btn',
+			attr: { 'aria-label': label },
+		});
+		setIcon(button, icon);
+		this.host.registerDomEvent(button, 'click', onClick);
+		return button;
+	}
+}

--- a/src/player/views/WaveformCanvas.ts
+++ b/src/player/views/WaveformCanvas.ts
@@ -180,7 +180,7 @@ export class WaveformCanvas {
 		for (let i = 0; i < barCount; i++) {
 			const barHeight = Math.max(
 				1,
-				bars[i] * (cssHeight - BAR_VERTICAL_INSET),
+				(bars[i] ?? 0) * (cssHeight - BAR_VERTICAL_INSET),
 			);
 			const x = i * barWidth;
 			const y = (cssHeight - barHeight) / 2;

--- a/src/recording/AudioSplitter.ts
+++ b/src/recording/AudioSplitter.ts
@@ -304,6 +304,9 @@ export function detachTrailingBytes(
 	let remaining = trailingBytes;
 	while (remaining > 0 && buffers.length > 0) {
 		const last = buffers[buffers.length - 1];
+		if (!last) {
+			break;
+		}
 		if (last.byteLength <= remaining) {
 			buffers.pop();
 			carry.unshift(last);

--- a/src/recording/AudioStreamHandler.ts
+++ b/src/recording/AudioStreamHandler.ts
@@ -6,7 +6,7 @@
 import { PLUGIN_LOG_PREFIX } from '../constants';
 import { AudioStreamError } from '../errors';
 import { delay } from '../utils/TimeUtils';
-import type { AudioRecorderSettings } from '../settings/Settings';
+import type { AudioRecorderSettings } from '../settings/settingsSchema';
 
 export interface TrackAudioSource {
 	trackNumber: number;

--- a/src/recording/ConversionService.ts
+++ b/src/recording/ConversionService.ts
@@ -10,7 +10,7 @@ import { encodeAudioBuffer } from '../audio/AudioEncoder';
 import { FORMAT_WAV } from '../constants';
 import {
 	decodeAudioBlob,
-	convertBlobToFormat,
+	convertBlobToFormatBuffer,
 } from '../audio/AudioFormatConverter';
 import type { EncodingWorkerClient } from '../audio/EncodingWorkerClient';
 import { updateLinksInVault } from '../utils/LinkUpdater';
@@ -93,14 +93,14 @@ export class ConversionService {
 				request.sourceFile.path,
 			);
 
-			let blob: Blob;
+			let data: ArrayBuffer;
 			if (request.targetFormat === FORMAT_WAV) {
 				// WAV needs a full decode; the streaming pipeline only
 				// targets compressed formats
 				onProgress('Decoding audio...');
 				const audioBuffer = await decodeAudioBlob(arrayBuffer);
 				onProgress('Encoding...');
-				blob = await encodeAudioBuffer(
+				const blob = await encodeAudioBuffer(
 					audioBuffer,
 					{
 						format: request.targetFormat,
@@ -110,9 +110,13 @@ export class ConversionService {
 						onProgress(`Encoding... ${String(percent)}%`);
 					},
 				);
+				data = await blob.arrayBuffer();
 			} else {
 				onProgress('Converting...');
-				blob = await convertBlobToFormat(
+				// Bytes go straight to createBinary; the buffer variant
+				// avoids wrapping the streamed result in a Blob only to
+				// read it back out.
+				data = await convertBlobToFormatBuffer(
 					new Blob([arrayBuffer]),
 					request.targetFormat,
 					request.bitrate,
@@ -124,10 +128,7 @@ export class ConversionService {
 			}
 
 			onProgress('Saving...');
-			createdFile = await this.app.vault.createBinary(
-				newPath,
-				await blob.arrayBuffer(),
-			);
+			createdFile = await this.app.vault.createBinary(newPath, data);
 		} catch (error) {
 			const message =
 				error instanceof Error ? error.message : String(error);

--- a/src/recording/ConversionService.ts
+++ b/src/recording/ConversionService.ts
@@ -15,7 +15,7 @@ import {
 import type { EncodingWorkerClient } from '../audio/EncodingWorkerClient';
 import { updateLinksInVault } from '../utils/LinkUpdater';
 import type { VaultLinkUpdateResult } from '../utils/LinkUpdater';
-import type { ConversionLinkAction } from '../settings/Settings';
+import type { ConversionLinkAction } from '../settings/settingsSchema';
 
 /**
  * Parameters of one conversion operation.

--- a/src/recording/InputLevelMonitor.ts
+++ b/src/recording/InputLevelMonitor.ts
@@ -21,7 +21,8 @@ export function computeRms(samples: Float32Array): number {
 	}
 	let sumSquares = 0;
 	for (let i = 0; i < samples.length; i++) {
-		sumSquares += samples[i] * samples[i];
+		const sample = samples[i] ?? 0;
+		sumSquares += sample * sample;
 	}
 	return Math.sqrt(sumSquares / samples.length);
 }

--- a/src/recording/NoteInserter.ts
+++ b/src/recording/NoteInserter.ts
@@ -130,7 +130,8 @@ export async function insertProcessedAudioEmbed(
 				note.path,
 			)?.path === sourceFile.path,
 	);
-	if (matches.length === 0) {
+	const firstMatch = matches[0];
+	if (!firstMatch) {
 		return null;
 	}
 	const processedFile = app.vault.getFileByPath(processedPath);
@@ -141,7 +142,7 @@ export async function insertProcessedAudioEmbed(
 	await app.vault.process(note, (content) =>
 		replaceSource
 			? replaceSourceEmbeds(content, matches, newEmbed)
-			: insertEmbedAfterSource(content, matches[0].original, newEmbed),
+			: insertEmbedAfterSource(content, firstMatch.original, newEmbed),
 	);
 	return note.path;
 }

--- a/src/recording/NoteInserter.ts
+++ b/src/recording/NoteInserter.ts
@@ -133,11 +133,10 @@ export async function insertProcessedAudioEmbed(
 	if (matches.length === 0) {
 		return null;
 	}
-	const processedFile = app.vault.getAbstractFileByPath(processedPath);
-	const link =
-		processedFile instanceof TFile
-			? app.fileManager.generateMarkdownLink(processedFile, note.path)
-			: `[[${processedPath.split('/').pop() ?? processedPath}]]`;
+	const processedFile = app.vault.getFileByPath(processedPath);
+	const link = processedFile
+		? app.fileManager.generateMarkdownLink(processedFile, note.path)
+		: `[[${processedPath.split('/').pop() ?? processedPath}]]`;
 	const newEmbed = `!${link}`;
 	await app.vault.process(note, (content) =>
 		replaceSource

--- a/src/recording/PartRotationController.ts
+++ b/src/recording/PartRotationController.ts
@@ -11,7 +11,7 @@ import { Notice } from 'obsidian';
 import type { App } from 'obsidian';
 import { RecordingStatus } from '../types';
 import type { RecordingSessionConfig, RecordingTarget } from '../types';
-import type { AudioRecorderSettings } from '../settings/Settings';
+import type { AudioRecorderSettings } from '../settings/settingsSchema';
 import { PLUGIN_LOG_PREFIX, MS_PER_MINUTE, FORMAT_WAV } from '../constants';
 import { DebugLogger } from '../utils/DebugLogger';
 import { resolveUniquePath } from '../audio/RecordingFileManager';

--- a/src/recording/RecorderFactory.ts
+++ b/src/recording/RecorderFactory.ts
@@ -1,0 +1,83 @@
+/**
+ * Creation of the capture primitives for a recording session: MediaRecorder
+ * instances (chunked compressed capture) and PcmStreamRecorder instances
+ * (direct PCM capture for desktop WAV). Kept separate from the session
+ * lifecycle so RecordingManager only orchestrates.
+ * @module recording/RecorderFactory
+ */
+
+import { CHUNK_TIMESLICE_MS } from '../constants';
+import { PcmStreamRecorder } from './PcmStreamRecorder';
+
+/** Configuration for a batch of MediaRecorders. */
+export interface MediaRecorderConfig {
+	/** Full MIME type passed to the MediaRecorder constructor. */
+	mimeType: string;
+	/** Encoder bitrate in bits per second. */
+	bitrate: number;
+}
+
+/** Callbacks attached to every created MediaRecorder. */
+export interface MediaRecorderCallbacks {
+	/** Called with each non-empty data chunk. */
+	onChunk: (index: number, data: Blob) => void;
+	/** Called when a recorder reports an error event. */
+	onError: (index: number, event: Event) => void;
+}
+
+/**
+ * Creates MediaRecorder instances on the given streams, attaches
+ * chunk/error handlers, and starts them with the chunk timeslice.
+ * Used at recording start and after each auto-split part rotation.
+ * @param streams - Audio streams to record, one recorder per stream
+ * @param config - MIME type and bitrate for every recorder
+ * @param callbacks - Chunk and error handlers
+ * @returns The started recorders, in stream order
+ */
+export function createAndStartMediaRecorders(
+	streams: MediaStream[],
+	config: MediaRecorderConfig,
+	callbacks: MediaRecorderCallbacks,
+): MediaRecorder[] {
+	const recorders = streams.map(
+		(stream) =>
+			new MediaRecorder(stream, {
+				mimeType: config.mimeType,
+				audioBitsPerSecond: config.bitrate,
+			}),
+	);
+	recorders.forEach((recorder, index) => {
+		recorder.ondataavailable = (event: BlobEvent): void => {
+			if (event.data.size > 0) {
+				callbacks.onChunk(index, event.data);
+			}
+		};
+		recorder.onerror = (event: Event): void => {
+			callbacks.onError(index, event);
+		};
+		recorder.start(CHUNK_TIMESLICE_MS);
+	});
+	return recorders;
+}
+
+/**
+ * Creates PcmStreamRecorder instances for direct PCM capture, one per
+ * stream. The recorders are not started; the caller starts them so it can
+ * read the negotiated channel count and sample rate per recorder.
+ * @param streams - Audio streams to capture
+ * @param sampleRate - Requested capture sample rate in Hz
+ * @param onChunk - Called with each captured PCM chunk
+ * @returns The created recorders, in stream order
+ */
+export function createPcmRecorders(
+	streams: MediaStream[],
+	sampleRate: number,
+	onChunk: (index: number, data: ArrayBuffer) => void,
+): PcmStreamRecorder[] {
+	return streams.map(
+		(stream, index) =>
+			new PcmStreamRecorder(stream, sampleRate, (data: ArrayBuffer) => {
+				onChunk(index, data);
+			}),
+	);
+}

--- a/src/recording/RecorderFactory.ts
+++ b/src/recording/RecorderFactory.ts
@@ -61,6 +61,19 @@ export function createAndStartMediaRecorders(
 }
 
 /**
+ * Detaches the chunk and error handlers from recorders that are being
+ * discarded, so a chunk already queued by the browser cannot fire into a
+ * torn-down session (e.g. after stop, unload, or a failed start).
+ * @param recorders - Recorders about to be dropped
+ */
+export function detachRecorderHandlers(recorders: MediaRecorder[]): void {
+	for (const recorder of recorders) {
+		recorder.ondataavailable = null;
+		recorder.onerror = null;
+	}
+}
+
+/**
  * Creates PcmStreamRecorder instances for direct PCM capture, one per
  * stream. The recorders are not started; the caller starts them so it can
  * read the negotiated channel count and sample rate per recorder.

--- a/src/recording/RecordingFinalizer.ts
+++ b/src/recording/RecordingFinalizer.ts
@@ -16,7 +16,7 @@ import type {
 	SaveProgress,
 	TrackFileGroup,
 } from '../types';
-import type { AudioRecorderSettings } from '../settings/Settings';
+import type { AudioRecorderSettings } from '../settings/settingsSchema';
 import { PLUGIN_LOG_PREFIX, FORMAT_WAV } from '../constants';
 import { DebugLogger } from '../utils/DebugLogger';
 import { assembleWavFromPcmSegmentFiles } from '../audio/WavEncoder';

--- a/src/recording/RecordingFinalizer.ts
+++ b/src/recording/RecordingFinalizer.ts
@@ -8,6 +8,7 @@
 
 import { Notice } from 'obsidian';
 import type { App } from 'obsidian';
+import { sessionTimestamp } from '../utils/ids';
 import type {
 	InsertionContext,
 	RecordingSaveResult,
@@ -142,8 +143,7 @@ export class RecordingFinalizer {
 		insertionContext: InsertionContext | null,
 	): Promise<RecordingSaveResult> {
 		const session = this.requireSession();
-		const effectiveTimestamp =
-			timestamp ?? new Date().toISOString().replace(/[:.]/g, '-');
+		const effectiveTimestamp = timestamp ?? sessionTimestamp();
 		const fileLinks: string[] = [];
 		const trackFiles: TrackFileGroup[] = [];
 

--- a/src/recording/RecordingFinalizer.ts
+++ b/src/recording/RecordingFinalizer.ts
@@ -149,11 +149,11 @@ export class RecordingFinalizer {
 
 		this.reportProgress(20, 'Flushing buffers...');
 
+		const soloTarget = targets.length === 1 ? targets[0] : undefined;
 		if (session.outputMode === 'single') {
-			if (targets.length === 1) {
-				const target = targets[0];
-				const paths = await this.finalizeTrackFiles(target);
-				const files = [...target.partPaths, ...paths];
+			if (soloTarget) {
+				const paths = await this.finalizeTrackFiles(soloTarget);
+				const files = [...soloTarget.partPaths, ...paths];
 				fileLinks.push(...files);
 				trackFiles.push({ trackIndex: 0, files });
 			} else {
@@ -279,6 +279,9 @@ export class RecordingFinalizer {
 				trackIndex++
 			) {
 				const target = targets[trackIndex];
+				if (!target) {
+					continue;
+				}
 				const paths = await this.finalizeTrackFiles(target);
 				const files = [...target.partPaths, ...paths];
 				fileLinks.push(...files);

--- a/src/recording/RecordingFinalizer.ts
+++ b/src/recording/RecordingFinalizer.ts
@@ -30,8 +30,8 @@ import {
 } from '../audio/RecordingFileManager';
 import {
 	isOfflineOnlyFormat,
-	convertBlobToWav,
-	convertBlobToFormat,
+	convertBlobToWavBuffer,
+	convertBlobToFormatBuffer,
 	mergeAudioTracks,
 } from '../audio/AudioFormatConverter';
 import { buildMimeType } from '../audio/AudioCapabilityDetector';
@@ -438,22 +438,19 @@ export class RecordingFinalizer {
 			if (reportProgress) {
 				this.reportProgress(40, 'Assembling audio...');
 			}
-			const wavBlob = await convertBlobToWav(blob, {
+			const wavData = await convertBlobToWavBuffer(blob, {
 				workerClient: this.getWorkerClient(),
 			});
 			if (reportProgress) {
 				this.reportProgress(60, 'Writing file...');
 			}
-			await this.app.vault.createBinary(
-				filePath,
-				await wavBlob.arrayBuffer(),
-			);
+			await this.app.vault.createBinary(filePath, wavData);
 		} else if (isOfflineOnlyFormat(outputFormat, session.recorderFormat)) {
 			// Offline-only format: decode intermediate blob, re-encode to target
 			if (reportProgress) {
 				this.reportProgress(40, 'Encoding audio...');
 			}
-			const outputBlob = await convertBlobToFormat(
+			const outputData = await convertBlobToFormatBuffer(
 				blob,
 				outputFormat,
 				session.bitrate,
@@ -472,10 +469,7 @@ export class RecordingFinalizer {
 			if (reportProgress) {
 				this.reportProgress(60, 'Writing file...');
 			}
-			await this.app.vault.createBinary(
-				filePath,
-				await outputBlob.arrayBuffer(),
-			);
+			await this.app.vault.createBinary(filePath, outputData);
 		} else {
 			if (reportProgress) {
 				this.reportProgress(60, 'Writing file...');

--- a/src/recording/RecordingManager.ts
+++ b/src/recording/RecordingManager.ts
@@ -11,22 +11,11 @@ import type {
 	RecordingSaveResult,
 	RecordingTarget,
 	SaveProgress,
-	TrackFileGroup,
 } from '../types';
 import { MarkerStore } from '../markers/MarkerStore';
-import {
-	MARKER_KIND,
-	removeMarker,
-	sortMarkers,
-	updateMarker,
-	type MarkerKind,
-} from '../markers/markerModel';
-import { defaultMarkerLabel, generateMarkerId } from '../markers/markerFactory';
-import {
-	groupMarkersByFile,
-	type RecordingMarkerDraft,
-	type RecordingMarkerHandle,
-} from './recordingMarkers';
+import type { MarkerKind } from '../markers/markerModel';
+import type { RecordingMarkerHandle } from './recordingMarkers';
+import { RecordingMarkerCoordinator } from './RecordingMarkerCoordinator';
 import type {
 	AudioRecorderSettings,
 	OutputMode,
@@ -39,7 +28,6 @@ import {
 } from './AudioStreamHandler';
 import {
 	PLUGIN_LOG_PREFIX,
-	CHUNK_TIMESLICE_MS,
 	RECORDER_STOP_TIMEOUT_MS,
 	MOBILE_BUFFER_LIMIT_BYTES,
 	PCM_FLUSH_THRESHOLD_BYTES,
@@ -55,7 +43,12 @@ import {
 	buildMimeType,
 	validateRecordingCapability,
 } from '../audio/AudioCapabilityDetector';
-import { PcmStreamRecorder } from './PcmStreamRecorder';
+import type { PcmStreamRecorder } from './PcmStreamRecorder';
+import {
+	createAndStartMediaRecorders,
+	createPcmRecorders,
+} from './RecorderFactory';
+import { describeRecordingError } from './recordingErrors';
 import { InputLevelMonitor } from './InputLevelMonitor';
 import { resolveRecorderFormat } from '../audio/AudioFormatConverter';
 import type { EncodingWorkerClient } from '../audio/EncodingWorkerClient';
@@ -114,17 +107,8 @@ export class RecordingManager {
 	private readonly finalizer: RecordingFinalizer;
 	/** Auto-split part rotation (timing, reentry, part finalization). */
 	private readonly rotation: PartRotationController;
-	/** Markers captured during the current session, flushed at stop. */
-	private markerBuffer: RecordingMarkerDraft[] = [];
-	/** Last marker kind chosen in the modal, preselected next time. */
-	private lastMarkerKind: MarkerKind = MARKER_KIND.bookmark;
-	/**
-	 * Sidecar paths each persisted marker landed in, keyed by draft id.
-	 * Populated at stop so a naming modal still open when the session ends
-	 * can edit or discard the already-saved marker rather than silently
-	 * losing the change. Reset when a new session starts.
-	 */
-	private readonly persistedMarkerPaths = new Map<string, string[]>();
+	/** Marker drafts and their persistence for the current session. */
+	private readonly markers: RecordingMarkerCoordinator;
 
 	/**
 	 * Creates a new RecordingManager.
@@ -146,11 +130,12 @@ export class RecordingManager {
 		private readonly onRecordingSaved?: (
 			result: RecordingSaveResult,
 		) => void,
-		private readonly markerStore: MarkerStore = new MarkerStore(app),
+		markerStore: MarkerStore = new MarkerStore(app),
 		getWorkerClient: () => EncodingWorkerClient | null = () => null,
 	) {
 		this.onStatusChange = onStatusChange;
 		this.debugLogger = new DebugLogger(settings);
+		this.markers = new RecordingMarkerCoordinator(markerStore);
 		this.writeQueue = new TrackWriteQueue(app, settings, journal);
 		this.finalizer = new RecordingFinalizer(
 			app,
@@ -253,160 +238,7 @@ export class RecordingManager {
 			return null;
 		}
 		const position = this.rotation.getCurrentPartPosition(this.status);
-		const kind = preselectKind ?? this.lastMarkerKind;
-		const draft: RecordingMarkerDraft = {
-			id: generateMarkerId(),
-			partOrdinal: position.partOrdinal,
-			offsetSeconds: position.offsetSeconds,
-			kind,
-			label: this.nextMarkerLabel(kind, null),
-		};
-		this.markerBuffer.push(draft);
-		return {
-			initialKind: draft.kind,
-			defaultLabelFor: (kind: MarkerKind) =>
-				this.nextMarkerLabel(kind, draft.id),
-			commit: (label: string, kind: MarkerKind) => {
-				draft.kind = kind;
-				const trimmed = label.trim();
-				draft.label =
-					trimmed.length > 0
-						? trimmed
-						: this.nextMarkerLabel(kind, draft.id);
-				this.lastMarkerKind = kind;
-				// If the session finalized while the modal was open the draft
-				// was already persisted with its default label; push the edit
-				// through to the sidecar so the user's name/kind is not lost.
-				void this.syncPersistedMarker(draft);
-			},
-			cancel: () => {
-				const index = this.markerBuffer.findIndex(
-					(entry) => entry.id === draft.id,
-				);
-				if (index !== -1) {
-					this.markerBuffer.splice(index, 1);
-				}
-				// Same race: a draft persisted before the modal closed must be
-				// removed from its sidecar so cancelling truly discards it.
-				void this.removePersistedMarker(draft.id);
-			},
-		};
-	}
-
-	/**
-	 * Default label for a new marker of the given kind, numbered after the
-	 * markers already buffered this session (excluding the given draft so it
-	 * never counts itself).
-	 * @param kind - Marker kind being labelled
-	 * @param excludeId - Draft id to exclude from the count, or null
-	 */
-	private nextMarkerLabel(
-		kind: MarkerKind,
-		excludeId: string | null,
-	): string {
-		const others = this.markerBuffer.filter(
-			(entry) => entry.id !== excludeId,
-		);
-		return defaultMarkerLabel(others, kind);
-	}
-
-	/**
-	 * Writes the session's buffered markers into the sidecars of the final
-	 * files. Each marker resolves to its part's file per track and fans out
-	 * to every track (they share one timeline). Never throws: a marker write
-	 * failure must not break the stop sequence.
-	 * @param result - The finalized save result with per-track file groups
-	 */
-	private async persistMarkers(result: RecordingSaveResult): Promise<void> {
-		if (this.markerBuffer.length === 0) {
-			return;
-		}
-		const groups: TrackFileGroup[] = result.trackFiles ?? [
-			{ trackIndex: 0, files: result.audioPaths },
-		];
-		const writes = groupMarkersByFile(this.markerBuffer, groups);
-		// Record where each draft landed before any await runs, so a modal
-		// still open can reach its persisted marker by id. Done in one
-		// synchronous pass: no commit/cancel can interleave mid-write.
-		for (const { path, markers } of writes) {
-			for (const marker of markers) {
-				const paths = this.persistedMarkerPaths.get(marker.id) ?? [];
-				paths.push(path);
-				this.persistedMarkerPaths.set(marker.id, paths);
-			}
-		}
-		for (const { path, markers } of writes) {
-			try {
-				const existing = await this.markerStore.get(path);
-				await this.markerStore.set(
-					path,
-					sortMarkers([...existing, ...markers]),
-				);
-			} catch (error) {
-				console.error(
-					`${PLUGIN_LOG_PREFIX} Failed to persist recording markers for ${path}:`,
-					error,
-				);
-			}
-		}
-	}
-
-	/**
-	 * Pushes a draft's edited label and kind onto every sidecar it was
-	 * already persisted to. No-op while the session is still active (the
-	 * draft is then edited in place in the buffer instead). Never throws: a
-	 * sidecar write failure must not surface from a UI commit handler.
-	 * @param draft - The edited draft
-	 */
-	private async syncPersistedMarker(
-		draft: RecordingMarkerDraft,
-	): Promise<void> {
-		const paths = this.persistedMarkerPaths.get(draft.id);
-		if (!paths) {
-			return;
-		}
-		for (const path of paths) {
-			try {
-				const existing = await this.markerStore.get(path);
-				await this.markerStore.set(
-					path,
-					updateMarker(existing, draft.id, {
-						label: draft.label,
-						kind: draft.kind,
-					}),
-				);
-			} catch (error) {
-				console.error(
-					`${PLUGIN_LOG_PREFIX} Failed to update persisted marker for ${path}:`,
-					error,
-				);
-			}
-		}
-	}
-
-	/**
-	 * Removes an already-persisted marker from every sidecar it landed in.
-	 * No-op while the session is still active (the draft is just dropped from
-	 * the buffer instead). Never throws.
-	 * @param id - The draft/marker id to remove
-	 */
-	private async removePersistedMarker(id: string): Promise<void> {
-		const paths = this.persistedMarkerPaths.get(id);
-		if (!paths) {
-			return;
-		}
-		this.persistedMarkerPaths.delete(id);
-		for (const path of paths) {
-			try {
-				const existing = await this.markerStore.get(path);
-				await this.markerStore.set(path, removeMarker(existing, id));
-			} catch (error) {
-				console.error(
-					`${PLUGIN_LOG_PREFIX} Failed to remove persisted marker for ${path}:`,
-					error,
-				);
-			}
-		}
+		return this.markers.captureDraft(position, preselectKind);
 	}
 
 	/**
@@ -516,8 +348,7 @@ export class RecordingManager {
 				.toISOString()
 				.replace(/[:.]/g, '-');
 			this.totalChunks = 0;
-			this.markerBuffer = [];
-			this.persistedMarkerPaths.clear();
+			this.markers.beginSession();
 			this.recordedBytes = 0;
 			this.startLevelMonitor();
 
@@ -607,7 +438,7 @@ export class RecordingManager {
 		this.trackOrder = [];
 		this.recordingTimestamp = null;
 		this.insertionContext = null;
-		this.markerBuffer = [];
+		this.markers.clearBuffer();
 	}
 
 	/**
@@ -721,15 +552,12 @@ export class RecordingManager {
 	private async initPcmRecording(): Promise<void> {
 		this.chunkTargets = await this.createChunkTargets(this.streams.length);
 
-		this.pcmRecorders = this.streams.map(
-			(stream, index) =>
-				new PcmStreamRecorder(
-					stream,
-					this.settings.sampleRate,
-					(data: ArrayBuffer) => {
-						void this.handlePcmChunk(index, data);
-					},
-				),
+		this.pcmRecorders = createPcmRecorders(
+			this.streams,
+			this.settings.sampleRate,
+			(index, data) => {
+				void this.handlePcmChunk(index, data);
+			},
 		);
 
 		await Promise.all(
@@ -748,64 +576,44 @@ export class RecordingManager {
 	 */
 	private async initMediaRecording(): Promise<void> {
 		this.chunkTargets = await this.createChunkTargets(this.streams.length);
-		this.createAndStartMediaRecorders();
+		this.startMediaRecorders();
 	}
 
 	/**
-	 * Creates MediaRecorder instances on the current streams, attaches
-	 * chunk/error handlers, and starts them with the chunk timeslice.
-	 * Used at recording start and after each auto-split part rotation.
+	 * Creates and starts MediaRecorders on the current streams via the
+	 * recorder factory. Used at recording start and after each auto-split
+	 * part rotation.
 	 */
-	private createAndStartMediaRecorders(): void {
-		const mimeType = buildMimeType(this.activeRecorderFormat);
-		this.recorders = this.streams.map(
-			(stream) =>
-				new MediaRecorder(stream, {
-					mimeType,
-					audioBitsPerSecond: this.sessionBitrate,
-				}),
+	private startMediaRecorders(): void {
+		this.recorders = createAndStartMediaRecorders(
+			this.streams,
+			{
+				mimeType: buildMimeType(this.activeRecorderFormat),
+				bitrate: this.sessionBitrate,
+			},
+			{
+				onChunk: (index, data) => {
+					void this.handleChunk(index, data);
+					this.debugLogger.logChunkSize(index, data.size);
+				},
+				onError: (_index, event) => {
+					console.error(
+						`${PLUGIN_LOG_PREFIX} Recorder error:`,
+						event,
+					);
+					new Notice(
+						'Recording error occurred. Check console for details.',
+					);
+				},
+			},
 		);
-
-		this.recorders.forEach((recorder, index) => {
-			recorder.ondataavailable = (event: BlobEvent): void => {
-				if (event.data.size > 0) {
-					void this.handleChunk(index, event.data);
-					this.debugLogger.logChunkSize(index, event.data.size);
-				}
-			};
-			recorder.onerror = (event: Event): void => {
-				console.error(`${PLUGIN_LOG_PREFIX} Recorder error:`, event);
-				new Notice(
-					'Recording error occurred. Check console for details.',
-				);
-			};
-			recorder.start(CHUNK_TIMESLICE_MS);
-		});
 	}
 
 	/**
 	 * Handles errors during recording start with user-friendly messages.
 	 */
 	private handleStartRecordingError(error: unknown): void {
-		if (error instanceof DOMException) {
-			if (error.name === 'NotAllowedError') {
-				new Notice(
-					'Microphone access denied. Please grant permission in browser settings.',
-				);
-			} else if (error.name === 'NotFoundError') {
-				new Notice(
-					'No microphone found. Please connect an audio input device.',
-				);
-			} else if (error.name === 'NotReadableError') {
-				new Notice('Microphone is in use by another application.');
-			} else {
-				new Notice(`Recording error: ${error.message}`);
-			}
-		} else {
-			const message =
-				error instanceof Error ? error.message : String(error);
-			new Notice(`Error starting recording: ${message}`);
-		}
+		new Notice(describeRecordingError(error));
 		console.error(`${PLUGIN_LOG_PREFIX} Error in startRecording:`, error);
 	}
 
@@ -851,7 +659,7 @@ export class RecordingManager {
 			);
 			// Persist live markers before the hook so they are on disk when a
 			// post-save action (e.g. opening the player) reads the sidecar
-			await this.persistMarkers(saveResult);
+			await this.markers.persistMarkers(saveResult);
 			if (saveResult.audioPaths.length > 0) {
 				// Fire-and-forget post-save hook (e.g. transcribe-on-save);
 				// failures must never break the stop sequence
@@ -894,7 +702,7 @@ export class RecordingManager {
 			this.isWavPcmRecording = false;
 			this.insertionContext = null;
 			this.sessionSplitEnabled = false;
-			this.markerBuffer = [];
+			this.markers.clearBuffer();
 			this.setStatus(RecordingStatus.Idle);
 		}
 	}
@@ -1114,7 +922,7 @@ export class RecordingManager {
 	 */
 	private restartMediaRecorders(): void {
 		try {
-			this.createAndStartMediaRecorders();
+			this.startMediaRecorders();
 			if (this.status === RecordingStatus.Paused) {
 				this.recorders.forEach((recorder) => recorder.pause());
 			}

--- a/src/recording/RecordingManager.ts
+++ b/src/recording/RecordingManager.ts
@@ -62,6 +62,7 @@ import {
 	sanitizePartSuffix,
 } from './AudioSplitter';
 import { captureInsertionContext } from './NoteInserter';
+import { sessionTimestamp } from '../utils/ids';
 
 /**
  * Manages the audio recording lifecycle.
@@ -344,9 +345,7 @@ export class RecordingManager {
 			this.rotation.beginSession(sessionConfig);
 
 			this.recordingStartTime = Date.now();
-			this.recordingTimestamp = new Date()
-				.toISOString()
-				.replace(/[:.]/g, '-');
+			this.recordingTimestamp = sessionTimestamp();
 			this.totalChunks = 0;
 			this.markers.beginSession();
 			this.recordedBytes = 0;

--- a/src/recording/RecordingManager.ts
+++ b/src/recording/RecordingManager.ts
@@ -47,6 +47,7 @@ import type { PcmStreamRecorder } from './PcmStreamRecorder';
 import {
 	createAndStartMediaRecorders,
 	createPcmRecorders,
+	detachRecorderHandlers,
 } from './RecorderFactory';
 import { describeRecordingError } from './recordingErrors';
 import { InputLevelMonitor } from './InputLevelMonitor';
@@ -431,6 +432,7 @@ export class RecordingManager {
 		}
 		stopAllStreams(this.streams);
 		this.streams = [];
+		detachRecorderHandlers(this.recorders);
 		this.recorders = [];
 		this.pcmRecorders = [];
 		this.chunkTargets = [];
@@ -584,6 +586,10 @@ export class RecordingManager {
 	 * part rotation.
 	 */
 	private startMediaRecorders(): void {
+		// The recorders being replaced (initial start: none; part rotation:
+		// the stopped previous batch) must not fire a late chunk into the
+		// new part's accounting.
+		detachRecorderHandlers(this.recorders);
 		this.recorders = createAndStartMediaRecorders(
 			this.streams,
 			{
@@ -691,6 +697,7 @@ export class RecordingManager {
 			this.stopLevelMonitor();
 			stopAllStreams(this.streams);
 			this.streams = [];
+			detachRecorderHandlers(this.recorders);
 			this.recorders = [];
 			this.pcmRecorders = [];
 			this.chunkTargets = [];
@@ -838,6 +845,7 @@ export class RecordingManager {
 			});
 		}
 		stopAllStreams(this.streams);
+		detachRecorderHandlers(this.recorders);
 		this.recorders = [];
 		this.pcmRecorders = [];
 		this.chunkTargets = [];

--- a/src/recording/RecordingManager.ts
+++ b/src/recording/RecordingManager.ts
@@ -253,8 +253,12 @@ export class RecordingManager {
 		if (!this.settings.showInputLevelMeter || this.streams.length === 0) {
 			return;
 		}
+		const primaryStream = this.streams[0];
+		if (!primaryStream) {
+			return;
+		}
 		this.levelMonitor = new InputLevelMonitor();
-		this.levelMonitor.start(this.streams[0]);
+		this.levelMonitor.start(primaryStream);
 	}
 
 	/**
@@ -525,7 +529,7 @@ export class RecordingManager {
 		}
 		const uniqueNames = sourceNames.map((name, index) =>
 			(nameCounts.get(name) ?? 0) > 1
-				? `${name}-${String(trackInfos[index].trackNumber)}`
+				? `${name}-${String(trackInfos[index]?.trackNumber ?? index + 1)}`
 				: name,
 		);
 		return uniqueNames.map((sourceName) => ({
@@ -565,6 +569,9 @@ export class RecordingManager {
 			this.pcmRecorders.map(async (recorder, index) => {
 				await recorder.start();
 				const target = this.chunkTargets[index];
+				if (!target) {
+					return;
+				}
 				target.pcmChannels = recorder.channels;
 				target.pcmSampleRate = recorder.sampleRate;
 			}),

--- a/src/recording/RecordingManager.ts
+++ b/src/recording/RecordingManager.ts
@@ -27,7 +27,10 @@ import {
 	type RecordingMarkerDraft,
 	type RecordingMarkerHandle,
 } from './recordingMarkers';
-import type { AudioRecorderSettings, OutputMode } from '../settings/Settings';
+import type {
+	AudioRecorderSettings,
+	OutputMode,
+} from '../settings/settingsSchema';
 import {
 	getAudioStreams,
 	getAudioSourceName,

--- a/src/recording/RecordingMarkerCoordinator.ts
+++ b/src/recording/RecordingMarkerCoordinator.ts
@@ -1,0 +1,233 @@
+/**
+ * Session-scoped marker drafts for a live recording: buffers drafts while
+ * the session runs, persists them into the final files' sidecars at stop,
+ * and reconciles the race where a naming modal is still open after the
+ * session has finalized (the edit or cancel must reach the already-saved
+ * marker instead of being silently lost).
+ * @module recording/RecordingMarkerCoordinator
+ */
+
+import { PLUGIN_LOG_PREFIX } from '../constants';
+import { MarkerStore } from '../markers/MarkerStore';
+import {
+	MARKER_KIND,
+	removeMarker,
+	sortMarkers,
+	updateMarker,
+	type MarkerKind,
+} from '../markers/markerModel';
+import { defaultMarkerLabel, generateMarkerId } from '../markers/markerFactory';
+import {
+	groupMarkersByFile,
+	type RecordingMarkerDraft,
+	type RecordingMarkerHandle,
+} from './recordingMarkers';
+import type { RecordingSaveResult, TrackFileGroup } from '../types';
+
+/** Position of a marker inside the running session. */
+export interface MarkerPosition {
+	/** Ordinal of the auto-split part the marker falls into. */
+	partOrdinal: number;
+	/** Offset in seconds from the start of that part. */
+	offsetSeconds: number;
+}
+
+/**
+ * Buffers and persists the markers captured during one recording session.
+ */
+export class RecordingMarkerCoordinator {
+	/** Markers captured during the current session, flushed at stop. */
+	private buffer: RecordingMarkerDraft[] = [];
+	/** Last marker kind chosen in the modal, preselected next time. */
+	private lastKind: MarkerKind = MARKER_KIND.bookmark;
+	/**
+	 * Sidecar paths each persisted marker landed in, keyed by draft id.
+	 * Populated at stop so a naming modal still open when the session ends
+	 * can edit or discard the already-saved marker rather than silently
+	 * losing the change. Reset when a new session starts.
+	 */
+	private readonly persistedPaths = new Map<string, string[]>();
+
+	/**
+	 * @param markerStore - Sidecar store the persisted markers are written to
+	 */
+	constructor(private readonly markerStore: MarkerStore) {}
+
+	/**
+	 * Resets the draft buffer and the persisted-path index for a new session.
+	 */
+	beginSession(): void {
+		this.buffer = [];
+		this.persistedPaths.clear();
+	}
+
+	/**
+	 * Drops the buffered drafts. The persisted-path index is kept so a
+	 * naming modal still open after stop can reach its saved marker.
+	 */
+	clearBuffer(): void {
+		this.buffer = [];
+	}
+
+	/**
+	 * Captures a marker at the given position and adds it to the session
+	 * buffer immediately, so it survives even if the recording stops while
+	 * the naming modal is still open. Returns an editing handle for the
+	 * modal.
+	 * @param position - Part ordinal and offset the marker was dropped at
+	 * @param preselectKind - Marker kind fixed by the invoking command;
+	 *   defaults to the kind last chosen in the modal
+	 */
+	captureDraft(
+		position: MarkerPosition,
+		preselectKind?: MarkerKind,
+	): RecordingMarkerHandle {
+		const kind = preselectKind ?? this.lastKind;
+		const draft: RecordingMarkerDraft = {
+			id: generateMarkerId(),
+			partOrdinal: position.partOrdinal,
+			offsetSeconds: position.offsetSeconds,
+			kind,
+			label: this.nextLabel(kind, null),
+		};
+		this.buffer.push(draft);
+		return {
+			initialKind: draft.kind,
+			defaultLabelFor: (kind: MarkerKind) =>
+				this.nextLabel(kind, draft.id),
+			commit: (label: string, kind: MarkerKind) => {
+				draft.kind = kind;
+				const trimmed = label.trim();
+				draft.label =
+					trimmed.length > 0
+						? trimmed
+						: this.nextLabel(kind, draft.id);
+				this.lastKind = kind;
+				// If the session finalized while the modal was open the draft
+				// was already persisted with its default label; push the edit
+				// through to the sidecar so the user's name/kind is not lost.
+				void this.syncPersisted(draft);
+			},
+			cancel: () => {
+				const index = this.buffer.findIndex(
+					(entry) => entry.id === draft.id,
+				);
+				if (index !== -1) {
+					this.buffer.splice(index, 1);
+				}
+				// Same race: a draft persisted before the modal closed must be
+				// removed from its sidecar so cancelling truly discards it.
+				void this.removePersisted(draft.id);
+			},
+		};
+	}
+
+	/**
+	 * Writes the session's buffered markers into the sidecars of the final
+	 * files. Each marker resolves to its part's file per track and fans out
+	 * to every track (they share one timeline). Never throws: a marker write
+	 * failure must not break the stop sequence.
+	 * @param result - The finalized save result with per-track file groups
+	 */
+	async persistMarkers(result: RecordingSaveResult): Promise<void> {
+		if (this.buffer.length === 0) {
+			return;
+		}
+		const groups: TrackFileGroup[] = result.trackFiles ?? [
+			{ trackIndex: 0, files: result.audioPaths },
+		];
+		const writes = groupMarkersByFile(this.buffer, groups);
+		// Record where each draft landed before any await runs, so a modal
+		// still open can reach its persisted marker by id. Done in one
+		// synchronous pass: no commit/cancel can interleave mid-write.
+		for (const { path, markers } of writes) {
+			for (const marker of markers) {
+				const paths = this.persistedPaths.get(marker.id) ?? [];
+				paths.push(path);
+				this.persistedPaths.set(marker.id, paths);
+			}
+		}
+		for (const { path, markers } of writes) {
+			try {
+				const existing = await this.markerStore.get(path);
+				await this.markerStore.set(
+					path,
+					sortMarkers([...existing, ...markers]),
+				);
+			} catch (error) {
+				console.error(
+					`${PLUGIN_LOG_PREFIX} Failed to persist recording markers for ${path}:`,
+					error,
+				);
+			}
+		}
+	}
+
+	/**
+	 * Default label for a new marker of the given kind, numbered after the
+	 * markers already buffered this session (excluding the given draft so it
+	 * never counts itself).
+	 * @param kind - Marker kind being labelled
+	 * @param excludeId - Draft id to exclude from the count, or null
+	 */
+	private nextLabel(kind: MarkerKind, excludeId: string | null): string {
+		const others = this.buffer.filter((entry) => entry.id !== excludeId);
+		return defaultMarkerLabel(others, kind);
+	}
+
+	/**
+	 * Pushes a draft's edited label and kind onto every sidecar it was
+	 * already persisted to. No-op while the session is still active (the
+	 * draft is then edited in place in the buffer instead). Never throws: a
+	 * sidecar write failure must not surface from a UI commit handler.
+	 * @param draft - The edited draft
+	 */
+	private async syncPersisted(draft: RecordingMarkerDraft): Promise<void> {
+		const paths = this.persistedPaths.get(draft.id);
+		if (!paths) {
+			return;
+		}
+		for (const path of paths) {
+			try {
+				const existing = await this.markerStore.get(path);
+				await this.markerStore.set(
+					path,
+					updateMarker(existing, draft.id, {
+						label: draft.label,
+						kind: draft.kind,
+					}),
+				);
+			} catch (error) {
+				console.error(
+					`${PLUGIN_LOG_PREFIX} Failed to update persisted marker for ${path}:`,
+					error,
+				);
+			}
+		}
+	}
+
+	/**
+	 * Removes an already-persisted marker from every sidecar it landed in.
+	 * No-op while the session is still active (the draft is just dropped from
+	 * the buffer instead). Never throws.
+	 * @param id - The draft/marker id to remove
+	 */
+	private async removePersisted(id: string): Promise<void> {
+		const paths = this.persistedPaths.get(id);
+		if (!paths) {
+			return;
+		}
+		this.persistedPaths.delete(id);
+		for (const path of paths) {
+			try {
+				const existing = await this.markerStore.get(path);
+				await this.markerStore.set(path, removeMarker(existing, id));
+			} catch (error) {
+				console.error(
+					`${PLUGIN_LOG_PREFIX} Failed to remove persisted marker for ${path}:`,
+					error,
+				);
+			}
+		}
+	}
+}

--- a/src/recording/RecoveryService.ts
+++ b/src/recording/RecoveryService.ts
@@ -176,7 +176,11 @@ export async function recoverSession(
 				extension = session.recorderFormat;
 			}
 
-			const directory = directoryOf(track.segmentPaths[0]);
+			const firstSegmentPath = track.segmentPaths[0];
+			if (firstSegmentPath === undefined) {
+				continue;
+			}
+			const directory = directoryOf(firstSegmentPath);
 			const outputPath = await resolveUniquePathInDirectory(
 				directory,
 				`${track.fileBaseName}-recovered.${extension}`,

--- a/src/recording/SplitService.ts
+++ b/src/recording/SplitService.ts
@@ -135,7 +135,7 @@ export class SplitService {
 
 			partFiles = await this.writePartFiles(parts, partPaths, onProgress);
 			partCount = parts.length;
-			firstPartName = partNames[0];
+			firstPartName = partNames[0] ?? '';
 		} catch (error) {
 			const message =
 				error instanceof Error ? error.message : String(error);
@@ -353,13 +353,18 @@ export class SplitService {
 				onProgress(
 					`Writing part ${String(i + 1)} of ${String(parts.length)}...`,
 				);
-				const bytes = await parts[i].data();
+				const part = parts[i];
+				const partPath = partPaths[i];
+				if (!part || !partPath) {
+					continue;
+				}
+				const bytes = await part.data();
 				const created = await this.app.vault.createBinary(
-					partPaths[i],
+					partPath,
 					bytes,
 				);
 				written.push({
-					path: partPaths[i],
+					path: partPath,
 					file: created instanceof TFile ? created : null,
 				});
 				// Yield to the UI between parts so the progress text repaints

--- a/src/recording/SplitService.ts
+++ b/src/recording/SplitService.ts
@@ -25,7 +25,7 @@ import {
 import { updateLinksInVault } from '../utils/LinkUpdater';
 import type { VaultLinkUpdateResult } from '../utils/LinkUpdater';
 import { delay } from '../utils/TimeUtils';
-import type { ConversionLinkAction } from '../settings/Settings';
+import type { ConversionLinkAction } from '../settings/settingsSchema';
 
 /**
  * Parameters of one split operation.

--- a/src/recording/StreamingMixer.ts
+++ b/src/recording/StreamingMixer.ts
@@ -42,10 +42,11 @@ export interface PcmMixTrack {
  * @returns True when all tracks share a sample rate and have data
  */
 export function canStreamMix(tracks: PcmMixTrack[]): boolean {
-	if (tracks.length === 0) {
+	const first = tracks[0];
+	if (!first) {
 		return false;
 	}
-	const rate = tracks[0].sampleRate;
+	const rate = first.sampleRate;
 	return tracks.every(
 		(track) =>
 			track.segmentPaths.length > 0 &&
@@ -89,12 +90,11 @@ class PcmSegmentReader {
 		let written = 0;
 		while (written < samplesWanted) {
 			if (!this.current || this.currentOffset >= this.current.length) {
-				if (this.segmentIndex >= this.segmentPaths.length) {
+				const path = this.segmentPaths[this.segmentIndex];
+				if (path === undefined) {
 					break;
 				}
-				const bytes = await this.app.vault.adapter.readBinary(
-					this.segmentPaths[this.segmentIndex],
-				);
+				const bytes = await this.app.vault.adapter.readBinary(path);
 				this.segmentIndex += 1;
 				// Whole int16 samples only; a torn trailing byte is dropped
 				this.current = new Int16Array(
@@ -163,12 +163,16 @@ export async function mixPcmTracksToWav(
 			Math.floor(bytes / (PCM_BYTES_PER_SAMPLE * track.channels)),
 		);
 	}
+	const firstTrack = tracks[0];
+	if (!firstTrack) {
+		throw new Error('No tracks to mix');
+	}
 	const totalFrames = Math.max(...frameCounts);
 	const outChannels = Math.min(
 		2,
 		Math.max(...tracks.map((track) => track.channels)),
 	);
-	const sampleRate = tracks[0].sampleRate;
+	const sampleRate = firstTrack.sampleRate;
 
 	const wavBuffer = createWavFileBuffer(
 		outChannels,
@@ -192,28 +196,39 @@ export async function mixPcmTracksToWav(
 		accumulator.fill(0, 0, frames * outChannels);
 
 		for (let trackIndex = 0; trackIndex < tracks.length; trackIndex++) {
-			const channels = tracks[trackIndex].channels;
+			const track = tracks[trackIndex];
 			const window = windows[trackIndex];
-			await readers[trackIndex].read(frames, window);
+			const reader = readers[trackIndex];
+			if (!track || !window || !reader) {
+				// The three arrays are built in lockstep from tracks;
+				// an index cannot miss one without missing all
+				continue;
+			}
+			await reader.read(frames, window);
 
-			if (channels === outChannels) {
+			// The `?? 0` narrows the checked index reads with the mix's
+			// neutral element; every access below is in bounds by
+			// construction (the buffers are sized from windowFrames)
+			if (track.channels === outChannels) {
 				for (let i = 0; i < frames * outChannels; i++) {
-					accumulator[i] += window[i];
+					accumulator[i] = (accumulator[i] ?? 0) + (window[i] ?? 0);
 				}
 			} else {
 				// Mono into stereo: duplicate the sample into both
 				// channels, matching the Web Audio up-mix behavior
 				for (let frame = 0; frame < frames; frame++) {
-					const sample = window[frame];
-					accumulator[frame * 2] += sample;
-					accumulator[frame * 2 + 1] += sample;
+					const sample = window[frame] ?? 0;
+					accumulator[frame * 2] =
+						(accumulator[frame * 2] ?? 0) + sample;
+					accumulator[frame * 2 + 1] =
+						(accumulator[frame * 2 + 1] ?? 0) + sample;
 				}
 			}
 		}
 
 		const outBase = frameOffset * outChannels;
 		for (let i = 0; i < frames * outChannels; i++) {
-			const sum = accumulator[i];
+			const sum = accumulator[i] ?? 0;
 			output[outBase + i] =
 				sum > INT16_MAX ? INT16_MAX : sum < INT16_MIN ? INT16_MIN : sum;
 		}

--- a/src/recording/TestRecorder.ts
+++ b/src/recording/TestRecorder.ts
@@ -9,7 +9,7 @@
 import { buildMimeType } from '../audio/AudioCapabilityDetector';
 import { FORMAT_WAV, FORMAT_WEBM, MIME_TYPE_AUDIO_PREFIX } from '../constants';
 import { getProcessingConstraints } from './AudioStreamHandler';
-import type { AudioRecorderSettings } from '../settings/Settings';
+import type { AudioRecorderSettings } from '../settings/settingsSchema';
 
 /** Outcome of one test capture. */
 export type TestRecordingResult =

--- a/src/recording/TrackWriteQueue.ts
+++ b/src/recording/TrackWriteQueue.ts
@@ -11,7 +11,7 @@
 import { Notice } from 'obsidian';
 import type { App } from 'obsidian';
 import type { RecordingSessionConfig, RecordingTarget } from '../types';
-import type { AudioRecorderSettings } from '../settings/Settings';
+import type { AudioRecorderSettings } from '../settings/settingsSchema';
 import { PLUGIN_LOG_PREFIX } from '../constants';
 import { concatArrayBuffers } from '../utils/buffers';
 import { resolveUniquePath } from '../audio/RecordingFileManager';

--- a/src/recording/api.ts
+++ b/src/recording/api.ts
@@ -1,0 +1,15 @@
+/**
+ * Public API of the recording domain for the UI layer. Modals and other
+ * presentation code import from here instead of reaching into individual
+ * recording modules, so the domain's internal layout can change without
+ * touching the UI.
+ * @module recording/api
+ */
+
+export { ConversionService } from './ConversionService';
+export type { ConversionOutcome, ConversionRequest } from './ConversionService';
+export { SplitService } from './SplitService';
+export type { SplitOutcome, SplitRequest } from './SplitService';
+export { clampSplitMinutes, sanitizePartSuffix } from './AudioSplitter';
+export type { RecordingMarkerHandle } from './recordingMarkers';
+export type { JournalSession } from './SessionJournal';

--- a/src/recording/recordingErrors.ts
+++ b/src/recording/recordingErrors.ts
@@ -1,0 +1,28 @@
+/**
+ * User-facing descriptions of recording-start failures.
+ * @module recording/recordingErrors
+ */
+
+/**
+ * Maps a recording-start failure onto a user-friendly message. Media
+ * capture failures surface as DOMExceptions with well-known names; those
+ * get specific guidance, everything else falls back to the error text.
+ * @param error - The thrown value from startRecording
+ * @returns Message suitable for a Notice
+ */
+export function describeRecordingError(error: unknown): string {
+	if (error instanceof DOMException) {
+		if (error.name === 'NotAllowedError') {
+			return 'Microphone access denied. Please grant permission in browser settings.';
+		}
+		if (error.name === 'NotFoundError') {
+			return 'No microphone found. Please connect an audio input device.';
+		}
+		if (error.name === 'NotReadableError') {
+			return 'Microphone is in use by another application.';
+		}
+		return `Recording error: ${error.message}`;
+	}
+	const message = error instanceof Error ? error.message : String(error);
+	return `Error starting recording: ${message}`;
+}

--- a/src/recording/recordingMarkers.ts
+++ b/src/recording/recordingMarkers.ts
@@ -163,6 +163,9 @@ export function groupMarkersByFile(
 				continue;
 			}
 			const path = group.files[fileIndex];
+			if (path === undefined) {
+				continue;
+			}
 			let entry = byPath.get(path);
 			if (!entry) {
 				entry = { path, markers: [] };

--- a/src/settings/FolderSuggest.ts
+++ b/src/settings/FolderSuggest.ts
@@ -1,0 +1,47 @@
+/**
+ * Native Obsidian popover suggestions for folder-path text inputs,
+ * replacing the plain <datalist> the save-folder fields used before -
+ * the popover matches Obsidian's styling and filters as the user types.
+ * @module settings/FolderSuggest
+ */
+
+import { AbstractInputSuggest } from 'obsidian';
+import type { App } from 'obsidian';
+
+/**
+ * Suggests existing vault folder paths for a text input.
+ */
+export class FolderSuggest extends AbstractInputSuggest<string> {
+	/**
+	 * @param app - Obsidian App instance
+	 * @param textInputEl - The input element to attach suggestions to
+	 * @param folders - Supplier of the current folder paths (read per
+	 *   query so a folder created while the dialog is open still appears)
+	 */
+	constructor(
+		app: App,
+		private readonly textInputEl: HTMLInputElement,
+		private readonly folders: () => string[],
+	) {
+		super(app, textInputEl);
+	}
+
+	protected getSuggestions(query: string): string[] {
+		const lower = query.toLowerCase();
+		return this.folders().filter((folder) =>
+			folder.toLowerCase().includes(lower),
+		);
+	}
+
+	renderSuggestion(value: string, el: HTMLElement): void {
+		el.setText(value);
+	}
+
+	override selectSuggestion(value: string): void {
+		this.setValue(value);
+		// Fire the input event so the wrapping TextComponent's onChange
+		// (which persists the setting) sees the picked value.
+		this.textInputEl.dispatchEvent(new Event('input'));
+		this.close();
+	}
+}

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -17,7 +17,7 @@ import type {
 	AudioRecorderSettings,
 	OutputMode,
 	ConversionLinkAction,
-} from './Settings';
+} from './settingsSchema';
 import {
 	detectSupportedFormats,
 	getSupportedSampleRates,

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -26,6 +26,7 @@ import {
 import { isOfflineEncodingSupported } from '../audio/AudioEncoder';
 import { getEncoderDescription } from '../ui/formatDescriptions';
 import { TestRecorder } from '../recording/TestRecorder';
+import { FolderSuggest } from './FolderSuggest';
 import {
 	DEFAULT_SPLIT_PART_SUFFIX,
 	MIN_SPLIT_CHUNK_MINUTES,
@@ -305,14 +306,9 @@ export class AudioRecorderSettingTab extends PluginSettingTab {
 				'Specify where recordings are saved in your vault. Existing folders are suggested as you type.',
 			)
 			.addText((text) => {
-				const folderOptions = this.getFolderOptions();
-				text.inputEl.setAttribute('list', 'folder-options');
-				const datalist = text.inputEl.createEl('datalist', {
-					attr: { id: 'folder-options' },
-				});
-				folderOptions.forEach((folder) => {
-					datalist.createEl('option', { attr: { value: folder } });
-				});
+				new FolderSuggest(this.app, text.inputEl, () =>
+					this.getFolderOptions(),
+				);
 				text.setValue(this.plugin.settings.saveFolder);
 				text.onChange((value) => {
 					this.plugin.settings.saveFolder = value;

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -23,10 +23,8 @@ import {
 	getSupportedSampleRates,
 	buildMimeType,
 } from '../audio/AudioCapabilityDetector';
-import {
-	getEncoderDescription,
-	isOfflineEncodingSupported,
-} from '../audio/AudioEncoder';
+import { isOfflineEncodingSupported } from '../audio/AudioEncoder';
+import { getEncoderDescription } from '../ui/formatDescriptions';
 import { TestRecorder } from '../recording/TestRecorder';
 import {
 	DEFAULT_SPLIT_PART_SUFFIX,

--- a/src/settings/labels.ts
+++ b/src/settings/labels.ts
@@ -1,0 +1,103 @@
+/**
+ * UI copy for settings-driven dropdowns: display labels and value/label
+ * option lists shared by the settings tab and the transcription modal.
+ * @module settings/labels
+ */
+
+import { LLM_PROVIDER_IDS, TRANSCRIPTION_PROVIDER_IDS } from '../constants';
+import type {
+	TranscriptDestination,
+	TranscriptFileFormat,
+} from '../transcription/TranscriptTypes';
+import type { LlmTask } from '../transcription/llmPostProcess';
+import type { LlmProviderId, TranscriptionProviderId } from './settingsSchema';
+
+/** Display labels for each transcription engine (single source for UI). */
+export const TRANSCRIPTION_PROVIDER_LABELS: Record<
+	TranscriptionProviderId,
+	string
+> = {
+	[TRANSCRIPTION_PROVIDER_IDS.WHISPER_API]: 'Whisper API (OpenAI-compatible)',
+	[TRANSCRIPTION_PROVIDER_IDS.DEEPGRAM]: 'Deepgram',
+	[TRANSCRIPTION_PROVIDER_IDS.GEMINI]: 'Google Gemini',
+	[TRANSCRIPTION_PROVIDER_IDS.LOCAL_WHISPER]: 'Local whisper.cpp (desktop)',
+};
+
+/** Display labels for each transcript destination (single source for UI). */
+export const TRANSCRIPT_DESTINATION_LABELS: Record<
+	TranscriptDestination,
+	string
+> = {
+	note: 'Insert into note',
+	file: 'Save to file',
+	both: 'Note and file',
+	link: 'Save to file and link it in the note',
+};
+
+/** Display labels for each transcript file format (single source for UI). */
+export const TRANSCRIPT_FILE_FORMAT_LABELS: Record<
+	TranscriptFileFormat,
+	string
+> = {
+	json: 'JSON (full data + speakers)',
+	srt: 'SubRip (.srt)',
+	vtt: 'WebVTT (.vtt)',
+	txt: 'Plain text (.txt)',
+};
+
+/** Display labels for each LLM post-processing task (single source for UI). */
+export const LLM_TASK_LABELS: Record<LlmTask, string> = {
+	cleanup: 'Clean up',
+	summary: 'Summarize',
+	custom: 'Custom',
+};
+
+/** Display labels for each LLM provider (single source for the UI). */
+export const LLM_PROVIDER_LABELS: Record<LlmProviderId, string> = {
+	[LLM_PROVIDER_IDS.OPENAI_COMPATIBLE]: 'OpenAI',
+	[LLM_PROVIDER_IDS.ANTHROPIC]: 'Anthropic (Claude)',
+	[LLM_PROVIDER_IDS.GEMINI]: 'Google Gemini',
+};
+
+/** A value/label pair for a dropdown control (single source for the UI). */
+export interface LabeledOption {
+	value: string;
+	label: string;
+}
+
+/**
+ * Builds dropdown options from a label map, preserving key insertion order.
+ * Lets the settings tab and the transcription modal share one source of
+ * truth for both option values and their display labels.
+ * @param labels - Map of value to display label
+ * @returns Ordered value/label option pairs
+ */
+function optionsFromLabels<K extends string>(
+	labels: Record<K, string>,
+): LabeledOption[] {
+	return (Object.keys(labels) as K[]).map((value) => ({
+		value,
+		label: labels[value],
+	}));
+}
+
+/** Engine dropdown options, derived from the engine label map. */
+export const TRANSCRIPTION_PROVIDER_OPTIONS = optionsFromLabels(
+	TRANSCRIPTION_PROVIDER_LABELS,
+);
+
+/** Destination dropdown options, derived from the destination label map. */
+export const TRANSCRIPT_DESTINATION_OPTIONS = optionsFromLabels(
+	TRANSCRIPT_DESTINATION_LABELS,
+);
+
+/** File-format dropdown options, derived from the file-format label map. */
+export const TRANSCRIPT_FILE_FORMAT_OPTIONS = optionsFromLabels(
+	TRANSCRIPT_FILE_FORMAT_LABELS,
+);
+
+/** LLM-task dropdown options, derived from the task label map. */
+export const LLM_TASK_OPTIONS = optionsFromLabels(LLM_TASK_LABELS);
+
+/** LLM-provider dropdown options, derived from the provider label map. */
+export const LLM_PROVIDER_OPTIONS = optionsFromLabels(LLM_PROVIDER_LABELS);

--- a/src/settings/sections/transcriptionSettingsSection.ts
+++ b/src/settings/sections/transcriptionSettingsSection.ts
@@ -25,13 +25,15 @@ import {
 } from '../../constants';
 import {
 	applyLlmProviderDefaults,
+	type TranscriptionProviderId,
+} from '../settingsSchema';
+import {
 	LLM_PROVIDER_OPTIONS,
 	LLM_TASK_OPTIONS,
 	TRANSCRIPT_DESTINATION_OPTIONS,
 	TRANSCRIPT_FILE_FORMAT_OPTIONS,
 	TRANSCRIPTION_PROVIDER_OPTIONS,
-	type TranscriptionProviderId,
-} from '../Settings';
+} from '../labels';
 import {
 	addDropdown,
 	addHeading,

--- a/src/settings/settingControls.ts
+++ b/src/settings/settingControls.ts
@@ -7,7 +7,8 @@
  */
 
 import { Setting } from 'obsidian';
-import type { AudioRecorderSettings, LabeledOption } from './Settings';
+import type { AudioRecorderSettings } from './settingsSchema';
+import type { LabeledOption } from './labels';
 import {
 	addModelToList,
 	ensureSelectedInList,

--- a/src/settings/settingsSchema.ts
+++ b/src/settings/settingsSchema.ts
@@ -1,20 +1,15 @@
 /**
- * Settings interface and default values for the Audio Recorder plugin.
- * @module settings/Settings
+ * Settings type surface and default values for the Audio Recorder plugin.
+ * @module settings/settingsSchema
  */
 
 import type { ConversionLinkAction, OutputMode } from '../types';
-import { SettingsValidationError } from '../errors';
 import {
 	FORMAT_WEBM,
 	DEFAULT_SAMPLE_RATE,
 	DEFAULT_BITRATE,
 	DEFAULT_SPLIT_CHUNK_MINUTES,
 	DEFAULT_SPLIT_PART_SUFFIX,
-	MIN_SPLIT_CHUNK_MINUTES,
-	MAX_SPLIT_CHUNK_MINUTES,
-	SPLIT_PART_SUFFIX_PATTERN,
-	SPLIT_PART_SUFFIX_RULE_TEXT,
 	DEFAULT_TRANSCRIBE_CHUNK_MB,
 	DEFAULT_WHISPER_API_BASE_URL,
 	DEFAULT_WHISPER_API_MODEL,
@@ -45,7 +40,6 @@ import {
 	DEFAULT_CLEANUP_GATE_THRESHOLD_DB,
 	DEFAULT_CLEANUP_LEVELING_MAKEUP_DB,
 } from '../constants';
-import { getDefaultDeviceId } from '../utils/DeviceUtils';
 import type {
 	TranscriptDestination,
 	TranscriptFileFormat,
@@ -268,99 +262,29 @@ export interface AudioRecorderSettings {
 export type TranscriptionProviderId =
 	(typeof TRANSCRIPTION_PROVIDER_IDS)[keyof typeof TRANSCRIPTION_PROVIDER_IDS];
 
-/** Display labels for each transcription engine (single source for UI). */
-export const TRANSCRIPTION_PROVIDER_LABELS: Record<
-	TranscriptionProviderId,
-	string
-> = {
-	[TRANSCRIPTION_PROVIDER_IDS.WHISPER_API]: 'Whisper API (OpenAI-compatible)',
-	[TRANSCRIPTION_PROVIDER_IDS.DEEPGRAM]: 'Deepgram',
-	[TRANSCRIPTION_PROVIDER_IDS.GEMINI]: 'Google Gemini',
-	[TRANSCRIPTION_PROVIDER_IDS.LOCAL_WHISPER]: 'Local whisper.cpp (desktop)',
-};
-
-/** Display labels for each transcript destination (single source for UI). */
-export const TRANSCRIPT_DESTINATION_LABELS: Record<
-	TranscriptDestination,
-	string
-> = {
-	note: 'Insert into note',
-	file: 'Save to file',
-	both: 'Note and file',
-	link: 'Save to file and link it in the note',
-};
-
-/** Display labels for each transcript file format (single source for UI). */
-export const TRANSCRIPT_FILE_FORMAT_LABELS: Record<
-	TranscriptFileFormat,
-	string
-> = {
-	json: 'JSON (full data + speakers)',
-	srt: 'SubRip (.srt)',
-	vtt: 'WebVTT (.vtt)',
-	txt: 'Plain text (.txt)',
-};
-
-/** Display labels for each LLM post-processing task (single source for UI). */
-export const LLM_TASK_LABELS: Record<LlmTask, string> = {
-	cleanup: 'Clean up',
-	summary: 'Summarize',
-	custom: 'Custom',
-};
-
 /** LLM post-processing provider identifier (derived from {@link LLM_PROVIDER_IDS}). */
 export type LlmProviderId =
 	(typeof LLM_PROVIDER_IDS)[keyof typeof LLM_PROVIDER_IDS];
 
-/** Display labels for each LLM provider (single source for the UI). */
-export const LLM_PROVIDER_LABELS: Record<LlmProviderId, string> = {
-	[LLM_PROVIDER_IDS.OPENAI_COMPATIBLE]: 'OpenAI',
-	[LLM_PROVIDER_IDS.ANTHROPIC]: 'Anthropic (Claude)',
-	[LLM_PROVIDER_IDS.GEMINI]: 'Google Gemini',
-};
-
-/** A value/label pair for a dropdown control (single source for the UI). */
-export interface LabeledOption {
-	value: string;
-	label: string;
+/**
+ * Partial settings as accepted from storage or callers; track sources may
+ * arrive as a Map or as the serialized record form.
+ */
+export interface AudioRecorderSettingsInput extends Partial<
+	Omit<AudioRecorderSettings, 'trackAudioSources'>
+> {
+	trackAudioSources?: TrackAudioSources | TrackAudioSourcesRecord;
 }
 
 /**
- * Builds dropdown options from a label map, preserving key insertion order.
- * Lets the settings tab and the transcription modal share one source of
- * truth for both option values and their display labels.
- * @param labels - Map of value to display label
- * @returns Ordered value/label option pairs
+ * Settings shape as persisted to disk (track sources flattened to a record).
  */
-function optionsFromLabels<K extends string>(
-	labels: Record<K, string>,
-): LabeledOption[] {
-	return (Object.keys(labels) as K[]).map((value) => ({
-		value,
-		label: labels[value],
-	}));
+export interface SerializedAudioRecorderSettings extends Omit<
+	AudioRecorderSettings,
+	'trackAudioSources'
+> {
+	trackAudioSources: Record<number, string>;
 }
-
-/** Engine dropdown options, derived from the engine label map. */
-export const TRANSCRIPTION_PROVIDER_OPTIONS = optionsFromLabels(
-	TRANSCRIPTION_PROVIDER_LABELS,
-);
-
-/** Destination dropdown options, derived from the destination label map. */
-export const TRANSCRIPT_DESTINATION_OPTIONS = optionsFromLabels(
-	TRANSCRIPT_DESTINATION_LABELS,
-);
-
-/** File-format dropdown options, derived from the file-format label map. */
-export const TRANSCRIPT_FILE_FORMAT_OPTIONS = optionsFromLabels(
-	TRANSCRIPT_FILE_FORMAT_LABELS,
-);
-
-/** LLM-task dropdown options, derived from the task label map. */
-export const LLM_TASK_OPTIONS = optionsFromLabels(LLM_TASK_LABELS);
-
-/** LLM-provider dropdown options, derived from the provider label map. */
-export const LLM_PROVIDER_OPTIONS = optionsFromLabels(LLM_PROVIDER_LABELS);
 
 /**
  * Default plugin settings.
@@ -502,241 +426,4 @@ export function applyLlmProviderDefaults(
 		settings.llmBaseUrl = DEFAULT_LLM_OPENAI_BASE_URL;
 	}
 	return settings;
-}
-
-export interface AudioRecorderSettingsInput extends Partial<
-	Omit<AudioRecorderSettings, 'trackAudioSources'>
-> {
-	trackAudioSources?: TrackAudioSources | TrackAudioSourcesRecord;
-}
-
-export interface SerializedAudioRecorderSettings extends Omit<
-	AudioRecorderSettings,
-	'trackAudioSources'
-> {
-	trackAudioSources: Record<number, string>;
-}
-
-/**
- * Normalizes track audio sources into a Map.
- */
-export function normalizeTrackAudioSources(
-	trackAudioSources?: TrackAudioSources | TrackAudioSourcesRecord,
-): TrackAudioSources {
-	if (!trackAudioSources) {
-		return new Map();
-	}
-
-	if (trackAudioSources instanceof Map) {
-		return new Map(trackAudioSources);
-	}
-
-	const sources = new Map<number, AudioSource>();
-	for (const [key, value] of Object.entries(trackAudioSources)) {
-		const trackNumber = Number(key);
-		if (Number.isNaN(trackNumber)) {
-			continue;
-		}
-		if (typeof value === 'string') {
-			sources.set(trackNumber, { deviceId: value });
-			continue;
-		}
-		if (value && typeof value === 'object' && 'deviceId' in value) {
-			const deviceId = (value as { deviceId?: unknown }).deviceId;
-			sources.set(trackNumber, {
-				deviceId: typeof deviceId === 'string' ? deviceId : '',
-			});
-		}
-	}
-	return sources;
-}
-
-/**
- * Serializes track audio sources into a plain object.
- */
-export function serializeTrackAudioSources(
-	trackAudioSources: TrackAudioSources,
-): Record<number, string> {
-	const serialized: Record<number, string> = {};
-	for (const [trackNumber, source] of trackAudioSources.entries()) {
-		serialized[trackNumber] = source.deviceId;
-	}
-	return serialized;
-}
-
-/**
- * Serializes settings for persistence.
- */
-export function serializeSettings(
-	settings: AudioRecorderSettings,
-): SerializedAudioRecorderSettings {
-	return {
-		...settings,
-		trackAudioSources: serializeTrackAudioSources(
-			settings.trackAudioSources,
-		),
-	};
-}
-
-/**
- * Merges user settings with defaults.
- * @param userSettings - Partial user settings
- * @returns Complete settings object
- */
-export function mergeSettings(
-	userSettings: AudioRecorderSettingsInput = {},
-): AudioRecorderSettings {
-	const merged: AudioRecorderSettings = {
-		...DEFAULT_SETTINGS,
-		...userSettings,
-		trackAudioSources: normalizeTrackAudioSources(
-			userSettings.trackAudioSources,
-		),
-	};
-	migrateLegacyLlmSettings(merged, userSettings);
-	return merged;
-}
-
-/**
- * Carries forward settings saved under the pre-rework LLM schema. The old
- * single `llmApiKey` maps onto the new per-vendor key (OpenAI reuses
- * `whisperApiKey`, Gemini reuses `geminiApiKey`, Anthropic uses its own
- * `anthropicApiKey`), and the old single `llmModel` maps onto the selected
- * model of the stored provider. The superseded flat fields are then dropped so
- * a later save does not persist them. A vendor key already set is never
- * overwritten, so the migration cannot clobber a freshly entered token.
- * @param merged - The merged settings to migrate in place
- * @param raw - The raw user settings as loaded from disk
- */
-function migrateLegacyLlmSettings(
-	merged: AudioRecorderSettings,
-	raw: AudioRecorderSettingsInput,
-): void {
-	const legacy = raw as unknown as Record<string, unknown>;
-	const legacyKey =
-		typeof legacy.llmApiKey === 'string' ? legacy.llmApiKey : '';
-	if (legacyKey) {
-		if (
-			merged.llmProvider === LLM_PROVIDER_IDS.ANTHROPIC &&
-			!merged.anthropicApiKey
-		) {
-			merged.anthropicApiKey = legacyKey;
-		} else if (
-			merged.llmProvider === LLM_PROVIDER_IDS.GEMINI &&
-			!merged.geminiApiKey
-		) {
-			merged.geminiApiKey = legacyKey;
-		} else if (
-			merged.llmProvider === LLM_PROVIDER_IDS.OPENAI_COMPATIBLE &&
-			!merged.whisperApiKey
-		) {
-			merged.whisperApiKey = legacyKey;
-		}
-	}
-	const legacyModel =
-		typeof legacy.llmModel === 'string' ? legacy.llmModel.trim() : '';
-	if (legacyModel) {
-		if (merged.llmProvider === LLM_PROVIDER_IDS.ANTHROPIC) {
-			merged.llmAnthropicModel = legacyModel;
-		} else if (merged.llmProvider === LLM_PROVIDER_IDS.GEMINI) {
-			merged.llmGeminiModel = legacyModel;
-		} else {
-			merged.llmOpenAiModel = legacyModel;
-		}
-	}
-	// Drop the superseded flat fields so a later save does not persist them.
-	const mergedRecord = merged as unknown as Record<string, unknown>;
-	delete mergedRecord.llmApiKey;
-	delete mergedRecord.llmModel;
-}
-
-/**
- * Async version of mergeSettings that detects and sets the default audio device
- * if no device is configured. This should be called during plugin initialization
- * to ensure a default device is selected for first-time users.
- * @param userSettings - Partial user settings from storage
- * @returns Complete settings object with default device if needed
- */
-export async function mergeSettingsAsync(
-	userSettings: AudioRecorderSettingsInput = {},
-): Promise<AudioRecorderSettings> {
-	const merged = mergeSettings(userSettings);
-
-	// Auto-select default device if no device is configured
-	if (!merged.audioDeviceId || merged.audioDeviceId.trim() === '') {
-		const defaultDeviceId = await getDefaultDeviceId();
-		if (defaultDeviceId) {
-			merged.audioDeviceId = defaultDeviceId;
-		}
-	}
-
-	return merged;
-}
-
-/**
- * Validates audio recorder settings before use.
- * @param settings - Settings to validate
- * @throws SettingsValidationError if any setting is invalid
- */
-export function validateSettings(settings: AudioRecorderSettings): void {
-	if (!settings.audioDeviceId || settings.audioDeviceId.trim() === '') {
-		throw new SettingsValidationError(
-			'audioDeviceId',
-			'Audio device is not selected. Please select an audio input device in plugin settings.',
-		);
-	}
-
-	if (!settings.sampleRate || settings.sampleRate <= 0) {
-		throw new SettingsValidationError(
-			'sampleRate',
-			'Sample rate must be a positive number.',
-		);
-	}
-
-	if (!settings.recordingFormat || settings.recordingFormat.trim() === '') {
-		throw new SettingsValidationError(
-			'recordingFormat',
-			'Recording format is not selected.',
-		);
-	}
-
-	if (!SPLIT_PART_SUFFIX_PATTERN.test(settings.splitPartSuffix)) {
-		throw new SettingsValidationError(
-			'splitPartSuffix',
-			SPLIT_PART_SUFFIX_RULE_TEXT,
-		);
-	}
-
-	// Validated regardless of autoSplitEnabled: the value is also the
-	// default part duration for manual splitting. Runtime paths still
-	// clamp/sanitize defensively (clampSplitMinutes, sanitizePartSuffix)
-	// because validateSettings is not on the production load path.
-	if (
-		!Number.isInteger(settings.splitChunkMinutes) ||
-		settings.splitChunkMinutes < MIN_SPLIT_CHUNK_MINUTES ||
-		settings.splitChunkMinutes > MAX_SPLIT_CHUNK_MINUTES
-	) {
-		throw new SettingsValidationError(
-			'splitChunkMinutes',
-			`Part duration must be an integer between ${String(MIN_SPLIT_CHUNK_MINUTES)} and ${String(MAX_SPLIT_CHUNK_MINUTES)} minutes.`,
-		);
-	}
-
-	if (settings.enableMultiTrack) {
-		const trackCount = settings.trackAudioSources.size;
-		if (trackCount === 0) {
-			throw new SettingsValidationError(
-				'trackAudioSources',
-				'Multi-track recording is enabled but no audio sources are selected.',
-			);
-		}
-		for (const [trackNum, source] of settings.trackAudioSources.entries()) {
-			if (!source.deviceId || source.deviceId.trim() === '') {
-				throw new SettingsValidationError(
-					`trackAudioSources[${trackNum}]`,
-					`Track ${trackNum} has no audio source selected.`,
-				);
-			}
-		}
-	}
 }

--- a/src/settings/settingsSerialization.ts
+++ b/src/settings/settingsSerialization.ts
@@ -1,0 +1,173 @@
+/**
+ * Settings persistence: serialization to disk shape, merging stored values
+ * with defaults, and migration of superseded schema versions.
+ * @module settings/settingsSerialization
+ */
+
+import { LLM_PROVIDER_IDS } from '../constants';
+import { getDefaultDeviceId } from '../utils/DeviceUtils';
+import {
+	DEFAULT_SETTINGS,
+	type AudioRecorderSettings,
+	type AudioRecorderSettingsInput,
+	type AudioSource,
+	type SerializedAudioRecorderSettings,
+	type TrackAudioSources,
+	type TrackAudioSourcesRecord,
+} from './settingsSchema';
+
+/**
+ * Normalizes track audio sources into a Map.
+ */
+export function normalizeTrackAudioSources(
+	trackAudioSources?: TrackAudioSources | TrackAudioSourcesRecord,
+): TrackAudioSources {
+	if (!trackAudioSources) {
+		return new Map();
+	}
+
+	if (trackAudioSources instanceof Map) {
+		return new Map(trackAudioSources);
+	}
+
+	const sources = new Map<number, AudioSource>();
+	for (const [key, value] of Object.entries(trackAudioSources)) {
+		const trackNumber = Number(key);
+		if (Number.isNaN(trackNumber)) {
+			continue;
+		}
+		if (typeof value === 'string') {
+			sources.set(trackNumber, { deviceId: value });
+			continue;
+		}
+		if (value && typeof value === 'object' && 'deviceId' in value) {
+			const deviceId = (value as { deviceId?: unknown }).deviceId;
+			sources.set(trackNumber, {
+				deviceId: typeof deviceId === 'string' ? deviceId : '',
+			});
+		}
+	}
+	return sources;
+}
+
+/**
+ * Serializes track audio sources into a plain object.
+ */
+export function serializeTrackAudioSources(
+	trackAudioSources: TrackAudioSources,
+): Record<number, string> {
+	const serialized: Record<number, string> = {};
+	for (const [trackNumber, source] of trackAudioSources.entries()) {
+		serialized[trackNumber] = source.deviceId;
+	}
+	return serialized;
+}
+
+/**
+ * Serializes settings for persistence.
+ */
+export function serializeSettings(
+	settings: AudioRecorderSettings,
+): SerializedAudioRecorderSettings {
+	return {
+		...settings,
+		trackAudioSources: serializeTrackAudioSources(
+			settings.trackAudioSources,
+		),
+	};
+}
+
+/**
+ * Merges user settings with defaults.
+ * @param userSettings - Partial user settings
+ * @returns Complete settings object
+ */
+export function mergeSettings(
+	userSettings: AudioRecorderSettingsInput = {},
+): AudioRecorderSettings {
+	const merged: AudioRecorderSettings = {
+		...DEFAULT_SETTINGS,
+		...userSettings,
+		trackAudioSources: normalizeTrackAudioSources(
+			userSettings.trackAudioSources,
+		),
+	};
+	migrateLegacyLlmSettings(merged, userSettings);
+	return merged;
+}
+
+/**
+ * Carries forward settings saved under the pre-rework LLM schema. The old
+ * single `llmApiKey` maps onto the new per-vendor key (OpenAI reuses
+ * `whisperApiKey`, Gemini reuses `geminiApiKey`, Anthropic uses its own
+ * `anthropicApiKey`), and the old single `llmModel` maps onto the selected
+ * model of the stored provider. The superseded flat fields are then dropped so
+ * a later save does not persist them. A vendor key already set is never
+ * overwritten, so the migration cannot clobber a freshly entered token.
+ * @param merged - The merged settings to migrate in place
+ * @param raw - The raw user settings as loaded from disk
+ */
+function migrateLegacyLlmSettings(
+	merged: AudioRecorderSettings,
+	raw: AudioRecorderSettingsInput,
+): void {
+	const legacy = raw as unknown as Record<string, unknown>;
+	const legacyKey =
+		typeof legacy.llmApiKey === 'string' ? legacy.llmApiKey : '';
+	if (legacyKey) {
+		if (
+			merged.llmProvider === LLM_PROVIDER_IDS.ANTHROPIC &&
+			!merged.anthropicApiKey
+		) {
+			merged.anthropicApiKey = legacyKey;
+		} else if (
+			merged.llmProvider === LLM_PROVIDER_IDS.GEMINI &&
+			!merged.geminiApiKey
+		) {
+			merged.geminiApiKey = legacyKey;
+		} else if (
+			merged.llmProvider === LLM_PROVIDER_IDS.OPENAI_COMPATIBLE &&
+			!merged.whisperApiKey
+		) {
+			merged.whisperApiKey = legacyKey;
+		}
+	}
+	const legacyModel =
+		typeof legacy.llmModel === 'string' ? legacy.llmModel.trim() : '';
+	if (legacyModel) {
+		if (merged.llmProvider === LLM_PROVIDER_IDS.ANTHROPIC) {
+			merged.llmAnthropicModel = legacyModel;
+		} else if (merged.llmProvider === LLM_PROVIDER_IDS.GEMINI) {
+			merged.llmGeminiModel = legacyModel;
+		} else {
+			merged.llmOpenAiModel = legacyModel;
+		}
+	}
+	// Drop the superseded flat fields so a later save does not persist them.
+	const mergedRecord = merged as unknown as Record<string, unknown>;
+	delete mergedRecord.llmApiKey;
+	delete mergedRecord.llmModel;
+}
+
+/**
+ * Async version of mergeSettings that detects and sets the default audio device
+ * if no device is configured. This should be called during plugin initialization
+ * to ensure a default device is selected for first-time users.
+ * @param userSettings - Partial user settings from storage
+ * @returns Complete settings object with default device if needed
+ */
+export async function mergeSettingsAsync(
+	userSettings: AudioRecorderSettingsInput = {},
+): Promise<AudioRecorderSettings> {
+	const merged = mergeSettings(userSettings);
+
+	// Auto-select default device if no device is configured
+	if (!merged.audioDeviceId || merged.audioDeviceId.trim() === '') {
+		const defaultDeviceId = await getDefaultDeviceId();
+		if (defaultDeviceId) {
+			merged.audioDeviceId = defaultDeviceId;
+		}
+	}
+
+	return merged;
+}

--- a/src/settings/settingsSerialization.ts
+++ b/src/settings/settingsSerialization.ts
@@ -5,6 +5,7 @@
  */
 
 import { LLM_PROVIDER_IDS } from '../constants';
+import { isRecord } from '../utils/objects';
 import { getDefaultDeviceId } from '../utils/DeviceUtils';
 import {
 	DEFAULT_SETTINGS,
@@ -111,7 +112,7 @@ function migrateLegacyLlmSettings(
 	merged: AudioRecorderSettings,
 	raw: AudioRecorderSettingsInput,
 ): void {
-	const legacy = raw as unknown as Record<string, unknown>;
+	const legacy: Record<string, unknown> = isRecord(raw) ? raw : {};
 	const legacyKey =
 		typeof legacy.llmApiKey === 'string' ? legacy.llmApiKey : '';
 	if (legacyKey) {
@@ -144,9 +145,10 @@ function migrateLegacyLlmSettings(
 		}
 	}
 	// Drop the superseded flat fields so a later save does not persist them.
-	const mergedRecord = merged as unknown as Record<string, unknown>;
-	delete mergedRecord.llmApiKey;
-	delete mergedRecord.llmModel;
+	if (isRecord(merged)) {
+		delete merged.llmApiKey;
+		delete merged.llmModel;
+	}
 }
 
 /**

--- a/src/settings/settingsValidation.ts
+++ b/src/settings/settingsValidation.ts
@@ -1,0 +1,83 @@
+/**
+ * Recording-path settings validation. Player-window settings deliberately
+ * stay out of here (see player/playerSettings.ts): they are unrelated to
+ * recording and must never throw on the recording path.
+ * @module settings/settingsValidation
+ */
+
+import { SettingsValidationError } from '../errors';
+import {
+	MIN_SPLIT_CHUNK_MINUTES,
+	MAX_SPLIT_CHUNK_MINUTES,
+	SPLIT_PART_SUFFIX_PATTERN,
+	SPLIT_PART_SUFFIX_RULE_TEXT,
+} from '../constants';
+import type { AudioRecorderSettings } from './settingsSchema';
+
+/**
+ * Validates audio recorder settings before use.
+ * @param settings - Settings to validate
+ * @throws SettingsValidationError if any setting is invalid
+ */
+export function validateSettings(settings: AudioRecorderSettings): void {
+	if (!settings.audioDeviceId || settings.audioDeviceId.trim() === '') {
+		throw new SettingsValidationError(
+			'audioDeviceId',
+			'Audio device is not selected. Please select an audio input device in plugin settings.',
+		);
+	}
+
+	if (!settings.sampleRate || settings.sampleRate <= 0) {
+		throw new SettingsValidationError(
+			'sampleRate',
+			'Sample rate must be a positive number.',
+		);
+	}
+
+	if (!settings.recordingFormat || settings.recordingFormat.trim() === '') {
+		throw new SettingsValidationError(
+			'recordingFormat',
+			'Recording format is not selected.',
+		);
+	}
+
+	if (!SPLIT_PART_SUFFIX_PATTERN.test(settings.splitPartSuffix)) {
+		throw new SettingsValidationError(
+			'splitPartSuffix',
+			SPLIT_PART_SUFFIX_RULE_TEXT,
+		);
+	}
+
+	// Validated regardless of autoSplitEnabled: the value is also the
+	// default part duration for manual splitting. Runtime paths still
+	// clamp/sanitize defensively (clampSplitMinutes, sanitizePartSuffix)
+	// because validateSettings is not on the production load path.
+	if (
+		!Number.isInteger(settings.splitChunkMinutes) ||
+		settings.splitChunkMinutes < MIN_SPLIT_CHUNK_MINUTES ||
+		settings.splitChunkMinutes > MAX_SPLIT_CHUNK_MINUTES
+	) {
+		throw new SettingsValidationError(
+			'splitChunkMinutes',
+			`Part duration must be an integer between ${String(MIN_SPLIT_CHUNK_MINUTES)} and ${String(MAX_SPLIT_CHUNK_MINUTES)} minutes.`,
+		);
+	}
+
+	if (settings.enableMultiTrack) {
+		const trackCount = settings.trackAudioSources.size;
+		if (trackCount === 0) {
+			throw new SettingsValidationError(
+				'trackAudioSources',
+				'Multi-track recording is enabled but no audio sources are selected.',
+			);
+		}
+		for (const [trackNum, source] of settings.trackAudioSources.entries()) {
+			if (!source.deviceId || source.deviceId.trim() === '') {
+				throw new SettingsValidationError(
+					`trackAudioSources[${trackNum}]`,
+					`Track ${trackNum} has no audio source selected.`,
+				);
+			}
+		}
+	}
+}

--- a/src/transcription/TranscriptionService.ts
+++ b/src/transcription/TranscriptionService.ts
@@ -52,6 +52,12 @@ import type { Transcript } from './TranscriptTypes';
 /** Cooperative cancellation signal checked between chunks. */
 export interface CancellationToken {
 	isCancelled(): boolean;
+	/**
+	 * Optional abort signal that fires when the run is cancelled, so
+	 * in-flight HTTP requests can be aborted immediately instead of only
+	 * being checked between chunks.
+	 */
+	signal?: AbortSignal;
 }
 
 /** A token that is never cancelled. */
@@ -145,6 +151,9 @@ export class TranscriptionService {
 					: undefined,
 			diarize,
 			wordTimestamps: settings.transcriptionWordTimestamps,
+			// Providers on abortable transports stop the in-flight request
+			// the moment the user cancels, not at the next chunk boundary.
+			signal: token.signal,
 		};
 
 		options.onProgress?.(0, 'Preparing audio...');
@@ -324,7 +333,7 @@ export class TranscriptionService {
 		// Materialize this payload's bytes only now, so a multi-chunk job never
 		// holds more than one chunk's WAV in memory at a time.
 		const payload: AudioPayload = {
-			data: prepared.createData(),
+			data: await prepared.createData(),
 			contentType: prepared.contentType,
 			filename: prepared.filename,
 			offsetSeconds: prepared.offsetSeconds,
@@ -341,9 +350,14 @@ export class TranscriptionService {
 				}),
 			});
 		} catch (error) {
-			// A cancel aborts the whole run; never salvage past it.
+			// A cancel aborts the whole run; never salvage past it. An abort
+			// of the in-flight request surfaces as a transport error, so map
+			// it back to the cancellation the user asked for.
 			if (error instanceof TranscriptionCancelledError) {
 				throw error;
+			}
+			if (token.isCancelled()) {
+				throw new TranscriptionCancelledError();
 			}
 			// The part overran the provider's output token budget. Retrying it as
 			// smaller pieces keeps each piece's output under the cap, so a dense

--- a/src/transcription/TranscriptionService.ts
+++ b/src/transcription/TranscriptionService.ts
@@ -13,6 +13,7 @@
 import { Notice } from 'obsidian';
 import type { App, TFile } from 'obsidian';
 import {
+	BYTES_PER_MB,
 	PLUGIN_LOG_PREFIX,
 	TRANSCRIBE_CHUNK_PROGRESS_CEILING,
 } from '../constants';
@@ -155,7 +156,7 @@ export class TranscriptionService {
 			audioPrepOptions(
 				provider.capabilities,
 				provider.requiresNetwork,
-				Math.max(1, settings.transcriptionChunkMb) * 1024 * 1024,
+				Math.max(1, settings.transcriptionChunkMb) * BYTES_PER_MB,
 				transcribeOptions.diarize,
 			),
 		);

--- a/src/transcription/TranscriptionService.ts
+++ b/src/transcription/TranscriptionService.ts
@@ -189,17 +189,19 @@ export class TranscriptionService {
 		const failedParts: { label: string; message: string }[] = [];
 		for (let i = 0; i < partCount; i++) {
 			this.throwIfCancelled(token);
+			const payload = payloads[i];
+			if (!payload) {
+				continue;
+			}
 			const partLabel =
-				partCount > 1
-					? this.describePart(payloads[i], i, partCount)
-					: '';
+				partCount > 1 ? this.describePart(payload, i, partCount) : '';
 			options.onProgress?.(
 				(i / partCount) * TRANSCRIBE_CHUNK_PROGRESS_CEILING,
 				partLabel ? `Transcribing ${partLabel}...` : 'Transcribing...',
 			);
 			await this.transcribePart(
 				provider,
-				payloads[i],
+				payload,
 				transcribeOptions,
 				token,
 				partLabel,
@@ -261,7 +263,7 @@ export class TranscriptionService {
 			new Notice(
 				`Some audio could not be transcribed (${labels}) and is missing ` +
 					'from the transcript; saving the parts that succeeded. ' +
-					failedParts[0].message,
+					(failedParts[0]?.message ?? ''),
 			);
 		}
 

--- a/src/transcription/TranscriptionService.ts
+++ b/src/transcription/TranscriptionService.ts
@@ -16,7 +16,7 @@ import {
 	PLUGIN_LOG_PREFIX,
 	TRANSCRIBE_CHUNK_PROGRESS_CEILING,
 } from '../constants';
-import type { AudioRecorderSettings } from '../settings/Settings';
+import type { AudioRecorderSettings } from '../settings/settingsSchema';
 import {
 	audioMimeFromExtension,
 	audioPrepOptions,

--- a/src/transcription/api.ts
+++ b/src/transcription/api.ts
@@ -1,0 +1,21 @@
+/**
+ * Public API of the transcription domain for the UI layer. Modals and other
+ * presentation code import from here instead of reaching into individual
+ * transcription modules, so the domain's internal layout can change without
+ * touching the UI.
+ * @module transcription/api
+ */
+
+export { transcribeFile } from './runTranscription';
+export {
+	effectiveDiarize,
+	providerSupportsDiarization,
+} from './providers/capabilities';
+export { effectiveTranscriptDestination } from './transcriptOutput';
+export { TranscriptionCancelledError } from './TranscriptionService';
+export type { CancellationToken } from './TranscriptionService';
+export type {
+	TranscriptDestination,
+	TranscriptFileFormat,
+} from './TranscriptTypes';
+export type { LlmTask } from './llmPostProcess';

--- a/src/transcription/audioChunks.ts
+++ b/src/transcription/audioChunks.ts
@@ -50,7 +50,7 @@ export async function encodeMonoWav(
 	for (let start = 0; start < samples.length; start += ENCODE_YIELD_FRAMES) {
 		const end = Math.min(samples.length, start + ENCODE_YIELD_FRAMES);
 		for (let i = start; i < end; i++) {
-			view.setInt16(i * 2, floatToInt16(samples[i]), true);
+			view.setInt16(i * 2, floatToInt16(samples[i] ?? 0), true);
 		}
 		if (end < samples.length) {
 			await yieldToEventLoop();

--- a/src/transcription/audioChunks.ts
+++ b/src/transcription/audioChunks.ts
@@ -15,15 +15,31 @@ const WAV_MONO_CHANNEL_COUNT = 1;
 import { decodeAudioBlob } from '../audio/AudioFormatConverter';
 
 /**
+ * Frames converted per synchronous slice of {@link encodeMonoWav} before
+ * yielding to the event loop. A 25 MB Whisper chunk is ~12.5M frames;
+ * without the yields that loop runs hundreds of milliseconds on the UI
+ * thread in one block. Half a million frames is a few milliseconds of
+ * work per slice.
+ */
+const ENCODE_YIELD_FRAMES = 500_000;
+
+/** Lets the UI thread breathe between conversion slices. */
+function yieldToEventLoop(): Promise<void> {
+	return new Promise((resolve) => window.setTimeout(resolve, 0));
+}
+
+/**
  * Encodes mono Float32 samples (range -1..1) into a 16-bit PCM WAV blob.
+ * The float-to-int16 conversion runs in slices with an event-loop yield
+ * between them, so encoding a large upload chunk does not jank the UI.
  * @param samples - Mono sample data
  * @param sampleRate - Sample rate in Hz
  * @returns WAV-encoded bytes
  */
-export function encodeMonoWav(
+export async function encodeMonoWav(
 	samples: Float32Array,
 	sampleRate: number,
-): ArrayBuffer {
+): Promise<ArrayBuffer> {
 	const pcmByteLength = samples.length * 2;
 	const out = createWavFileBuffer(
 		WAV_MONO_CHANNEL_COUNT,
@@ -31,8 +47,14 @@ export function encodeMonoWav(
 		pcmByteLength,
 	);
 	const view = new DataView(out, WAV_HEADER_SIZE);
-	for (let i = 0; i < samples.length; i++) {
-		view.setInt16(i * 2, floatToInt16(samples[i]), true);
+	for (let start = 0; start < samples.length; start += ENCODE_YIELD_FRAMES) {
+		const end = Math.min(samples.length, start + ENCODE_YIELD_FRAMES);
+		for (let i = start; i < end; i++) {
+			view.setInt16(i * 2, floatToInt16(samples[i]), true);
+		}
+		if (end < samples.length) {
+			await yieldToEventLoop();
+		}
 	}
 	return out;
 }
@@ -153,7 +175,7 @@ export async function decodeToMono16k(
 export function extractChunkWav(
 	samples: Float32Array,
 	chunk: ChunkPlan,
-): ArrayBuffer {
+): Promise<ArrayBuffer> {
 	// Round both ends the same way so adjacent chunks tile exactly - a shared
 	// boundary maps to one frame, with no duplicated or dropped sample.
 	const startFrame = Math.min(

--- a/src/transcription/audioChunks.ts
+++ b/src/transcription/audioChunks.ts
@@ -9,6 +9,9 @@
 import { TRANSCRIBE_BYTES_PER_SEC, TRANSCRIBE_SAMPLE_RATE } from '../constants';
 import { createWavFileBuffer, WAV_HEADER_SIZE } from '../audio/WavEncoder';
 import { floatToInt16 } from '../audio/pcm';
+
+/** Channel count of the mono WAV uploads produced for transcription. */
+const WAV_MONO_CHANNEL_COUNT = 1;
 import { decodeAudioBlob } from '../audio/AudioFormatConverter';
 
 /**
@@ -22,7 +25,11 @@ export function encodeMonoWav(
 	sampleRate: number,
 ): ArrayBuffer {
 	const pcmByteLength = samples.length * 2;
-	const out = createWavFileBuffer(1, sampleRate, pcmByteLength);
+	const out = createWavFileBuffer(
+		WAV_MONO_CHANNEL_COUNT,
+		sampleRate,
+		pcmByteLength,
+	);
 	const view = new DataView(out, WAV_HEADER_SIZE);
 	for (let i = 0; i < samples.length; i++) {
 		view.setInt16(i * 2, floatToInt16(samples[i]), true);

--- a/src/transcription/audioPrep.ts
+++ b/src/transcription/audioPrep.ts
@@ -78,7 +78,7 @@ export interface PreparedPayload {
 	 */
 	endSeconds?: number;
 	/** Builds the upload bytes; invoked once, right before uploading. */
-	createData(): ArrayBuffer;
+	createData(): ArrayBuffer | Promise<ArrayBuffer>;
 	/**
 	 * Splits this payload into smaller payloads covering the same audio, for a
 	 * provider that overran its output token budget on this part. Present only on
@@ -197,6 +197,13 @@ export async function prepareAudio(
 		};
 	}
 
+	// The full decoded PCM stays alive for the whole run (~230 MB for an
+	// hour at 16 kHz mono, audit finding 6.8): each chunk's WAV is
+	// materialized lazily from a non-copying subarray view, and keeping the
+	// samples is what lets a part be re-split on demand when a provider
+	// overruns its output token budget. A decode-per-chunk scheme would
+	// drop the retention but re-decode the file once per chunk; revisit if
+	// long-recording memory pressure ever outweighs that trade.
 	const samples = await decodeToMono16k(raw);
 	const totalSeconds = samples.length / TRANSCRIBE_SAMPLE_RATE;
 	const plans = planChunks(totalSeconds, options.chunkBytes);

--- a/src/transcription/factories.ts
+++ b/src/transcription/factories.ts
@@ -9,7 +9,7 @@ import {
 	MS_PER_MINUTE,
 	TRANSCRIPTION_PROVIDER_IDS,
 } from '../constants';
-import type { AudioRecorderSettings } from '../settings/Settings';
+import type { AudioRecorderSettings } from '../settings/settingsSchema';
 import { WhisperApiProvider } from './providers/WhisperApiProvider';
 import { LocalWhisperProvider } from './providers/LocalWhisperProvider';
 import { DeepgramProvider } from './providers/DeepgramProvider';

--- a/src/transcription/httpClient.ts
+++ b/src/transcription/httpClient.ts
@@ -12,6 +12,7 @@ import {
 	TRANSCRIBE_REQUEST_TIMEOUT_MS,
 	TRANSCRIBE_UPLOAD_BYTES_PER_MS,
 } from '../constants';
+import { randomToken } from '../utils/ids';
 
 /** One field of a multipart/form-data body. */
 export type MultipartField =
@@ -36,7 +37,7 @@ export interface MultipartBody {
  * @returns The encoded body and the matching content-type header value
  */
 export function buildMultipart(fields: MultipartField[]): MultipartBody {
-	const boundary = `----aar${Math.random().toString(16).slice(2)}${String(Date.now())}`;
+	const boundary = `----aar${randomToken()}${String(Date.now())}`;
 	const encoder = new TextEncoder();
 	const chunks: Uint8Array[] = [];
 	const pushText = (text: string): void => {

--- a/src/transcription/httpClient.ts
+++ b/src/transcription/httpClient.ts
@@ -214,6 +214,124 @@ function withTimeout(
 }
 
 /**
+ * The response surface both transports provide. Structurally a subset of
+ * Obsidian's RequestUrlResponse, so the requestUrl path returns its
+ * response unchanged while the fetch path builds a compatible object.
+ */
+export interface HttpResponse {
+	status: number;
+	headers: Record<string, string>;
+	text: string;
+}
+
+/**
+ * Performs the request through `fetch`, which - unlike `requestUrl` -
+ * honors an AbortSignal, so pressing Cancel releases the socket and the
+ * in-flight request body immediately instead of after the timeout. The
+ * timeout aborts through the same controller. Only usable against
+ * endpoints that allow browser (CORS) requests; the caller falls back to
+ * `requestUrl` when the endpoint refuses.
+ * @param options - Request options (signal set by the caller)
+ * @param timeoutMs - Deadline in milliseconds
+ * @param safeUrl - Query-stripped URL for error messages
+ */
+async function fetchResponse(
+	options: RequestOptions,
+	timeoutMs: number,
+	safeUrl: string,
+): Promise<HttpResponse> {
+	const controller = new AbortController();
+	let timedOut = false;
+	const timer = window.setTimeout(() => {
+		timedOut = true;
+		controller.abort();
+	}, timeoutMs);
+	const outer = options.signal;
+	const onOuterAbort = (): void => {
+		controller.abort();
+	};
+	if (outer?.aborted) {
+		controller.abort();
+	} else {
+		outer?.addEventListener('abort', onOuterAbort);
+	}
+	try {
+		const headers: Record<string, string> = { ...options.headers };
+		if (options.contentType) {
+			headers['Content-Type'] = options.contentType;
+		}
+		// eslint-disable-next-line no-restricted-globals -- deliberate: requestUrl cannot abort an in-flight request; fetch honors the AbortSignal, and CORS-refusing endpoints fall back to requestUrl (see dispatchRequest)
+		const response = await fetch(options.url, {
+			method: options.method,
+			headers,
+			body: options.body,
+			signal: controller.signal,
+		});
+		const text = await response.text();
+		const responseHeaders: Record<string, string> = {};
+		response.headers.forEach((value, key) => {
+			responseHeaders[key] = value;
+		});
+		return { status: response.status, headers: responseHeaders, text };
+	} catch (error) {
+		if (controller.signal.aborted) {
+			throw new HttpError(
+				NO_HTTP_STATUS,
+				timedOut
+					? `Request to ${safeUrl} timed out after ${String(timeoutMs)} ms.`
+					: `Request to ${safeUrl} was cancelled.`,
+			);
+		}
+		throw error;
+	} finally {
+		window.clearTimeout(timer);
+		outer?.removeEventListener('abort', onOuterAbort);
+	}
+}
+
+/**
+ * Chooses the transport for one request: abortable `fetch` when a signal
+ * was provided, otherwise Obsidian's CORS-exempt `requestUrl`. A fetch
+ * that fails at the network layer (typically a CORS rejection from an
+ * OpenAI-compatible endpoint that only expects server-side clients) is
+ * retried once through `requestUrl` - re-sending the body, but that
+ * matches the pre-abort behavior where every request went that way.
+ * @param options - Request options
+ * @param timeoutMs - Deadline in milliseconds
+ * @param safeUrl - Query-stripped URL for error messages
+ */
+async function dispatchRequest(
+	options: RequestOptions,
+	timeoutMs: number,
+	safeUrl: string,
+): Promise<HttpResponse> {
+	if (options.signal) {
+		try {
+			return await fetchResponse(options, timeoutMs, safeUrl);
+		} catch (error) {
+			// An HttpError here is a timeout or cancel - final either way. A
+			// TypeError is fetch's network-layer failure (CORS/DNS/refused);
+			// only then is requestUrl worth a try.
+			if (error instanceof HttpError || !(error instanceof TypeError)) {
+				throw error;
+			}
+		}
+	}
+	return withTimeout(
+		requestUrl({
+			url: options.url,
+			method: options.method,
+			headers: options.headers,
+			body: options.body,
+			contentType: options.contentType,
+			throw: false,
+		}),
+		timeoutMs,
+		safeUrl,
+	);
+}
+
+/**
  * Maps an HTTP failure to a short, human-readable hint for the common cases -
  * out of quota/credit, bad key, rate limit, provider outage - or '' when no
  * specific guidance applies. Provider-neutral: matches OpenAI
@@ -264,6 +382,14 @@ export interface RequestOptions {
 	contentType?: string;
 	/** Per-request deadline; defaults to the transcription floor timeout. */
 	timeoutMs?: number;
+	/**
+	 * Optional abort signal. When set, the request is sent through `fetch`
+	 * (which can actually abort mid-flight) so a Cancel releases the socket
+	 * and request body immediately. Endpoints that refuse browser (CORS)
+	 * requests fall back to `requestUrl`, which cannot abort - there the
+	 * request keeps running until the timeout, as before.
+	 */
+	signal?: AbortSignal;
 }
 
 /**
@@ -279,22 +405,12 @@ export interface RequestOptions {
  */
 export async function requestRaw(
 	options: RequestOptions,
-): Promise<RequestUrlResponse> {
+): Promise<HttpResponse> {
 	const safeUrl = urlForMessage(options.url);
-	let response: RequestUrlResponse;
+	const timeoutMs = options.timeoutMs ?? TRANSCRIBE_REQUEST_TIMEOUT_MS;
+	let response: HttpResponse;
 	try {
-		response = await withTimeout(
-			requestUrl({
-				url: options.url,
-				method: options.method,
-				headers: options.headers,
-				body: options.body,
-				contentType: options.contentType,
-				throw: false,
-			}),
-			options.timeoutMs ?? TRANSCRIBE_REQUEST_TIMEOUT_MS,
-			safeUrl,
-		);
+		response = await dispatchRequest(options, timeoutMs, safeUrl);
 	} catch (error) {
 		if (error instanceof HttpError) {
 			throw error;

--- a/src/transcription/providers/DeepgramProvider.ts
+++ b/src/transcription/providers/DeepgramProvider.ts
@@ -71,6 +71,7 @@ export class DeepgramProvider implements TranscriptionProvider {
 				payload.data.byteLength,
 				this.config.requestTimeoutMs,
 			),
+			signal: options.signal,
 		});
 		return mapDeepgramResponse(json, options.diarize);
 	}

--- a/src/transcription/providers/GeminiProvider.ts
+++ b/src/transcription/providers/GeminiProvider.ts
@@ -150,7 +150,7 @@ export class GeminiProvider implements TranscriptionProvider {
 		const accepted = GEMINI_AUDIO_MIME_TYPES.has(payload.contentType);
 		const data = accepted
 			? payload.data
-			: encodeMonoWav(
+			: await encodeMonoWav(
 					await decodeToMono16k(payload.data),
 					TRANSCRIBE_SAMPLE_RATE,
 				);
@@ -163,6 +163,7 @@ export class GeminiProvider implements TranscriptionProvider {
 			mimeType,
 			payload.filename,
 			this.config.requestTimeoutMs,
+			options.signal,
 		);
 		try {
 			await waitUntilActive(
@@ -207,6 +208,7 @@ export class GeminiProvider implements TranscriptionProvider {
 					data.byteLength,
 					this.config.requestTimeoutMs,
 				),
+				signal: options.signal,
 			});
 			// A truncated (MAX_TOKENS) response yields invalid JSON, and a
 			// safety/policy block yields no candidate; both would otherwise map

--- a/src/transcription/providers/LocalWhisperProvider.ts
+++ b/src/transcription/providers/LocalWhisperProvider.ts
@@ -15,6 +15,7 @@ import type { TranscriptSegment } from '../TranscriptTypes';
 import { LOCAL_WHISPER_CAPABILITIES } from './capabilities';
 import type { WhisperResult } from './whisperResponse';
 import { isRecord, num } from './responseUtils';
+import { randomToken } from '../../utils/ids';
 import type {
 	AudioPayload,
 	ProviderCapabilities,
@@ -133,7 +134,7 @@ export class LocalWhisperProvider implements TranscriptionProvider {
 		}
 		const base = node.path.join(
 			node.os.tmpdir(),
-			`aar-whisper-${String(Date.now())}-${Math.random().toString(16).slice(2)}`,
+			`aar-whisper-${String(Date.now())}-${randomToken()}`,
 		);
 		const wavPath = `${base}.wav`;
 		const jsonPath = `${base}.json`;

--- a/src/transcription/providers/TranscriptionProvider.ts
+++ b/src/transcription/providers/TranscriptionProvider.ts
@@ -17,6 +17,13 @@ export interface TranscribeOptions {
 	diarize: boolean;
 	/** Request word-level timestamps when supported. */
 	wordTimestamps: boolean;
+	/**
+	 * Optional abort signal for the provider's HTTP requests. Providers on
+	 * CORS-capable endpoints pass it through so a cancel aborts the upload
+	 * mid-flight; providers that cannot abort (requestUrl-only endpoints,
+	 * the local CLI) ignore it and remain cancel-between-chunks only.
+	 */
+	signal?: AbortSignal;
 }
 
 /**

--- a/src/transcription/providers/WhisperApiProvider.ts
+++ b/src/transcription/providers/WhisperApiProvider.ts
@@ -94,6 +94,7 @@ export class WhisperApiProvider implements TranscriptionProvider {
 				body.byteLength,
 				this.config.requestTimeoutMs,
 			),
+			signal: options.signal,
 		});
 		return mapWhisperResponse(json);
 	}

--- a/src/transcription/providers/capabilities.ts
+++ b/src/transcription/providers/capabilities.ts
@@ -15,7 +15,7 @@ import {
 	TRANSCRIPTION_PROVIDER_IDS,
 	WHISPER_API_MAX_REQUEST_BYTES,
 } from '../../constants';
-import type { TranscriptionProviderId } from '../../settings/Settings';
+import type { TranscriptionProviderId } from '../../settings/settingsSchema';
 import type { ProviderCapabilities } from './TranscriptionProvider';
 
 /**

--- a/src/transcription/providers/geminiFileApi.ts
+++ b/src/transcription/providers/geminiFileApi.ts
@@ -113,6 +113,7 @@ export async function uploadFile(
 	mimeType: string,
 	displayName: string,
 	maxTimeoutMs?: number,
+	signal?: AbortSignal,
 ): Promise<GeminiFile> {
 	const base = trimTrailingSlash(baseUrl);
 	const numBytes = String(data.byteLength);
@@ -130,6 +131,7 @@ export async function uploadFile(
 		},
 		contentType: 'application/json',
 		body: JSON.stringify({ file: { display_name: displayName } }),
+		signal,
 	});
 	const uploadUrl = readHeader(start.headers, 'x-goog-upload-url');
 	if (!uploadUrl) {
@@ -148,6 +150,7 @@ export async function uploadFile(
 		},
 		body: data,
 		timeoutMs: uploadTimeoutMs(data.byteLength, maxTimeoutMs),
+		signal,
 	});
 	return parseFile(finalized);
 }

--- a/src/transcription/runTranscription.ts
+++ b/src/transcription/runTranscription.ts
@@ -7,7 +7,7 @@
  */
 
 import type { App, TFile } from 'obsidian';
-import type { AudioRecorderSettings } from '../settings/Settings';
+import type { AudioRecorderSettings } from '../settings/settingsSchema';
 import {
 	TranscriptionService,
 	type CancellationToken,

--- a/src/transcription/transcriptFormat.ts
+++ b/src/transcription/transcriptFormat.ts
@@ -115,7 +115,7 @@ function applyTemplate(
 		/\{(\w+)\}/g,
 		(_match, name: string) =>
 			Object.prototype.hasOwnProperty.call(values, name)
-				? values[name]
+				? (values[name] ?? '')
 				: '',
 	);
 	return substituted.replace(/[ \t]{2,}/g, ' ').trim();

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,12 +11,16 @@ export type OutputMode = 'single' | 'multiple';
 /**
  * Recording status states.
  */
-export enum RecordingStatus {
-	Idle = 'idle',
-	Recording = 'recording',
-	Paused = 'paused',
-	Saving = 'saving',
-}
+export const RecordingStatus = {
+	Idle: 'idle',
+	Recording: 'recording',
+	Paused: 'paused',
+	Saving: 'saving',
+} as const;
+
+/** A recording lifecycle state (derived from {@link RecordingStatus}). */
+export type RecordingStatus =
+	(typeof RecordingStatus)[keyof typeof RecordingStatus];
 
 /**
  * Progress information during the save phase.

--- a/src/ui/ContextMenu.ts
+++ b/src/ui/ContextMenu.ts
@@ -374,8 +374,9 @@ export class ContextMenu {
 		while ((match = internalLinkRegex.exec(lineText)) !== null) {
 			const start = match.index;
 			const end = start + match[0].length;
-			if (cursorCh >= start && cursorCh <= end) {
-				return { path: match[1], start, end };
+			const path = match[1];
+			if (path !== undefined && cursorCh >= start && cursorCh <= end) {
+				return { path, start, end };
 			}
 		}
 
@@ -384,8 +385,9 @@ export class ContextMenu {
 		while ((match = markdownLinkRegex.exec(lineText)) !== null) {
 			const start = match.index;
 			const end = start + match[0].length;
-			if (cursorCh >= start && cursorCh <= end) {
-				return { path: match[2], start, end };
+			const path = match[2];
+			if (path !== undefined && cursorCh >= start && cursorCh <= end) {
+				return { path, start, end };
 			}
 		}
 

--- a/src/ui/ConversionModal.ts
+++ b/src/ui/ConversionModal.ts
@@ -19,7 +19,7 @@ import type { EncodingWorkerClient } from '../audio/EncodingWorkerClient';
 import type {
 	AudioRecorderSettings,
 	ConversionLinkAction,
-} from '../settings/Settings';
+} from '../settings/settingsSchema';
 
 /**
  * Modal for converting an audio file to a different format.

--- a/src/ui/ConversionModal.ts
+++ b/src/ui/ConversionModal.ts
@@ -4,17 +4,15 @@
  */
 
 import { App, Modal, Notice, Setting, TFile } from 'obsidian';
-import {
-	isOfflineEncodingSupported,
-	getEncoderDescription,
-} from '../audio/AudioEncoder';
+import { isOfflineEncodingSupported } from '../audio/AudioEncoder';
 import { AUDIO_EXTENSIONS, FORMAT_WAV } from '../constants';
 import {
 	addBitrateSetting,
 	addDeleteSourceSetting,
 	addLinkActionSetting,
 } from './settingHelpers';
-import { ConversionService } from '../recording/ConversionService';
+import { getEncoderDescription } from './formatDescriptions';
+import { ConversionService } from '../recording/api';
 import type { EncodingWorkerClient } from '../audio/EncodingWorkerClient';
 import type {
 	AudioRecorderSettings,

--- a/src/ui/ConversionModal.ts
+++ b/src/ui/ConversionModal.ts
@@ -83,9 +83,10 @@ export class ConversionModal extends Modal {
 						`${format.toUpperCase()} (${encoder})`,
 					);
 				});
-				if (availableFormats.length > 0) {
-					this.targetFormat = availableFormats[0];
-					dropdown.setValue(this.targetFormat);
+				const firstFormat = availableFormats[0];
+				if (firstFormat) {
+					this.targetFormat = firstFormat;
+					dropdown.setValue(firstFormat);
 				}
 				dropdown.onChange((value) => {
 					this.targetFormat = value;

--- a/src/ui/MarkerModal.ts
+++ b/src/ui/MarkerModal.ts
@@ -8,7 +8,7 @@
 
 import { App, Modal, setIcon } from 'obsidian';
 import { MARKER_KIND, type MarkerKind } from '../markers/markerModel';
-import type { RecordingMarkerHandle } from '../recording/recordingMarkers';
+import type { RecordingMarkerHandle } from '../recording/api';
 
 /** A selectable kind option rendered as a segmented-toggle button. */
 interface KindOption {

--- a/src/ui/RecoveryModal.ts
+++ b/src/ui/RecoveryModal.ts
@@ -9,7 +9,7 @@
 
 import { App, Modal, Notice, Setting } from 'obsidian';
 import { PLUGIN_LOG_PREFIX } from '../constants';
-import type { JournalSession } from '../recording/SessionJournal';
+import type { JournalSession } from '../recording/api';
 
 /**
  * Actions the user can take on the interrupted sessions.

--- a/src/ui/SplitModal.ts
+++ b/src/ui/SplitModal.ts
@@ -28,7 +28,7 @@ import { SplitService } from '../recording/SplitService';
 import type {
 	AudioRecorderSettings,
 	ConversionLinkAction,
-} from '../settings/Settings';
+} from '../settings/settingsSchema';
 
 /**
  * Modal for splitting an audio file into parts of a fixed duration.

--- a/src/ui/SplitModal.ts
+++ b/src/ui/SplitModal.ts
@@ -23,8 +23,8 @@ import {
 import {
 	clampSplitMinutes,
 	sanitizePartSuffix,
-} from '../recording/AudioSplitter';
-import { SplitService } from '../recording/SplitService';
+	SplitService,
+} from '../recording/api';
 import type {
 	AudioRecorderSettings,
 	ConversionLinkAction,

--- a/src/ui/TranscriptionModal.ts
+++ b/src/ui/TranscriptionModal.ts
@@ -11,14 +11,16 @@
 
 import { MarkdownView, Modal, Notice, Setting } from 'obsidian';
 import type { App, ButtonComponent, TFile } from 'obsidian';
+import type {
+	AudioRecorderSettings,
+	TranscriptionProviderId,
+} from '../settings/settingsSchema';
 import {
 	LLM_TASK_OPTIONS,
 	TRANSCRIPT_DESTINATION_OPTIONS,
 	TRANSCRIPT_FILE_FORMAT_OPTIONS,
 	TRANSCRIPTION_PROVIDER_OPTIONS,
-	type AudioRecorderSettings,
-	type TranscriptionProviderId,
-} from '../settings/Settings';
+} from '../settings/labels';
 import type {
 	TranscriptDestination,
 	TranscriptFileFormat,

--- a/src/ui/TranscriptionModal.ts
+++ b/src/ui/TranscriptionModal.ts
@@ -68,6 +68,8 @@ export type TranscriptionModalOptions = {
  */
 export class TranscriptionModal extends Modal {
 	private cancelled = false;
+	/** Aborts the in-flight run's HTTP requests when cancelled. */
+	private abortController: AbortController | null = null;
 	private running = false;
 	private statusEl: HTMLElement | null = null;
 	private elapsedEl: HTMLElement | null = null;
@@ -173,7 +175,7 @@ export class TranscriptionModal extends Modal {
 				this.secondaryButton = button;
 				button.setButtonText('Close').onClick(() => {
 					if (this.running) {
-						this.cancelled = true;
+						this.cancelRun();
 					} else {
 						this.close();
 					}
@@ -333,7 +335,13 @@ export class TranscriptionModal extends Modal {
 		// Snapshot the options so a control toggled mid-run cannot change an
 		// in-flight job; edits only affect the next attempt after a failure.
 		const settings = { ...this.runSettings };
-		const token: CancellationToken = { isCancelled: () => this.cancelled };
+		this.abortController = new AbortController();
+		const token: CancellationToken = {
+			isCancelled: () => this.cancelled,
+			// Lets abort-capable providers stop an in-flight upload at once;
+			// requestUrl-only endpoints still finish or time out on their own.
+			signal: this.abortController.signal,
+		};
 		try {
 			await transcribeFile(this.app, () => settings, this.file, {
 				notePathForLinks: this.notePath,
@@ -370,6 +378,15 @@ export class TranscriptionModal extends Modal {
 			}
 			this.clearBackgroundProgress();
 		}
+	}
+
+	/**
+	 * Cancels the in-flight run: flags the cooperative token and aborts the
+	 * current HTTP request where the transport supports it.
+	 */
+	private cancelRun(): void {
+		this.cancelled = true;
+		this.abortController?.abort();
 	}
 
 	/**
@@ -490,7 +507,7 @@ export class TranscriptionModal extends Modal {
 			return;
 		}
 		if (this.running) {
-			this.cancelled = true;
+			this.cancelRun();
 		}
 		this.stopElapsedTimer();
 		this.clearBackgroundProgress();

--- a/src/ui/TranscriptionModal.ts
+++ b/src/ui/TranscriptionModal.ts
@@ -21,28 +21,24 @@ import {
 	TRANSCRIPT_FILE_FORMAT_OPTIONS,
 	TRANSCRIPTION_PROVIDER_OPTIONS,
 } from '../settings/labels';
-import type {
-	TranscriptDestination,
-	TranscriptFileFormat,
-} from '../transcription/TranscriptTypes';
-import type { LlmTask } from '../transcription/llmPostProcess';
 import {
 	addDropdown,
 	addText,
 	addToggle,
 	type SettingsSectionContext,
 } from '../settings/settingControls';
-import { transcribeFile } from '../transcription/runTranscription';
 import { formatTimecode } from '../utils/TimeUtils';
 import {
 	effectiveDiarize,
+	effectiveTranscriptDestination,
 	providerSupportsDiarization,
-} from '../transcription/providers/capabilities';
-import { effectiveTranscriptDestination } from '../transcription/transcriptOutput';
-import {
+	transcribeFile,
 	TranscriptionCancelledError,
 	type CancellationToken,
-} from '../transcription/TranscriptionService';
+	type LlmTask,
+	type TranscriptDestination,
+	type TranscriptFileFormat,
+} from '../transcription/api';
 import type { SaveProgress } from '../types';
 
 /** Default status label shown before the engine reports a finer-grained stage. */

--- a/src/ui/formatDescriptions.ts
+++ b/src/ui/formatDescriptions.ts
@@ -1,0 +1,41 @@
+/**
+ * Presentation copy for audio formats: the encoder description shown in
+ * the settings tab and the conversion dialog. Kept in the UI layer so the
+ * audio/codec layer carries no display strings.
+ * @module ui/formatDescriptions
+ */
+
+import {
+	FORMAT_WAV,
+	FORMAT_WEBM,
+	FORMAT_OGG,
+	FORMAT_MP3,
+	FORMAT_MP4,
+	FORMAT_M4A,
+	FORMAT_AAC,
+	FORMAT_FLAC,
+} from '../constants';
+import type { AudioFormatId } from '../audio/formatRegistry';
+
+/** Encoder description per format id. */
+const ENCODER_DESCRIPTIONS: Record<AudioFormatId, string> = {
+	[FORMAT_WAV]: 'PCM (built-in)',
+	[FORMAT_WEBM]: 'AudioEncoder (Opus) + Mediabunny',
+	[FORMAT_OGG]: 'AudioEncoder (Opus) + Mediabunny',
+	[FORMAT_MP3]: 'Mediabunny MP3 Encoder',
+	[FORMAT_M4A]: 'AudioEncoder (AAC) + Mediabunny',
+	[FORMAT_MP4]: 'AudioEncoder (AAC) + Mediabunny',
+	[FORMAT_FLAC]: 'Mediabunny FLAC Encoder',
+	[FORMAT_AAC]: 'AudioEncoder (AAC) + Mediabunny',
+};
+
+/**
+ * Returns a human-readable description of the encoder used for the format.
+ * @param format - Audio format id
+ * @returns Encoder description string
+ */
+export function getEncoderDescription(format: string): string {
+	return (
+		(ENCODER_DESCRIPTIONS as Record<string, string>)[format] ?? 'Unknown'
+	);
+}

--- a/src/ui/settingHelpers.ts
+++ b/src/ui/settingHelpers.ts
@@ -6,7 +6,7 @@
 
 import { Setting } from 'obsidian';
 import { getSupportedBitrates } from '../audio/AudioCapabilityDetector';
-import type { ConversionLinkAction } from '../settings/Settings';
+import type { ConversionLinkAction } from '../settings/settingsSchema';
 
 /**
  * Adds a bitrate dropdown listing the supported bitrates. The initial

--- a/src/utils/AudioFileAnalyzer.ts
+++ b/src/utils/AudioFileAnalyzer.ts
@@ -15,6 +15,7 @@ import {
 } from '../audio/formatRegistry';
 import { formatByteSize } from './formatBytes';
 import { formatTimecode } from './TimeUtils';
+import { autoClosing, disposableOf } from './disposables';
 
 /**
  * Represents detailed information about an audio file.
@@ -107,10 +108,12 @@ async function probeMetadata(
 	data: ArrayBuffer,
 	path: string,
 ): Promise<ProbedAudioMetadata | null> {
-	const input = new Input({
-		source: new BufferSource(data),
-		formats: ALL_FORMATS,
-	});
+	using input = disposableOf(
+		new Input({
+			source: new BufferSource(data),
+			formats: ALL_FORMATS,
+		}),
+	);
 	try {
 		const track = await input.getPrimaryAudioTrack();
 		if (!track) {
@@ -127,8 +130,6 @@ async function probeMetadata(
 			error,
 		);
 		return null;
-	} finally {
-		input.dispose();
 	}
 }
 
@@ -143,10 +144,7 @@ async function decodeMetadata(
 ): Promise<ProbedAudioMetadata | null> {
 	// Use window.AudioContext or window.webkitAudioContext for
 	// cross-browser compatibility.
-	const AudioContextClass =
-		window.AudioContext ||
-		(window as unknown as { webkitAudioContext?: typeof AudioContext })
-			.webkitAudioContext;
+	const AudioContextClass = window.AudioContext || window.webkitAudioContext;
 	if (!AudioContextClass) {
 		console.error(
 			`${PLUGIN_LOG_PREFIX} AudioContext is not supported in this environment.`,
@@ -157,7 +155,9 @@ async function decodeMetadata(
 		return null;
 	}
 
-	const audioContext = new AudioContextClass();
+	// The context is released after decoding - autoClosing skips a
+	// context that is already closed
+	await using audioContext = autoClosing(new AudioContextClass());
 	try {
 		const audioBuffer = await audioContext.decodeAudioData(data);
 		return {
@@ -169,11 +169,6 @@ async function decodeMetadata(
 		console.error(`${PLUGIN_LOG_PREFIX} Failed to decode audio data:`, e);
 		new Notice('Failed to decode audio file data.');
 		return null;
-	} finally {
-		// Ensure we release the context resources after decoding
-		if (audioContext.state !== 'closed') {
-			await audioContext.close();
-		}
 	}
 }
 

--- a/src/utils/AudioFileAnalyzer.ts
+++ b/src/utils/AudioFileAnalyzer.ts
@@ -1,9 +1,13 @@
 /**
  * Data structures and utilities for extracting audio file metadata.
+ * Metadata is read through mediabunny's container probe, which parses
+ * headers instead of decoding the whole file to PCM; the full decode is
+ * kept only as a fallback for containers the probe cannot parse.
  * @module utils/AudioFileAnalyzer
  */
 
 import { App, Notice, TFile } from 'obsidian';
+import { ALL_FORMATS, BufferSource, Input } from 'mediabunny';
 import { PLUGIN_LOG_PREFIX } from '../constants';
 import {
 	audioMimeForExtension,
@@ -26,6 +30,13 @@ export interface AudioFileInfo {
 	channels: string;
 }
 
+/** The raw numbers the info dialog is built from. */
+interface ProbedAudioMetadata {
+	durationSeconds: number;
+	sampleRate: number;
+	channels: number;
+}
+
 /**
  * Extracts metadata from an audio file.
  * @param app - The Obsidian App instance.
@@ -39,43 +50,15 @@ export async function getAudioFileInfo(
 	try {
 		const arrayBuffer = await app.vault.readBinary(file);
 
-		// Attempt to decode the audio data using the browser's native AudioContext.
-		// Use window.AudioContext or window.webkitAudioContext for cross-browser compatibility.
-		const AudioContextClass =
-			window.AudioContext ||
-			(window as unknown as { webkitAudioContext?: typeof AudioContext })
-				.webkitAudioContext;
-		if (!AudioContextClass) {
-			console.error(
-				`${PLUGIN_LOG_PREFIX} AudioContext is not supported in this environment.`,
-			);
-			new Notice(
-				'Audio context is not supported. Cannot extract audio metadata.',
-			);
+		const metadata =
+			(await probeMetadata(arrayBuffer, file.path)) ??
+			(await decodeMetadata(arrayBuffer));
+		if (!metadata) {
 			return null;
-		}
-
-		const audioContext = new AudioContextClass();
-		let audioBuffer: AudioBuffer;
-
-		try {
-			audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
-		} catch (e) {
-			console.error(
-				`${PLUGIN_LOG_PREFIX} Failed to decode audio data:`,
-				e,
-			);
-			new Notice('Failed to decode audio file data.');
-			return null;
-		} finally {
-			// Ensure we release the context resources after decoding
-			if (audioContext.state !== 'closed') {
-				await audioContext.close();
-			}
 		}
 
 		const fileSizeInBytes = file.stat.size;
-		const durationInSeconds = audioBuffer.duration;
+		const durationInSeconds = metadata.durationSeconds;
 
 		// Calculate bitrate in kbps
 		// bitRate = (fileSizeInBytes * 8 bits) / durationInSeconds
@@ -99,8 +82,8 @@ export async function getAudioFileInfo(
 			containerFormat: audioMimeForExtension(extension),
 			audioCodec: getFormatDescriptor(extension)?.codecLabel ?? 'unknown',
 			bitrate: `${bitrateKbps} kbps`,
-			sampleRate: `${audioBuffer.sampleRate} Hz`,
-			channels: formatChannels(audioBuffer.numberOfChannels),
+			sampleRate: `${metadata.sampleRate} Hz`,
+			channels: formatChannels(metadata.channels),
 		};
 	} catch (error) {
 		console.error(
@@ -109,6 +92,88 @@ export async function getAudioFileInfo(
 		);
 		new Notice('An error occurred while analyzing the audio file.');
 		return null;
+	}
+}
+
+/**
+ * Reads duration, sample rate, and channel count from the container
+ * headers via mediabunny - no PCM decode, so the cost stays flat no
+ * matter how long the recording is. Returns null when the container
+ * cannot be parsed, letting the caller fall back to a full decode.
+ * @param data - The file's bytes
+ * @param path - Vault path, for the warning log only
+ */
+async function probeMetadata(
+	data: ArrayBuffer,
+	path: string,
+): Promise<ProbedAudioMetadata | null> {
+	const input = new Input({
+		source: new BufferSource(data),
+		formats: ALL_FORMATS,
+	});
+	try {
+		const track = await input.getPrimaryAudioTrack();
+		if (!track) {
+			return null;
+		}
+		return {
+			durationSeconds: await input.computeDuration(),
+			sampleRate: await track.getSampleRate(),
+			channels: await track.getNumberOfChannels(),
+		};
+	} catch (error) {
+		console.warn(
+			`${PLUGIN_LOG_PREFIX} Container probe failed for ${path}; falling back to a full decode:`,
+			error,
+		);
+		return null;
+	} finally {
+		input.dispose();
+	}
+}
+
+/**
+ * Fallback metadata path: fully decodes the file through the Web Audio
+ * API. Expensive for long recordings, so it only runs when the container
+ * probe could not parse the file.
+ * @param data - The file's bytes
+ */
+async function decodeMetadata(
+	data: ArrayBuffer,
+): Promise<ProbedAudioMetadata | null> {
+	// Use window.AudioContext or window.webkitAudioContext for
+	// cross-browser compatibility.
+	const AudioContextClass =
+		window.AudioContext ||
+		(window as unknown as { webkitAudioContext?: typeof AudioContext })
+			.webkitAudioContext;
+	if (!AudioContextClass) {
+		console.error(
+			`${PLUGIN_LOG_PREFIX} AudioContext is not supported in this environment.`,
+		);
+		new Notice(
+			'Audio context is not supported. Cannot extract audio metadata.',
+		);
+		return null;
+	}
+
+	const audioContext = new AudioContextClass();
+	try {
+		const audioBuffer = await audioContext.decodeAudioData(data);
+		return {
+			durationSeconds: audioBuffer.duration,
+			sampleRate: audioBuffer.sampleRate,
+			channels: audioBuffer.numberOfChannels,
+		};
+	} catch (e) {
+		console.error(`${PLUGIN_LOG_PREFIX} Failed to decode audio data:`, e);
+		new Notice('Failed to decode audio file data.');
+		return null;
+	} finally {
+		// Ensure we release the context resources after decoding
+		if (audioContext.state !== 'closed') {
+			await audioContext.close();
+		}
 	}
 }
 

--- a/src/utils/LinkUpdater.ts
+++ b/src/utils/LinkUpdater.ts
@@ -190,8 +190,8 @@ export async function updateLinksInVault(
 		.map(([notePath]) => notePath);
 
 	for (const notePath of referencingPaths) {
-		const note = app.vault.getAbstractFileByPath(notePath);
-		if (!(note instanceof TFile)) {
+		const note = app.vault.getFileByPath(notePath);
+		if (!note) {
 			continue;
 		}
 		result.frontmatterReferences += countFrontmatterReferences(

--- a/src/utils/TimeUtils.ts
+++ b/src/utils/TimeUtils.ts
@@ -76,6 +76,9 @@ export function parseTimecode(value: string): number | null {
 	let seconds = 0;
 	for (let index = 0; index < parts.length; index++) {
 		const part = parts[index];
+		if (part === undefined) {
+			return null;
+		}
 		// Only the last segment may carry a fractional component; the
 		// hour and minute segments are whole numbers
 		const isLast = index === parts.length - 1;

--- a/src/utils/disposables.ts
+++ b/src/utils/disposables.ts
@@ -1,0 +1,42 @@
+/**
+ * Adapters that give non-disposable platform resources a Symbol.dispose /
+ * Symbol.asyncDispose, so call sites can bind them with `using` /
+ * `await using` instead of hand-written try/finally blocks.
+ * @module utils/disposables
+ */
+
+/**
+ * Wraps a resource with a synchronous dispose() (e.g. a mediabunny Input)
+ * so a `using` binding releases it when the block exits - on success and
+ * on every throw path alike.
+ * @param resource - The resource to manage
+ * @returns The same resource, made Disposable
+ */
+export function disposableOf<T extends { dispose(): void }>(
+	resource: T,
+): T & Disposable {
+	const managed = resource as T & Disposable;
+	managed[Symbol.dispose] = () => {
+		resource.dispose();
+	};
+	return managed;
+}
+
+/**
+ * Wraps an AudioContext-like resource so an `await using` binding closes
+ * it when the block exits (skipping a context that is already closed,
+ * which would throw).
+ * @param context - The context to manage
+ * @returns The same context, made AsyncDisposable
+ */
+export function autoClosing<
+	T extends { state: AudioContextState; close(): Promise<void> },
+>(context: T): T & AsyncDisposable {
+	const managed = context as T & AsyncDisposable;
+	managed[Symbol.asyncDispose] = async () => {
+		if (context.state !== 'closed') {
+			await context.close();
+		}
+	};
+	return managed;
+}

--- a/src/utils/ids.ts
+++ b/src/utils/ids.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared timestamp and random-token helpers for session and file naming.
+ * The project's preferred idiom for identifiers is crypto.randomUUID()
+ * (see markers/markerFactory.ts); use randomToken() only where a shorter
+ * token is specifically required, such as multipart boundaries or
+ * temp-file names.
+ * @module utils/ids
+ */
+
+/**
+ * A filename-safe ISO timestamp (colons and dots replaced with hyphens),
+ * used to name recording sessions and their files.
+ * @param date - The moment to stamp (defaults to now)
+ * @returns Timestamp like 2026-07-03T12-34-56-789Z
+ */
+export function sessionTimestamp(date: Date = new Date()): string {
+	return date.toISOString().replace(/[:.]/g, '-');
+}
+
+/**
+ * A short random hex token. Not cryptographically strong - prefer
+ * crypto.randomUUID() for identifiers; this is for cases where a shorter
+ * disposable token is enough.
+ * @returns Hex string of ~13 characters
+ */
+export function randomToken(): string {
+	return Math.random().toString(16).slice(2);
+}

--- a/src/utils/objects.ts
+++ b/src/utils/objects.ts
@@ -1,0 +1,13 @@
+/**
+ * Small object-shape helpers shared across layers.
+ * @module utils/objects
+ */
+
+/**
+ * Narrows an unknown value to a plain record so its properties can be
+ * accessed without unchecked casts.
+ * @param value - Value to test
+ */
+export function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null;
+}

--- a/tests/integration/AudioPlayer.decomposition.test.ts
+++ b/tests/integration/AudioPlayer.decomposition.test.ts
@@ -1,4 +1,3 @@
-/** @jest-environment jsdom */
 /**
  * Regression guards for the AudioPlayer decomposition (audit finding 2.6):
  * the control row (PlayerControlsView), pointer/keyboard seeking

--- a/tests/integration/AudioPlayer.decomposition.test.ts
+++ b/tests/integration/AudioPlayer.decomposition.test.ts
@@ -1,0 +1,541 @@
+/** @jest-environment jsdom */
+/**
+ * Regression guards for the AudioPlayer decomposition (audit finding 2.6):
+ * the control row (PlayerControlsView), pointer/keyboard seeking
+ * (SeekController), infinite-duration resolution (DurationProbe), and
+ * marker CRUD (PlayerMarkerController) were extracted from the player.
+ * These tests drive the REAL AudioPlayer through the real DOM - clicks,
+ * keydowns, pointer events - and assert on the shared audio element and
+ * the persisted markers, so a wiring regression in the coordinator cannot
+ * hide behind mocked collaborators.
+ */
+
+import { App, Modal } from 'obsidian';
+import { AudioPlayer } from 'src/player/AudioPlayer';
+import { WaveformPeakCache, type AudioDecoder } from 'src/player/WaveformData';
+import type { AudioPlayerRegistry } from 'src/player/AudioPlayerRegistry';
+import type { MarkerStore } from 'src/markers/MarkerStore';
+import type { ResolvedPlayerSettings } from 'src/player/playerSettings';
+import type { PlayerMarker } from 'src/markers/markerModel';
+import { PLAYER_SKIP_SECONDS } from 'src/constants';
+import type { TFile } from 'obsidian';
+
+type Listener = () => void;
+
+interface FakeAudio {
+	paused: boolean;
+	loop: boolean;
+	playbackRate: number;
+	volume: number;
+	muted: boolean;
+	currentTime: number;
+	duration: number;
+	readyState: number;
+	play: jest.Mock;
+	pause: jest.Mock;
+	addEventListener: (type: string, cb: Listener) => void;
+	removeEventListener: (type: string, cb: Listener) => void;
+	emit: (type: string) => void;
+}
+
+function makeFakeAudio(): FakeAudio {
+	const handlers = new Map<string, Set<Listener>>();
+	const audio: FakeAudio = {
+		paused: true,
+		loop: false,
+		playbackRate: 1,
+		volume: 1,
+		muted: false,
+		currentTime: 0,
+		duration: 100,
+		readyState: 1,
+		play: jest.fn(() => {
+			audio.paused = false;
+			return Promise.resolve();
+		}),
+		pause: jest.fn(() => {
+			audio.paused = true;
+		}),
+		addEventListener: (type, cb) => {
+			const set = handlers.get(type) ?? new Set<Listener>();
+			set.add(cb);
+			handlers.set(type, set);
+		},
+		removeEventListener: (type, cb) => {
+			handlers.get(type)?.delete(cb);
+		},
+		emit: (type) => {
+			handlers.get(type)?.forEach((cb) => {
+				cb();
+			});
+		},
+	};
+	return audio;
+}
+
+function makeRegistry(...audios: FakeAudio[]): AudioPlayerRegistry {
+	const entries = new Map<string, { audio: FakeAudio; engaged: boolean }>();
+	let nextAudio = 0;
+	return {
+		acquireAudio: jest.fn((key: string) => {
+			const existing = entries.get(key);
+			if (existing) {
+				return {
+					audio: existing.audio as unknown as HTMLAudioElement,
+					isNew: false,
+				};
+			}
+			const audio = audios[nextAudio] ?? makeFakeAudio();
+			nextAudio += 1;
+			entries.set(key, { audio, engaged: false });
+			return { audio: audio as unknown as HTMLAudioElement, isNew: true };
+		}),
+		releaseAudio: jest.fn(),
+		register: jest.fn(),
+		unregister: jest.fn(),
+		reloadMarkers: jest.fn(),
+		seek: jest.fn(),
+		applySettings: jest.fn(),
+		clear: jest.fn(),
+		markAudioEngaged: jest.fn((key: string) => {
+			const entry = entries.get(key);
+			if (entry) {
+				entry.engaged = true;
+			}
+		}),
+		isAudioEngaged: jest.fn(
+			(key: string) => entries.get(key)?.engaged ?? false,
+		),
+	};
+}
+
+const app = {
+	vault: {
+		getResourcePath: () => 'app://media',
+		readBinary: () => Promise.resolve(new ArrayBuffer(0)),
+	},
+	fileManager: {
+		generateMarkdownLink: () => '[[rec.webm]]',
+	},
+} as unknown as App;
+
+const decoder: AudioDecoder = {
+	decode: () => Promise.reject(new Error('no decode in tests')),
+};
+
+/** An in-memory marker store the tests can inspect. */
+function makeMarkerStore(): MarkerStore & {
+	data: Map<string, PlayerMarker[]>;
+} {
+	const data = new Map<string, PlayerMarker[]>();
+	return {
+		data,
+		get: jest.fn((path: string) => Promise.resolve(data.get(path) ?? [])),
+		set: jest.fn((path: string, markers: PlayerMarker[]) => {
+			data.set(path, markers);
+			return Promise.resolve();
+		}),
+	};
+}
+
+function makeFile(size = 1000, extension = 'webm'): TFile {
+	return {
+		path: `rec.${extension}`,
+		extension,
+		stat: { mtime: 1, size },
+	} as unknown as TFile;
+}
+
+function makeContainer(): HTMLElement {
+	const el = new Modal(new App()).contentEl.createDiv();
+	document.body.appendChild(el);
+	return el;
+}
+
+const PLAIN: ResolvedPlayerSettings = {
+	showWaveform: false,
+	enableMarkers: false,
+};
+
+function makePlayer(
+	container: HTMLElement,
+	registry: AudioPlayerRegistry,
+	settings: ResolvedPlayerSettings = PLAIN,
+	markerStore: MarkerStore = makeMarkerStore(),
+	startSeconds: number | null = null,
+): AudioPlayer {
+	return new AudioPlayer(
+		container,
+		app,
+		makeFile(1000, 'wav'),
+		settings,
+		registry,
+		new WaveformPeakCache(),
+		decoder,
+		markerStore,
+		{ startSeconds, sourcePath: 'note.md', immediate: true },
+	);
+}
+
+/** The seek area, prepared for pointer interaction under jsdom. */
+function seekArea(container: HTMLElement): HTMLElement {
+	const seekEl = container.querySelector<HTMLElement>('.aar-player-seek');
+	if (!seekEl) {
+		throw new Error('seek area not rendered');
+	}
+	seekEl.getBoundingClientRect = () =>
+		({ left: 0, width: 100, top: 0, height: 10 }) as DOMRect;
+	seekEl.setPointerCapture = jest.fn();
+	seekEl.hasPointerCapture = jest.fn().mockReturnValue(true);
+	seekEl.releasePointerCapture = jest.fn();
+	return seekEl;
+}
+
+function pointerEvent(type: string, clientX: number): MouseEvent {
+	// jsdom has no PointerEvent; a MouseEvent with the same type exercises
+	// the same listeners (pointerId is undefined, capture calls are mocked)
+	return new MouseEvent(type, { button: 0, clientX, bubbles: true });
+}
+
+const tick = (): Promise<void> =>
+	new Promise((resolve) => setTimeout(resolve, 0));
+
+afterEach(() => {
+	document.body.innerHTML = '';
+	jest.clearAllMocks();
+});
+
+describe('control row drives the shared audio (PlayerControlsView wiring)', () => {
+	it('skip buttons move the shared currentTime by the configured step', () => {
+		const audio = makeFakeAudio();
+		audio.currentTime = 30;
+		const container = makeContainer();
+		makePlayer(container, makeRegistry(audio)).onload();
+
+		container
+			.querySelector<HTMLElement>(
+				`[aria-label="Forward ${String(PLAYER_SKIP_SECONDS)}s"]`,
+			)
+			?.click();
+		expect(audio.currentTime).toBe(30 + PLAYER_SKIP_SECONDS);
+
+		container
+			.querySelector<HTMLElement>(
+				`[aria-label="Back ${String(PLAYER_SKIP_SECONDS)}s"]`,
+			)
+			?.click();
+		expect(audio.currentTime).toBe(30);
+	});
+
+	it('mute button toggles the shared muted flag and its active state', () => {
+		const audio = makeFakeAudio();
+		const container = makeContainer();
+		makePlayer(container, makeRegistry(audio)).onload();
+		const mute = container.querySelector<HTMLElement>(
+			'[aria-label="Mute / unmute"]',
+		);
+
+		mute?.click();
+		expect(audio.muted).toBe(true);
+		expect(mute?.classList.contains('is-active')).toBe(true);
+
+		mute?.click();
+		expect(audio.muted).toBe(false);
+		expect(mute?.classList.contains('is-active')).toBe(false);
+	});
+
+	it('raising the volume slider unmutes the shared audio', () => {
+		const audio = makeFakeAudio();
+		audio.muted = true;
+		const container = makeContainer();
+		makePlayer(container, makeRegistry(audio)).onload();
+
+		const volume =
+			container.querySelector<HTMLInputElement>('.aar-player-volume');
+		if (!volume) {
+			throw new Error('volume slider not rendered');
+		}
+		volume.value = '0.5';
+		volume.dispatchEvent(new Event('input'));
+
+		expect(audio.volume).toBe(0.5);
+		expect(audio.muted).toBe(false);
+	});
+
+	it('loop button toggles the shared loop flag', () => {
+		const audio = makeFakeAudio();
+		const container = makeContainer();
+		makePlayer(container, makeRegistry(audio)).onload();
+		const loop = container.querySelector<HTMLElement>(
+			'[aria-label="Loop"]',
+		);
+
+		loop?.click();
+		expect(audio.loop).toBe(true);
+		expect(loop?.classList.contains('is-active')).toBe(true);
+
+		loop?.click();
+		expect(audio.loop).toBe(false);
+	});
+
+	it('play button toggles between playing and pausing the shared audio', () => {
+		const audio = makeFakeAudio();
+		const container = makeContainer();
+		makePlayer(container, makeRegistry(audio)).onload();
+		const play = container.querySelector<HTMLElement>(
+			'[aria-label="Play / pause"]',
+		);
+
+		play?.click();
+		expect(audio.play).toHaveBeenCalled();
+		audio.emit('play');
+
+		play?.click();
+		expect(audio.pause).toHaveBeenCalled();
+	});
+});
+
+describe('pointer and keyboard seeking (SeekController wiring)', () => {
+	it('a primary-button click seeks the shared audio to the pointer position', () => {
+		const audio = makeFakeAudio();
+		const registry = makeRegistry(audio);
+		const container = makeContainer();
+		makePlayer(container, registry).onload();
+		const seekEl = seekArea(container);
+
+		seekEl.dispatchEvent(pointerEvent('pointerdown', 40));
+
+		// 40% of a 100s track
+		expect(audio.currentTime).toBe(40);
+		expect(registry.markAudioEngaged).toHaveBeenCalled();
+	});
+
+	it('dragging updates the position across pointermove events', () => {
+		const audio = makeFakeAudio();
+		const container = makeContainer();
+		makePlayer(container, makeRegistry(audio)).onload();
+		const seekEl = seekArea(container);
+
+		seekEl.dispatchEvent(pointerEvent('pointerdown', 10));
+		expect(audio.currentTime).toBe(10);
+		seekEl.dispatchEvent(pointerEvent('pointermove', 70));
+		expect(audio.currentTime).toBe(70);
+		seekEl.dispatchEvent(pointerEvent('pointerup', 70));
+		// After release, a stray move no longer seeks
+		seekEl.dispatchEvent(pointerEvent('pointermove', 20));
+		expect(audio.currentTime).toBe(70);
+	});
+
+	it('a right-click does not seek (context menu stays usable)', () => {
+		const audio = makeFakeAudio();
+		audio.currentTime = 5;
+		const container = makeContainer();
+		makePlayer(container, makeRegistry(audio)).onload();
+		const seekEl = seekArea(container);
+
+		seekEl.dispatchEvent(
+			new MouseEvent('pointerdown', { button: 2, clientX: 40 }),
+		);
+
+		expect(audio.currentTime).toBe(5);
+	});
+
+	it('arrow keys nudge playback and Home/End jump to the bounds', () => {
+		const audio = makeFakeAudio();
+		audio.currentTime = 50;
+		const container = makeContainer();
+		makePlayer(container, makeRegistry(audio)).onload();
+		const seekEl = seekArea(container);
+
+		seekEl.dispatchEvent(
+			new KeyboardEvent('keydown', { key: 'ArrowRight' }),
+		);
+		expect(audio.currentTime).toBeGreaterThan(50);
+
+		seekEl.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home' }));
+		expect(audio.currentTime).toBe(0);
+
+		seekEl.dispatchEvent(new KeyboardEvent('keydown', { key: 'End' }));
+		expect(audio.currentTime).toBe(100);
+	});
+
+	it('keyboard skip engages a pending #t= start first', () => {
+		const audio = makeFakeAudio();
+		audio.duration = 100;
+		const container = makeContainer();
+		makePlayer(
+			container,
+			makeRegistry(audio),
+			PLAIN,
+			makeMarkerStore(),
+			30,
+		).onload();
+		const seekEl = seekArea(container);
+
+		// The shared element is untouched while the #t=30 hint is display-only
+		expect(audio.currentTime).toBe(0);
+		seekEl.dispatchEvent(
+			new KeyboardEvent('keydown', { key: 'ArrowRight' }),
+		);
+
+		// The skip engaged the start (30) and then moved relative to it
+		expect(audio.currentTime).toBeGreaterThan(30);
+	});
+});
+
+describe('infinite-duration resolution (DurationProbe wiring)', () => {
+	it('probes a far position on an unusable duration and restores the start on resolution', () => {
+		const audio = makeFakeAudio();
+		audio.duration = Infinity;
+		const container = makeContainer();
+		makePlayer(container, makeRegistry(audio)).onload();
+
+		audio.emit('loadedmetadata');
+		// The probe seeks far ahead to force the browser to compute a length
+		expect(audio.currentTime).toBeGreaterThan(1e100);
+
+		audio.duration = 60;
+		audio.emit('durationchange');
+
+		// Resolution restores the start and unlocks the timeline display
+		expect(audio.currentTime).toBe(0);
+		expect(container.querySelector('.aar-player-time')?.textContent).toBe(
+			'0:00 / 1:00',
+		);
+	});
+
+	it('also probes a finite-but-zero duration (unstamped container)', () => {
+		const audio = makeFakeAudio();
+		audio.duration = 0;
+		const container = makeContainer();
+		makePlayer(container, makeRegistry(audio)).onload();
+
+		audio.emit('loadedmetadata');
+		expect(audio.currentTime).toBeGreaterThan(1e100);
+
+		// A durationchange still reporting 0 must NOT end the probe
+		audio.emit('durationchange');
+		expect(audio.currentTime).toBeGreaterThan(1e100);
+
+		audio.duration = 42;
+		audio.emit('durationchange');
+		expect(audio.currentTime).toBe(0);
+	});
+
+	it('gives up after the watchdog timeout so playback is not stranded', () => {
+		jest.useFakeTimers();
+		try {
+			const audio = makeFakeAudio();
+			audio.duration = Infinity;
+			const container = makeContainer();
+			makePlayer(container, makeRegistry(audio)).onload();
+
+			audio.emit('loadedmetadata');
+			expect(audio.currentTime).toBeGreaterThan(1e100);
+
+			jest.advanceTimersByTime(6000);
+
+			expect(audio.currentTime).toBe(0);
+		} finally {
+			jest.useRealTimers();
+		}
+	});
+});
+
+describe('marker CRUD stays player-driven and persisted (PlayerMarkerController wiring)', () => {
+	const WITH_MARKERS: ResolvedPlayerSettings = {
+		showWaveform: false,
+		enableMarkers: true,
+	};
+
+	it('adding a marker from the controls persists it and renders the list', async () => {
+		const audio = makeFakeAudio();
+		audio.currentTime = 12;
+		const store = makeMarkerStore();
+		const registry = makeRegistry(audio);
+		const container = makeContainer();
+		const player = makePlayer(container, registry, WITH_MARKERS, store);
+		player.onload();
+		await tick();
+
+		container
+			.querySelector<HTMLElement>(
+				'[aria-label="Add marker at current position"]',
+			)
+			?.click();
+		await tick();
+
+		const saved = store.data.get('rec.wav') ?? [];
+		expect(saved).toHaveLength(1);
+		expect(saved[0].time).toBe(12);
+		expect(saved[0].kind).toBe('bookmark');
+		// Other live players of the file are refreshed after the persist
+		expect(registry.reloadMarkers).toHaveBeenCalledWith('rec.wav', player);
+	});
+
+	it('reloadMarkers re-reads the store so views stay in sync', async () => {
+		const audio = makeFakeAudio();
+		const store = makeMarkerStore();
+		const container = makeContainer();
+		const player = makePlayer(
+			container,
+			makeRegistry(audio),
+			WITH_MARKERS,
+			store,
+		);
+		player.onload();
+		await tick();
+
+		store.data.set('rec.wav', [
+			{ id: 'm1', time: 5, label: 'Marker 1', kind: 'bookmark' },
+		]);
+		player.reloadMarkers();
+		await tick();
+
+		expect(container.textContent).toContain('Marker 1');
+	});
+
+	it('chapter navigation buttons jump between persisted chapters', async () => {
+		const audio = makeFakeAudio();
+		audio.currentTime = 50;
+		const store = makeMarkerStore();
+		store.data.set('rec.wav', [
+			{ id: 'c1', time: 10, label: 'Intro', kind: 'chapter' },
+			{ id: 'c2', time: 80, label: 'Outro', kind: 'chapter' },
+		]);
+		const container = makeContainer();
+		makePlayer(
+			container,
+			makeRegistry(audio),
+			WITH_MARKERS,
+			store,
+		).onload();
+		await tick();
+
+		container
+			.querySelector<HTMLElement>('[aria-label="Next chapter"]')
+			?.click();
+		expect(audio.currentTime).toBe(80);
+
+		container
+			.querySelector<HTMLElement>('[aria-label="Previous chapter"]')
+			?.click();
+		// Shortly after a boundary, previous returns to that boundary's start
+		expect(audio.currentTime).toBe(10);
+	});
+
+	it('does not render marker controls or load markers when the window is off', async () => {
+		const audio = makeFakeAudio();
+		const store = makeMarkerStore();
+		const container = makeContainer();
+		makePlayer(container, makeRegistry(audio), PLAIN, store).onload();
+		await tick();
+
+		expect(
+			container.querySelector(
+				'[aria-label="Add marker at current position"]',
+			),
+		).toBeNull();
+		expect(store.get).not.toHaveBeenCalled();
+	});
+});

--- a/tests/integration/AudioPlayer.regression.test.ts
+++ b/tests/integration/AudioPlayer.regression.test.ts
@@ -1,4 +1,3 @@
-/** @jest-environment jsdom */
 /**
  * Regression guards for the enhanced player's two long-standing defects:
  *

--- a/tests/mocks/obsidian.ts
+++ b/tests/mocks/obsidian.ts
@@ -271,8 +271,10 @@ export class MarkdownRenderChild extends Component {
 /**
  * Adds Obsidian DOM extension methods to an HTMLElement.
  * Obsidian extends HTMLElement with helper methods like createEl, setText, etc.
+ * Exported so DOM-driven tests can extend elements Obsidian extends at
+ * runtime (e.g. document.body for body-mounted UI like RecordingBanner).
  */
-function addObsidianDomExtensions(el: HTMLElement): HTMLElement {
+export function addObsidianDomExtensions(el: HTMLElement): HTMLElement {
 	// Use unknown cast to avoid TypeScript's overloaded HTMLElement extension conflicts
 	const extended = el as unknown as Record<string, unknown>;
 

--- a/tests/mocks/obsidian.ts
+++ b/tests/mocks/obsidian.ts
@@ -848,6 +848,56 @@ export const Platform = {
 	isMobileApp: false,
 };
 
+/** Mock of obsidian's module-level API version export. */
+export const apiVersion = '1.12.3';
+
+/**
+ * Mock AbstractInputSuggest: enough surface for components that attach
+ * popover suggestions to a text input (e.g. FolderSuggest). Suggestions
+ * never open in tests; the constructor and the value plumbing suffice.
+ */
+export abstract class AbstractInputSuggest<T> {
+	limit = 100;
+
+	constructor(
+		public app: App,
+		protected inputEl: HTMLInputElement | HTMLDivElement,
+	) {}
+
+	protected abstract getSuggestions(query: string): T[] | Promise<T[]>;
+	abstract renderSuggestion(value: T, el: HTMLElement): void;
+
+	setValue(value: string): void {
+		if (this.inputEl instanceof HTMLInputElement) {
+			this.inputEl.value = value;
+		}
+	}
+
+	getValue(): string {
+		return this.inputEl instanceof HTMLInputElement
+			? this.inputEl.value
+			: '';
+	}
+
+	selectSuggestion(_value: T, _evt: MouseEvent | KeyboardEvent): void {
+		// Mock implementation
+	}
+
+	onSelect(
+		_callback: (value: T, evt: MouseEvent | KeyboardEvent) => unknown,
+	): this {
+		return this;
+	}
+
+	open(): void {
+		// Mock implementation
+	}
+
+	close(): void {
+		// Mock implementation
+	}
+}
+
 /**
  * Debounced function type returned by the debounce mock.
  */

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -5,6 +5,24 @@
 
 import { TextDecoder, TextEncoder } from 'util';
 
+// Explicit resource management (`using`/`await using`) lowers through
+// tslib helpers that require the well-known dispose symbols; jest's
+// sandboxed global may lack them.
+const symbolWithDispose = Symbol as {
+	dispose?: symbol;
+	asyncDispose?: symbol;
+};
+if (typeof symbolWithDispose.dispose === 'undefined') {
+	Object.defineProperty(Symbol, 'dispose', {
+		value: Symbol.for('Symbol.dispose'),
+	});
+}
+if (typeof symbolWithDispose.asyncDispose === 'undefined') {
+	Object.defineProperty(Symbol, 'asyncDispose', {
+		value: Symbol.for('Symbol.asyncDispose'),
+	});
+}
+
 if (typeof globalThis.TextDecoder === 'undefined') {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- globalThis type augmentation requires any
 	(globalThis as any).TextDecoder = TextDecoder;

--- a/tests/unit/AudioCapabilityDetector.test.ts
+++ b/tests/unit/AudioCapabilityDetector.test.ts
@@ -3,10 +3,9 @@
  * Tests format detection, MIME type building, and pre-recording validation.
  * @module tests/unit/AudioCapabilityDetector.test
  */
-/** @jest-environment jsdom */
 
 // Mock AudioEncoder module to avoid mediabunny TextDecoder requirement
-jest.mock('../../src/audio/AudioEncoder', () => ({
+jest.mock('src/audio/AudioEncoder', () => ({
 	isOfflineEncodingSupported: jest.fn((format: string) => {
 		return ['mp3', 'flac', 'aac'].includes(format);
 	}),
@@ -21,7 +20,7 @@ import {
 	detectCapabilities,
 	detectCodecSupport,
 	FORMAT_FLAC,
-} from '../../src/audio/AudioCapabilityDetector';
+} from 'src/audio/AudioCapabilityDetector';
 
 describe('AudioCapabilityDetector', () => {
 	beforeEach(() => {

--- a/tests/unit/AudioEncoder.test.ts
+++ b/tests/unit/AudioEncoder.test.ts
@@ -7,7 +7,6 @@
 import {
 	encodeAudioBuffer,
 	isOfflineEncodingSupported,
-	getEncoderDescription,
 } from '../../src/audio/AudioEncoder';
 import type { EncodingOptions } from '../../src/audio/AudioEncoder';
 import { EncodingError } from '../../src/errors';
@@ -382,50 +381,6 @@ describe('AudioEncoder', () => {
 
 		it('should return false for unknown formats', () => {
 			expect(isOfflineEncodingSupported('xyz')).toBe(false);
-		});
-	});
-
-	describe('getEncoderDescription', () => {
-		it('should return correct description for WAV', () => {
-			expect(getEncoderDescription('wav')).toBe('PCM (built-in)');
-		});
-
-		it('should return correct description for WebM', () => {
-			expect(getEncoderDescription('webm')).toBe(
-				'AudioEncoder (Opus) + Mediabunny',
-			);
-		});
-
-		it('should return correct description for OGG', () => {
-			expect(getEncoderDescription('ogg')).toBe(
-				'AudioEncoder (Opus) + Mediabunny',
-			);
-		});
-
-		it('should return correct description for MP4/M4A/AAC', () => {
-			expect(getEncoderDescription('mp4')).toBe(
-				'AudioEncoder (AAC) + Mediabunny',
-			);
-			expect(getEncoderDescription('m4a')).toBe(
-				'AudioEncoder (AAC) + Mediabunny',
-			);
-			expect(getEncoderDescription('aac')).toBe(
-				'AudioEncoder (AAC) + Mediabunny',
-			);
-		});
-
-		it('should return correct description for MP3', () => {
-			expect(getEncoderDescription('mp3')).toBe('Mediabunny MP3 Encoder');
-		});
-
-		it('should return correct description for FLAC', () => {
-			expect(getEncoderDescription('flac')).toBe(
-				'Mediabunny FLAC Encoder',
-			);
-		});
-
-		it('should return Unknown for unsupported formats', () => {
-			expect(getEncoderDescription('xyz')).toBe('Unknown');
 		});
 	});
 });

--- a/tests/unit/AudioEncoder.test.ts
+++ b/tests/unit/AudioEncoder.test.ts
@@ -2,14 +2,13 @@
  * Unit tests for AudioEncoder module.
  * @module tests/unit/AudioEncoder.test
  */
-/** @jest-environment jsdom */
 
 import {
 	encodeAudioBuffer,
 	isOfflineEncodingSupported,
-} from '../../src/audio/AudioEncoder';
-import type { EncodingOptions } from '../../src/audio/AudioEncoder';
-import { EncodingError } from '../../src/errors';
+} from 'src/audio/AudioEncoder';
+import type { EncodingOptions } from 'src/audio/AudioEncoder';
+import { EncodingError } from 'src/errors';
 import { createMockAudioBuffer } from '../helpers/createMockAudioBuffer';
 
 // Mock WavEncoder

--- a/tests/unit/AudioFileAnalyzer.test.ts
+++ b/tests/unit/AudioFileAnalyzer.test.ts
@@ -24,6 +24,23 @@ jest.mock('obsidian', () => ({
 	})),
 }));
 
+// Mock mediabunny's container probe. Defaults to an unparseable input
+// (getPrimaryAudioTrack rejects) so the existing decode-fallback tests
+// keep exercising the AudioContext path; probe tests override it.
+const mockGetPrimaryAudioTrack = jest.fn();
+const mockComputeDuration = jest.fn();
+const mockDispose = jest.fn();
+
+jest.mock('mediabunny', () => ({
+	ALL_FORMATS: [],
+	BufferSource: jest.fn(),
+	Input: jest.fn().mockImplementation(() => ({
+		getPrimaryAudioTrack: (): unknown => mockGetPrimaryAudioTrack(),
+		computeDuration: (): unknown => mockComputeDuration(),
+		dispose: mockDispose,
+	})),
+}));
+
 // Setup mock AudioContext
 const mockDecodeAudioData = jest.fn();
 const mockClose = jest.fn();
@@ -56,10 +73,53 @@ describe('getAudioFileInfo', () => {
 		});
 		mockClose.mockResolvedValue(undefined);
 
+		// Default: the probe cannot parse the container, so the decode
+		// fallback runs (the pre-probe behavior the older tests assert).
+		mockGetPrimaryAudioTrack.mockRejectedValue(
+			new Error('unparseable container'),
+		);
+		mockComputeDuration.mockResolvedValue(0);
+
 		Object.defineProperty(window, 'AudioContext', {
 			writable: true,
 			value: MockAudioContext,
 		});
+	});
+
+	it('reads metadata from the container probe without decoding', async () => {
+		mockGetPrimaryAudioTrack.mockResolvedValue({
+			getSampleRate: () => 48000,
+			getNumberOfChannels: () => 2,
+		});
+		mockComputeDuration.mockResolvedValue(90);
+
+		const result = await getAudioFileInfo(app, file);
+
+		expect(result).toEqual({
+			fileName: 'test.webm',
+			fileSize: '1.5 MB',
+			duration: '1:30',
+			containerFormat: 'audio/webm',
+			audioCodec: 'opus',
+			bitrate: '140 kbps',
+			sampleRate: '48000 Hz',
+			channels: '2 (Stereo)',
+		});
+		// The probe answered, so the expensive full decode never ran
+		expect(mockDecodeAudioData).not.toHaveBeenCalled();
+		expect(mockDispose).toHaveBeenCalled();
+	});
+
+	it('disposes the probe input even when parsing fails', async () => {
+		const warn = jest.spyOn(console, 'warn').mockImplementation();
+		try {
+			await getAudioFileInfo(app, file);
+			expect(mockDispose).toHaveBeenCalled();
+			// The decode fallback provided the metadata instead
+			expect(mockDecodeAudioData).toHaveBeenCalled();
+		} finally {
+			warn.mockRestore();
+		}
 	});
 
 	it('should accurately extract and format audio metadata', async () => {

--- a/tests/unit/AudioFileAnalyzer.test.ts
+++ b/tests/unit/AudioFileAnalyzer.test.ts
@@ -1,10 +1,9 @@
-/** @jest-environment jsdom */
 /**
  * Unit tests for AudioFileAnalyzer.
  * @module tests/unit/AudioFileAnalyzer
  */
 
-import { getAudioFileInfo } from '../../src/utils/AudioFileAnalyzer';
+import { getAudioFileInfo } from 'src/utils/AudioFileAnalyzer';
 import { App, Notice, TFile } from 'obsidian';
 
 // Mock Notice

--- a/tests/unit/AudioFileInfoModal.test.ts
+++ b/tests/unit/AudioFileInfoModal.test.ts
@@ -1,11 +1,10 @@
-/** @jest-environment jsdom */
 /**
  * Unit tests for AudioFileInfoModal.
  * @module tests/unit/AudioFileInfoModal
  */
 
-import { AudioFileInfoModal } from '../../src/ui/AudioFileInfoModal';
-import type { AudioFileInfo } from '../../src/utils/AudioFileAnalyzer';
+import { AudioFileInfoModal } from 'src/ui/AudioFileInfoModal';
+import type { AudioFileInfo } from 'src/utils/AudioFileAnalyzer';
 import { App } from 'obsidian';
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/AudioFormatConverter.test.ts
+++ b/tests/unit/AudioFormatConverter.test.ts
@@ -3,11 +3,10 @@
  * Tests format resolution, blob conversion, offline encoding, and track merging.
  * @module tests/unit/AudioFormatConverter.test
  */
-/** @jest-environment jsdom */
 
-import type { AudioRecorderSettings } from '../../src/settings/settingsSchema';
-import { DEFAULT_SETTINGS } from '../../src/settings/settingsSchema';
-import type { RecordingTarget } from '../../src/types';
+import type { AudioRecorderSettings } from 'src/settings/settingsSchema';
+import { DEFAULT_SETTINGS } from 'src/settings/settingsSchema';
+import type { RecordingTarget } from 'src/types';
 
 // Mock obsidian module
 jest.mock('obsidian', () => ({
@@ -15,7 +14,7 @@ jest.mock('obsidian', () => ({
 }));
 
 // Mock AudioEncoder module
-jest.mock('../../src/audio/AudioEncoder', () => ({
+jest.mock('src/audio/AudioEncoder', () => ({
 	encodeAudioBuffer: jest
 		.fn()
 		.mockResolvedValue(new Blob(['encoded'], { type: 'audio/mp4' })),
@@ -127,8 +126,8 @@ import {
 	decodeAudioBlob,
 	buildOutputBlob,
 	mergeAudioTracks,
-} from '../../src/audio/AudioFormatConverter';
-import type { EncodingWorkerClient } from '../../src/audio/EncodingWorkerClient';
+} from 'src/audio/AudioFormatConverter';
+import type { EncodingWorkerClient } from 'src/audio/EncodingWorkerClient';
 
 describe('AudioFormatConverter', () => {
 	beforeEach(() => {
@@ -161,71 +160,44 @@ describe('AudioFormatConverter', () => {
 	// resolveRecorderFormat
 	// ---------------------------------------------------------------
 	describe('resolveRecorderFormat', () => {
-		it('should return native format when MediaRecorder supports it', () => {
-			const settings: AudioRecorderSettings = {
-				...DEFAULT_SETTINGS,
-				recordingFormat: 'webm',
-			};
-			const result = resolveRecorderFormat(settings);
-			expect(result).toEqual({
-				recorderFormat: 'webm',
-				mimeType: 'audio/webm',
-			});
-		});
+		it.each([
+			['webm (native support)', 'webm', 'webm'],
+			['ogg (native support)', 'ogg', 'ogg'],
+			['wav (always via intermediate, never native)', 'wav', 'webm'],
+			['WEBM (case-insensitive)', 'WEBM', 'webm'],
+		])(
+			'resolves %s to the %s recorder',
+			(_case, recordingFormat, expected) => {
+				const settings: AudioRecorderSettings = {
+					...DEFAULT_SETTINGS,
+					recordingFormat,
+				};
+				expect(resolveRecorderFormat(settings)).toEqual({
+					recorderFormat: expected,
+					mimeType: `audio/${expected}`,
+				});
+			},
+		);
 
-		it('should return native format for OGG when supported', () => {
-			const settings: AudioRecorderSettings = {
-				...DEFAULT_SETTINGS,
-				recordingFormat: 'ogg',
-			};
-			const result = resolveRecorderFormat(settings);
-			expect(result).toEqual({
-				recorderFormat: 'ogg',
-				mimeType: 'audio/ogg',
-			});
-		});
-
-		it('should fall back to WebM when native format is not supported', () => {
-			const settings: AudioRecorderSettings = {
-				...DEFAULT_SETTINGS,
-				recordingFormat: 'mp4',
-			};
-			// mp4 not supported natively, but webm is
-			(MediaRecorder.isTypeSupported as jest.Mock).mockImplementation(
-				(mime: string) => mime === 'audio/webm',
-			);
-			const result = resolveRecorderFormat(settings);
-			expect(result).toEqual({
-				recorderFormat: 'webm',
-				mimeType: 'audio/webm',
-			});
-		});
-
-		it('should fall back to OGG when WebM is not supported', () => {
-			const settings: AudioRecorderSettings = {
-				...DEFAULT_SETTINGS,
-				recordingFormat: 'mp4',
-			};
-			(MediaRecorder.isTypeSupported as jest.Mock).mockImplementation(
-				(mime: string) => mime === 'audio/ogg',
-			);
-			const result = resolveRecorderFormat(settings);
-			expect(result).toEqual({
-				recorderFormat: 'ogg',
-				mimeType: 'audio/ogg',
-			});
-		});
-
-		it('should always use intermediate format for WAV (never native)', () => {
-			const settings: AudioRecorderSettings = {
-				...DEFAULT_SETTINGS,
-				recordingFormat: 'wav',
-			};
-			const result = resolveRecorderFormat(settings);
-			// WAV always falls through to intermediate compressed format
-			expect(result.recorderFormat).toBe('webm');
-			expect(result.mimeType).toBe('audio/webm');
-		});
+		it.each([
+			['WebM', 'audio/webm', 'webm'],
+			['OGG when WebM is unsupported', 'audio/ogg', 'ogg'],
+		])(
+			'falls back to %s for an unsupported native format',
+			(_case, supportedMime, expected) => {
+				const settings: AudioRecorderSettings = {
+					...DEFAULT_SETTINGS,
+					recordingFormat: 'mp4',
+				};
+				(MediaRecorder.isTypeSupported as jest.Mock).mockImplementation(
+					(mime: string) => mime === supportedMime,
+				);
+				expect(resolveRecorderFormat(settings)).toEqual({
+					recorderFormat: expected,
+					mimeType: supportedMime,
+				});
+			},
+		);
 
 		it('should throw when neither WebM nor OGG is supported', () => {
 			const settings: AudioRecorderSettings = {
@@ -237,56 +209,34 @@ describe('AudioFormatConverter', () => {
 				/neither WebM nor OGG is supported/,
 			);
 		});
-
-		it('should treat format case-insensitively', () => {
-			const settings: AudioRecorderSettings = {
-				...DEFAULT_SETTINGS,
-				recordingFormat: 'WEBM',
-			};
-			const result = resolveRecorderFormat(settings);
-			expect(result).toEqual({
-				recorderFormat: 'webm',
-				mimeType: 'audio/webm',
-			});
-		});
 	});
 
 	// ---------------------------------------------------------------
 	// isOfflineOnlyFormat
 	// ---------------------------------------------------------------
 	describe('isOfflineOnlyFormat', () => {
-		it('should return true when format differs from recorder format and supports offline encoding', () => {
-			// mp4 is offline-encodable and recorder uses webm
-			expect(isOfflineOnlyFormat('mp4', 'webm')).toBe(true);
-		});
-
-		it('should return true for mp3 with webm recorder', () => {
-			expect(isOfflineOnlyFormat('mp3', 'webm')).toBe(true);
-		});
-
-		it('should return true for flac with ogg recorder', () => {
-			expect(isOfflineOnlyFormat('flac', 'ogg')).toBe(true);
-		});
-
-		it('should return true for aac with webm recorder', () => {
-			expect(isOfflineOnlyFormat('aac', 'webm')).toBe(true);
-		});
-
-		it('should return true for m4a with webm recorder', () => {
-			expect(isOfflineOnlyFormat('m4a', 'webm')).toBe(true);
-		});
-
-		it('should return false when format matches recorder format', () => {
-			expect(isOfflineOnlyFormat('webm', 'webm')).toBe(false);
-		});
-
-		it('should return false for wav (always handled separately)', () => {
-			expect(isOfflineOnlyFormat('wav', 'webm')).toBe(false);
-		});
+		it.each([
+			['mp4', 'webm', true],
+			['mp3', 'webm', true],
+			['flac', 'ogg', true],
+			['aac', 'webm', true],
+			['m4a', 'webm', true],
+			// Matching the recorder format needs no offline pass
+			['webm', 'webm', false],
+			// WAV is always handled separately
+			['wav', 'webm', false],
+		])(
+			'isOfflineOnlyFormat(%s, %s) is %s',
+			(format, recorderFormat, expected) => {
+				expect(isOfflineOnlyFormat(format, recorderFormat)).toBe(
+					expected,
+				);
+			},
+		);
 
 		it('should return false when format is not offline-encoding-supported', () => {
 			const { isOfflineEncodingSupported } = jest.requireMock(
-				'../../src/audio/AudioEncoder',
+				'src/audio/AudioEncoder',
 			);
 			isOfflineEncodingSupported.mockReturnValueOnce(false);
 			expect(isOfflineOnlyFormat('unknownformat', 'webm')).toBe(false);
@@ -317,7 +267,7 @@ describe('AudioFormatConverter', () => {
 				new Error('unreadable container'),
 			);
 			const { encodeAudioBuffer } = jest.requireMock(
-				'../../src/audio/AudioEncoder',
+				'src/audio/AudioEncoder',
 			);
 
 			const inputBlob = new Blob(['audio-data'], { type: 'audio/webm' });
@@ -435,7 +385,7 @@ describe('AudioFormatConverter', () => {
 
 		it('should convert via the streaming Conversion pipeline', async () => {
 			const { encodeAudioBuffer } = jest.requireMock(
-				'../../src/audio/AudioEncoder',
+				'src/audio/AudioEncoder',
 			);
 			const blob = new Blob(['test'], { type: 'audio/webm' });
 
@@ -459,7 +409,7 @@ describe('AudioFormatConverter', () => {
 
 		it('should register the extension encoder before converting', async () => {
 			const { ensureEncoderRegistered } = jest.requireMock(
-				'../../src/audio/AudioEncoder',
+				'src/audio/AudioEncoder',
 			);
 			const blob = new Blob(['test'], { type: 'audio/webm' });
 
@@ -528,7 +478,7 @@ describe('AudioFormatConverter', () => {
 
 		it('should fall back when the audio track is discarded', async () => {
 			const { encodeAudioBuffer } = jest.requireMock(
-				'../../src/audio/AudioEncoder',
+				'src/audio/AudioEncoder',
 			);
 			// Conversion.init does not throw for codec problems: the
 			// track is discarded and the output would contain no audio
@@ -586,7 +536,7 @@ describe('AudioFormatConverter', () => {
 
 		it('should fall back when the conversion is invalid', async () => {
 			const { encodeAudioBuffer } = jest.requireMock(
-				'../../src/audio/AudioEncoder',
+				'src/audio/AudioEncoder',
 			);
 			mockConversionInit.mockImplementationOnce(() =>
 				Promise.resolve({
@@ -609,7 +559,7 @@ describe('AudioFormatConverter', () => {
 
 		it('should fall back when the input has no audio track', async () => {
 			const { encodeAudioBuffer } = jest.requireMock(
-				'../../src/audio/AudioEncoder',
+				'src/audio/AudioEncoder',
 			);
 			mockGetPrimaryAudioTrack.mockResolvedValueOnce(null);
 			const warnSpy = jest
@@ -626,7 +576,7 @@ describe('AudioFormatConverter', () => {
 
 		it('should fall back to decode and re-encode when conversion fails', async () => {
 			const { encodeAudioBuffer } = jest.requireMock(
-				'../../src/audio/AudioEncoder',
+				'src/audio/AudioEncoder',
 			);
 			mockConversionInit.mockRejectedValueOnce(
 				new Error('unreadable container'),
@@ -651,7 +601,7 @@ describe('AudioFormatConverter', () => {
 
 		it('should fall back when the conversion produces empty output', async () => {
 			const { encodeAudioBuffer } = jest.requireMock(
-				'../../src/audio/AudioEncoder',
+				'src/audio/AudioEncoder',
 			);
 			const { BufferTarget } = jest.requireMock('mediabunny');
 			BufferTarget.mockImplementationOnce(() => ({ buffer: null }));
@@ -681,7 +631,7 @@ describe('AudioFormatConverter', () => {
 			await convertBlobToFormat(blob, 'mp4', 128000, progressFn);
 
 			const { encodeAudioBuffer } = jest.requireMock(
-				'../../src/audio/AudioEncoder',
+				'src/audio/AudioEncoder',
 			);
 			expect(encodeAudioBuffer).toHaveBeenCalledWith(
 				expect.anything(),
@@ -805,7 +755,7 @@ describe('AudioFormatConverter', () => {
 
 		it('should encode merged result for offline-encodable formats', async () => {
 			const { encodeAudioBuffer } = jest.requireMock(
-				'../../src/audio/AudioEncoder',
+				'src/audio/AudioEncoder',
 			);
 			const targets = [createMockTarget('track1')];
 			const buildTrackBlob = jest
@@ -831,7 +781,7 @@ describe('AudioFormatConverter', () => {
 
 		it('should encode the mix as WAV when format is wav', async () => {
 			const { encodeAudioBuffer } = jest.requireMock(
-				'../../src/audio/AudioEncoder',
+				'src/audio/AudioEncoder',
 			);
 			const targets = [createMockTarget('track1')];
 			const buildTrackBlob = jest
@@ -1054,7 +1004,7 @@ describe('AudioFormatConverter', () => {
 
 		it('should forward progress callback with adjusted percentage', async () => {
 			const { encodeAudioBuffer } = jest.requireMock(
-				'../../src/audio/AudioEncoder',
+				'src/audio/AudioEncoder',
 			);
 
 			// Capture the progress callback passed to encodeAudioBuffer

--- a/tests/unit/AudioFormatConverter.test.ts
+++ b/tests/unit/AudioFormatConverter.test.ts
@@ -5,8 +5,8 @@
  */
 /** @jest-environment jsdom */
 
-import type { AudioRecorderSettings } from '../../src/settings/Settings';
-import { DEFAULT_SETTINGS } from '../../src/settings/Settings';
+import type { AudioRecorderSettings } from '../../src/settings/settingsSchema';
+import { DEFAULT_SETTINGS } from '../../src/settings/settingsSchema';
 import type { RecordingTarget } from '../../src/types';
 
 // Mock obsidian module

--- a/tests/unit/AudioProcessingModal.test.ts
+++ b/tests/unit/AudioProcessingModal.test.ts
@@ -9,8 +9,8 @@
 import { App, Notice, TFile } from 'obsidian';
 import { AudioProcessingModal } from '../../src/cleanup/AudioProcessingModal';
 import { AudioProcessingService } from '../../src/cleanup/AudioProcessingService';
-import { DEFAULT_SETTINGS } from '../../src/settings/Settings';
-import type { AudioRecorderSettings } from '../../src/settings/Settings';
+import { DEFAULT_SETTINGS } from '../../src/settings/settingsSchema';
+import type { AudioRecorderSettings } from '../../src/settings/settingsSchema';
 
 jest.mock('../../src/cleanup/AudioProcessingService');
 

--- a/tests/unit/AudioProcessingModal.test.ts
+++ b/tests/unit/AudioProcessingModal.test.ts
@@ -130,7 +130,7 @@ describe('AudioProcessingModal', () => {
 		await settle();
 
 		expect(processMock).not.toHaveBeenCalled();
-		expect(Notice as unknown as jest.Mock).toHaveBeenCalledWith(
+		expect(Notice).toHaveBeenCalledWith(
 			'Enable at least one processing stage.',
 		);
 	});
@@ -155,7 +155,7 @@ describe('AudioProcessingModal', () => {
 			replaceSource: false,
 		});
 		expect(app.fileManager.trashFile).not.toHaveBeenCalled();
-		expect(Notice as unknown as jest.Mock).toHaveBeenCalledWith(
+		expect(Notice).toHaveBeenCalledWith(
 			'Processed audio saved to recordings/take-processed.wav',
 		);
 		expect(closeSpy).toHaveBeenCalled();
@@ -202,7 +202,7 @@ describe('AudioProcessingModal', () => {
 		processButton.click();
 		await settle();
 
-		expect(Notice as unknown as jest.Mock).toHaveBeenCalledWith(
+		expect(Notice).toHaveBeenCalledWith(
 			'Processed audio saved to recordings/take-processed.wav, but the source could not be deleted.',
 		);
 		warnSpy.mockRestore();
@@ -219,7 +219,7 @@ describe('AudioProcessingModal', () => {
 		processButton.click();
 		await settle();
 
-		expect(Notice as unknown as jest.Mock).toHaveBeenCalledWith(
+		expect(Notice).toHaveBeenCalledWith(
 			'Audio processing failed: decode failed',
 		);
 		expect(closeSpy).not.toHaveBeenCalled();
@@ -240,7 +240,7 @@ describe('AudioProcessingModal', () => {
 		processButton.click();
 		await settle();
 
-		expect(Notice as unknown as jest.Mock).toHaveBeenCalledWith(
+		expect(Notice).toHaveBeenCalledWith(
 			'Processed audio saved to recordings/take-processed.wav',
 		);
 		expect(closeSpy).toHaveBeenCalled();

--- a/tests/unit/AudioProcessingModal.test.ts
+++ b/tests/unit/AudioProcessingModal.test.ts
@@ -7,12 +7,12 @@
  */
 
 import { App, Notice, TFile } from 'obsidian';
-import { AudioProcessingModal } from '../../src/cleanup/AudioProcessingModal';
-import { AudioProcessingService } from '../../src/cleanup/AudioProcessingService';
-import { DEFAULT_SETTINGS } from '../../src/settings/settingsSchema';
-import type { AudioRecorderSettings } from '../../src/settings/settingsSchema';
+import { AudioProcessingModal } from 'src/cleanup/AudioProcessingModal';
+import { AudioProcessingService } from 'src/cleanup/AudioProcessingService';
+import { DEFAULT_SETTINGS } from 'src/settings/settingsSchema';
+import type { AudioRecorderSettings } from 'src/settings/settingsSchema';
 
-jest.mock('../../src/cleanup/AudioProcessingService');
+jest.mock('src/cleanup/AudioProcessingService');
 
 const processMock = jest.fn();
 

--- a/tests/unit/AudioProcessingService.test.ts
+++ b/tests/unit/AudioProcessingService.test.ts
@@ -5,7 +5,6 @@
  * path runs: read -> decode -> gate -> offline render -> WAV encode ->
  * write. Also covers the WAV encoder round-trip and the guards.
  *
- * @jest-environment jsdom
  */
 
 import type { App, TFile } from 'obsidian';

--- a/tests/unit/AudioSplitter.test.ts
+++ b/tests/unit/AudioSplitter.test.ts
@@ -16,9 +16,9 @@ import {
 	totalByteLength,
 	detachTrailingBytes,
 	type WavLayout,
-} from '../../src/recording/AudioSplitter';
-import { PCM_BYTES_PER_SAMPLE } from '../../src/audio/pcm';
-import { createWavHeader } from '../../src/audio/WavEncoder';
+} from 'src/recording/AudioSplitter';
+import { PCM_BYTES_PER_SAMPLE } from 'src/audio/pcm';
+import { createWavHeader } from 'src/audio/WavEncoder';
 
 /** WAV header size produced by createWavHeader. */
 const WAV_HEADER_SIZE = 44;
@@ -260,7 +260,7 @@ describe('computeWavPartBytes', () => {
 		const wav = buildTestWav(1, 1000, 12000);
 		const layout = parseWavLayout(wav);
 
-		expect(computeWavPartBytes(layout!, 2)).toBe(4000);
+		expect(computeWavPartBytes(layout, 2)).toBe(4000);
 	});
 
 	it('should align the part size down to blockAlign', () => {
@@ -293,7 +293,7 @@ describe('buildWavPart', () => {
 		const wav = buildTestWav(1, 1000, 12000);
 		const layout = parseWavLayout(wav);
 
-		const parts = splitWav(wav, layout!, 2);
+		const parts = splitWav(wav, layout, 2);
 
 		expect(parts).toHaveLength(3);
 		for (const part of parts) {
@@ -306,7 +306,7 @@ describe('buildWavPart', () => {
 		const wav = buildTestWav(1, 1000, 10000);
 		const layout = parseWavLayout(wav);
 
-		const parts = splitWav(wav, layout!, 2);
+		const parts = splitWav(wav, layout, 2);
 
 		expect(parts).toHaveLength(3);
 		expect(parseWavLayout(parts[0])?.dataLength).toBe(4000);
@@ -320,7 +320,7 @@ describe('buildWavPart', () => {
 		const layout = parseWavLayout(wav);
 
 		// 1.5 s -> raw 6000 B, already aligned to 4
-		const parts = splitWav(wav, layout!, 1.5);
+		const parts = splitWav(wav, layout, 1.5);
 
 		expect(parts).toHaveLength(3);
 		for (const part of parts) {
@@ -333,7 +333,7 @@ describe('buildWavPart', () => {
 		const wav = buildTestWav(1, 1000, 6000);
 		const layout = parseWavLayout(wav);
 
-		const parts = splitWav(wav, layout!, 1.5);
+		const parts = splitWav(wav, layout, 1.5);
 
 		const reassembled: number[] = [];
 		for (const part of parts) {
@@ -353,7 +353,7 @@ describe('buildWavPart', () => {
 		const wav = buildTestWav(1, 1000, 6000);
 		const layout = parseWavLayout(wav);
 
-		const parts = splitWav(wav, layout!, 2);
+		const parts = splitWav(wav, layout, 2);
 
 		for (const part of parts) {
 			const view = new DataView(part);
@@ -365,7 +365,7 @@ describe('buildWavPart', () => {
 		const wav = buildTestWav(1, 1000, 10000);
 		const layout = parseWavLayout(wav);
 
-		const parts = splitWav(wav, layout!, 2);
+		const parts = splitWav(wav, layout, 2);
 
 		const expectedSizes = [4000, 4000, 2000];
 		parts.forEach((part, index) => {
@@ -383,7 +383,7 @@ describe('buildWavPart', () => {
 		const layout = parseWavLayout(wav);
 		expect(layout?.dataOffset).toBe(WAV_HEADER_SIZE + 18);
 
-		const parts = splitWav(wav, layout!, 0.0025);
+		const parts = splitWav(wav, layout, 0.0025);
 
 		expect(parts).toHaveLength(3);
 		const reassembled: number[] = [];
@@ -406,7 +406,7 @@ describe('buildWavPart', () => {
 		const wav = buildTestWav(1, 1000, 6000);
 		const layout = parseWavLayout(wav);
 
-		expect(splitWav(wav, layout!, 0)).toEqual([]);
+		expect(splitWav(wav, layout, 0)).toEqual([]);
 	});
 
 	it('should build a header-only part when the index starts at the data end', () => {
@@ -414,7 +414,7 @@ describe('buildWavPart', () => {
 		const layout = parseWavLayout(wav);
 
 		// start = 2 * 3000 = dataLength, so the part holds zero sample bytes
-		const part = buildWavPart(wav, layout!, 3000, 2);
+		const part = buildWavPart(wav, layout, 3000, 2);
 
 		expect(part.byteLength).toBe(WAV_HEADER_SIZE);
 		const view = new DataView(part);

--- a/tests/unit/AudioStreamHandler.test.ts
+++ b/tests/unit/AudioStreamHandler.test.ts
@@ -8,7 +8,7 @@ import {
 	getOrderedTrackSources,
 } from '../../src/recording/AudioStreamHandler';
 import { AudioStreamError } from '../../src/errors';
-import { DEFAULT_SETTINGS } from '../../src/settings/Settings';
+import { DEFAULT_SETTINGS } from '../../src/settings/settingsSchema';
 
 /** Builds a MediaStream stub whose tracks record stop() calls. */
 function fakeStream(): { stream: MediaStream; stop: jest.Mock } {

--- a/tests/unit/AudioStreamHandler.test.ts
+++ b/tests/unit/AudioStreamHandler.test.ts
@@ -6,9 +6,9 @@
 import {
 	getAudioStreams,
 	getOrderedTrackSources,
-} from '../../src/recording/AudioStreamHandler';
-import { AudioStreamError } from '../../src/errors';
-import { DEFAULT_SETTINGS } from '../../src/settings/settingsSchema';
+} from 'src/recording/AudioStreamHandler';
+import { AudioStreamError } from 'src/errors';
+import { DEFAULT_SETTINGS } from 'src/settings/settingsSchema';
 
 /** Builds a MediaStream stub whose tracks record stop() calls. */
 function fakeStream(): { stream: MediaStream; stop: jest.Mock } {

--- a/tests/unit/ContextMenu.test.ts
+++ b/tests/unit/ContextMenu.test.ts
@@ -1,14 +1,18 @@
 /**
- * Unit tests for ContextMenu module.
+ * Unit tests for ContextMenu. Behavior-focused: menus are rendered into a
+ * recording Menu fake and asserted by their visible item titles and what
+ * each item's click actually does (modals opened, files trashed, links
+ * removed), not by the setIcon/setSection call structure - so harmless
+ * implementation changes do not break the suite while real regressions
+ * (a missing action, a click doing the wrong thing) still do.
  * @module tests/unit/ContextMenu.test
  */
-/** @jest-environment jsdom */
 
-import { ContextMenu } from '../../src/ui/ContextMenu';
-import { FILE_ACTIONS } from '../../src/actions/fileActions';
-import { AUDIO_EXTENSIONS, FORMAT_MP4 } from '../../src/constants';
-import type { AudioRecorderSettings } from '../../src/settings/settingsSchema';
-import * as AudioFileAnalyzer from '../../src/utils/AudioFileAnalyzer';
+import { ContextMenu } from 'src/ui/ContextMenu';
+import { FILE_ACTIONS } from 'src/actions/fileActions';
+import { AUDIO_EXTENSIONS } from 'src/constants';
+import type { AudioRecorderSettings } from 'src/settings/settingsSchema';
+import * as AudioFileAnalyzer from 'src/utils/AudioFileAnalyzer';
 import {
 	App,
 	Menu,
@@ -22,51 +26,111 @@ import {
 	FileManager,
 } from 'obsidian';
 
-// Mock obsidian module
-jest.mock('obsidian', () => ({
-	App: jest.fn(),
-	Menu: class {
-		addItem = jest.fn();
-		showAtPosition = jest.fn();
-	},
-	Modal: class {},
-	TFile: jest.fn(),
-	Plugin: jest.fn(),
-	Editor: jest.fn(),
-	Notice: jest.fn(),
-	MarkdownView: jest.fn(),
-	FileManager: jest.fn(),
-}));
+/** The shape of a recorded menu item (see the Menu fake below). */
+interface RecordedMenuItem {
+	title: string;
+	onClickHandler: (() => unknown) | null;
+}
 
-jest.mock('../../src/ui/AudioFileInfoModal', () => ({
+/** The shape of the recording Menu fake, for structural casts. */
+interface RecordedMenu {
+	items: RecordedMenuItem[];
+	showAtPosition: jest.Mock;
+}
+
+// Mock obsidian with a recording Menu fake: items are inspectable by
+// title and clickable, so tests assert user-visible behavior instead of
+// builder-call structure.
+jest.mock('obsidian', () => {
+	class MockMenuItem {
+		title = '';
+		onClickHandler: (() => unknown) | null = null;
+		setTitle(title: string): this {
+			this.title = title;
+			return this;
+		}
+		setIcon(): this {
+			return this;
+		}
+		setSection(): this {
+			return this;
+		}
+		onClick(handler: () => unknown): this {
+			this.onClickHandler = handler;
+			return this;
+		}
+	}
+	class MockMenu {
+		items: MockMenuItem[] = [];
+		showAtPosition = jest.fn();
+		addItem(cb: (item: MockMenuItem) => void): this {
+			const item = new MockMenuItem();
+			cb(item);
+			this.items.push(item);
+			return this;
+		}
+		addSeparator(): this {
+			return this;
+		}
+	}
+	return {
+		App: jest.fn(),
+		Menu: MockMenu,
+		Modal: class {},
+		TFile: jest.fn(),
+		Plugin: jest.fn(),
+		Editor: jest.fn(),
+		Notice: jest.fn(),
+		MarkdownView: jest.fn(),
+		FileManager: jest.fn(),
+	};
+});
+
+jest.mock('src/ui/AudioFileInfoModal', () => ({
 	AudioFileInfoModal: jest.fn().mockImplementation(() => ({
 		open: jest.fn(),
 	})),
 }));
 
-jest.mock('../../src/ui/ConversionModal', () => ({
+jest.mock('src/ui/ConversionModal', () => ({
 	ConversionModal: jest.fn().mockImplementation(() => ({
 		open: jest.fn(),
 	})),
 }));
 
-jest.mock('../../src/ui/SplitModal', () => ({
+jest.mock('src/ui/SplitModal', () => ({
 	SplitModal: jest.fn().mockImplementation(() => ({
 		open: jest.fn(),
 	})),
 }));
 
-jest.mock('../../src/cleanup/AudioProcessingModal', () => ({
+jest.mock('src/cleanup/AudioProcessingModal', () => ({
 	AudioProcessingModal: jest.fn().mockImplementation(() => ({
 		open: jest.fn(),
 	})),
 }));
 
 // Mock AudioEncoder to avoid mediabunny TextDecoder requirement
-jest.mock('../../src/audio/AudioEncoder', () => ({
+jest.mock('src/audio/AudioEncoder', () => ({
 	encodeAudioBuffer: jest.fn(),
 	isOfflineEncodingSupported: jest.fn().mockReturnValue(true),
 }));
+
+/** The visible item titles of a rendered menu. */
+function titlesOf(menu: Menu): string[] {
+	return (menu as unknown as RecordedMenu).items.map((item) => item.title);
+}
+
+/** Clicks the menu item with the given title (fails if absent). */
+async function clickItem(menu: Menu, title: string): Promise<void> {
+	const item = (menu as unknown as RecordedMenu).items.find(
+		(candidate) => candidate.title === title,
+	);
+	if (!item?.onClickHandler) {
+		throw new Error(`menu item "${title}" not found or not clickable`);
+	}
+	await item.onClickHandler();
+}
 
 describe('ContextMenu', () => {
 	let contextMenu: ContextMenu;
@@ -80,7 +144,6 @@ describe('ContextMenu', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 
-		// Mock App and its components
 		mockWorkspace = {
 			on: jest.fn(),
 			trigger: jest.fn(),
@@ -107,7 +170,6 @@ describe('ContextMenu', () => {
 			fileManager: mockFileManager,
 		} as unknown as App;
 
-		// Mock Plugin
 		mockPlugin = {
 			registerEvent: jest.fn(),
 			registerDomEvent: jest.fn(),
@@ -130,25 +192,25 @@ describe('ContextMenu', () => {
 		);
 	});
 
+	function makeAudioFile(extension = 'mp3'): TFile {
+		const file = new TFile();
+		Object.defineProperty(file, 'extension', { value: extension });
+		return file;
+	}
+
 	describe('register', () => {
 		it('should register file, editor, and player menus', () => {
-			// We can't easily spy on private methods, so we verify side effects (calls to plugin.register*)
 			contextMenu.register();
 
-			// registerFileMenu calls workspace.on('file-menu') and plugin.registerEvent
 			expect(mockWorkspace.on).toHaveBeenCalledWith(
 				'file-menu',
 				expect.any(Function),
 			);
 			expect(mockPlugin.registerEvent).toHaveBeenCalled();
-
-			// registerEditorMenu calls workspace.on('editor-menu') and plugin.registerEvent
 			expect(mockWorkspace.on).toHaveBeenCalledWith(
 				'editor-menu',
 				expect.any(Function),
 			);
-
-			// registerPlayerMenu calls plugin.registerDomEvent
 			expect(mockPlugin.registerDomEvent).toHaveBeenCalledWith(
 				document,
 				'contextmenu',
@@ -163,330 +225,146 @@ describe('ContextMenu', () => {
 
 		beforeEach(() => {
 			contextMenu.register();
-			// Extract the callback passed to workspace.on('file-menu', ...)
 			const call = (mockWorkspace.on as jest.Mock).mock.calls.find(
 				(c) => c[0] === 'file-menu',
 			);
 			fileMenuCallback = call[1];
 		});
 
-		it('should include mp4 in AUDIO_EXTENSIONS', () => {
-			expect(AUDIO_EXTENSIONS).toContain(FORMAT_MP4);
-		});
-
 		test.each(AUDIO_EXTENSIONS)(
-			'should add "Delete recording" item for %s files',
+			'offers the recording actions for %s files',
 			(extension) => {
-				const mockMenu = new Menu();
-				const mockFile = new TFile();
-				Object.defineProperty(mockFile, 'extension', {
-					value: extension,
-				});
+				const menu = new Menu();
 
-				fileMenuCallback(mockMenu, mockFile);
+				fileMenuCallback(menu, makeAudioFile(extension));
 
-				expect(mockMenu.addItem).toHaveBeenCalled();
+				expect(titlesOf(menu)).toContain('Delete recording');
 			},
 		);
 
-		it('should add "Delete recording" item for audio files', () => {
-			const mockMenu = new Menu();
-			const mockFile = new TFile();
-			// Mock TFile properties setup
-			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
+		it('offers the full action set for an audio file (transcription off)', () => {
+			const menu = new Menu();
 
-			fileMenuCallback(mockMenu, mockFile);
+			fileMenuCallback(menu, makeAudioFile());
 
-			expect(mockMenu.addItem).toHaveBeenCalledTimes(5);
-
-			// Verify the delete item configuration (4th item: Audio info, Convert, Split, Delete)
-			const addItemCallback = (mockMenu.addItem as jest.Mock).mock
-				.calls[4][0];
-			const mockItem = {
-				setTitle: jest.fn().mockReturnThis(),
-				setIcon: jest.fn().mockReturnThis(),
-				setSection: jest.fn().mockReturnThis(),
-				onClick: jest.fn(),
-			};
-			addItemCallback(mockItem);
-
-			expect(mockItem.setTitle).toHaveBeenCalledWith('Delete recording');
-			expect(mockItem.setIcon).toHaveBeenCalledWith('trash');
-			expect(mockItem.setSection).toHaveBeenCalledWith('aar');
+			expect(titlesOf(menu)).toEqual([
+				'Audio file info',
+				'Convert audio format',
+				'Split audio into parts',
+				'Clean up audio',
+				'Delete recording',
+			]);
 		});
 
-		it('should add "Audio file info" item for audio files', () => {
-			const mockMenu = new Menu();
-			const mockFile = new TFile();
-			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
-
-			fileMenuCallback(mockMenu, mockFile);
-
-			expect(mockMenu.addItem).toHaveBeenCalledTimes(5);
-
-			// Verify the audio info item configuration (1st item)
-			const addItemCallback = (mockMenu.addItem as jest.Mock).mock
-				.calls[0][0];
-			const mockItem = {
-				setTitle: jest.fn().mockReturnThis(),
-				setIcon: jest.fn().mockReturnThis(),
-				setSection: jest.fn().mockReturnThis(),
-				onClick: jest.fn(),
-			};
-			addItemCallback(mockItem);
-
-			expect(mockItem.setTitle).toHaveBeenCalledWith('Audio file info');
-			expect(mockItem.setIcon).toHaveBeenCalledWith('info');
-			expect(mockItem.setSection).toHaveBeenCalledWith('aar');
-		});
-
-		it('should open AudioFileInfoModal on "Audio file info" click', async () => {
-			const mockMenu = new Menu();
-			const mockFile = new TFile();
-			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
-
-			const mockInfo = { name: 'audio.mp3', size: 1024 };
+		it('opens the file-info modal from "Audio file info"', async () => {
+			const { AudioFileInfoModal } = jest.requireMock(
+				'src/ui/AudioFileInfoModal',
+			);
+			const menu = new Menu();
+			const file = makeAudioFile();
+			const info = { name: 'audio.mp3', size: 1024 };
 			jest.spyOn(AudioFileAnalyzer, 'getAudioFileInfo').mockResolvedValue(
-				mockInfo,
+				info,
 			);
 
-			fileMenuCallback(mockMenu, mockFile);
-
-			const addItemCallback = (mockMenu.addItem as jest.Mock).mock
-				.calls[0][0];
-			const mockItem = {
-				setTitle: jest.fn().mockReturnThis(),
-				setIcon: jest.fn().mockReturnThis(),
-				setSection: jest.fn().mockReturnThis(),
-				onClick: jest.fn(),
-			};
-			addItemCallback(mockItem);
-
-			const clickHandler = mockItem.onClick.mock.calls[0][0];
-			await clickHandler();
+			fileMenuCallback(menu, file);
+			await clickItem(menu, 'Audio file info');
 
 			expect(AudioFileAnalyzer.getAudioFileInfo).toHaveBeenCalledWith(
 				mockApp,
-				mockFile,
+				file,
 			);
+			expect(AudioFileInfoModal).toHaveBeenCalled();
 		});
 
-		it('should not open modal if getAudioFileInfo returns null', async () => {
-			const mockMenu = new Menu();
-			const mockFile = new TFile();
-			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
-
+		it('does not open the file-info modal when analysis fails', async () => {
+			const { AudioFileInfoModal } = jest.requireMock(
+				'src/ui/AudioFileInfoModal',
+			);
+			const menu = new Menu();
 			jest.spyOn(AudioFileAnalyzer, 'getAudioFileInfo').mockResolvedValue(
 				null,
 			);
 
-			fileMenuCallback(mockMenu, mockFile);
+			fileMenuCallback(menu, makeAudioFile());
+			await clickItem(menu, 'Audio file info');
 
-			const addItemCallback = (mockMenu.addItem as jest.Mock).mock
-				.calls[0][0];
-			const mockItem = {
-				setTitle: jest.fn().mockReturnThis(),
-				setIcon: jest.fn().mockReturnThis(),
-				setSection: jest.fn().mockReturnThis(),
-				onClick: jest.fn(),
-			};
-			addItemCallback(mockItem);
+			expect(AudioFileInfoModal).not.toHaveBeenCalled();
+		});
 
-			const clickHandler = mockItem.onClick.mock.calls[0][0];
-			await clickHandler();
+		it('does not duplicate actions when both menu hooks fire for one menu', () => {
+			const menu = new Menu();
+			const file = makeAudioFile();
 
-			expect(AudioFileAnalyzer.getAudioFileInfo).toHaveBeenCalledWith(
-				mockApp,
-				mockFile,
+			// Simulate both editor-menu and file-menu firing for the same Menu
+			fileMenuCallback(menu, file);
+			fileMenuCallback(menu, file);
+
+			const titles = titlesOf(menu);
+			expect(titles.filter((t) => t === 'Audio file info')).toHaveLength(
+				1,
 			);
+			expect(
+				titles.filter((t) => t === 'Split audio into parts'),
+			).toHaveLength(1);
 		});
 
-		it('should not duplicate "Audio file info" when called twice on the same menu', () => {
-			const mockMenu = new Menu();
-			const mockFile = new TFile();
-			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
+		it('opens SplitModal with the current settings from "Split audio into parts"', async () => {
+			const { SplitModal } = jest.requireMock('src/ui/SplitModal');
+			const menu = new Menu();
+			const file = makeAudioFile();
 
-			// Simulate both editor-menu and file-menu firing for the same Menu instance
-			fileMenuCallback(mockMenu, mockFile);
-			fileMenuCallback(mockMenu, mockFile);
-
-			// "Audio file info" should be added only once, but "Delete recording" is added each time
-			const calls = (mockMenu.addItem as jest.Mock).mock.calls;
-			const titles: string[] = [];
-			for (const call of calls) {
-				const mockItem = {
-					setTitle: jest.fn().mockReturnThis(),
-					setIcon: jest.fn().mockReturnThis(),
-					setSection: jest.fn().mockReturnThis(),
-					onClick: jest.fn(),
-				};
-				call[0](mockItem);
-				titles.push(mockItem.setTitle.mock.calls[0][0] as string);
-			}
-
-			const infoCount = titles.filter(
-				(t) => t === 'Audio file info',
-			).length;
-			expect(infoCount).toBe(1);
-		});
-
-		it('should add "Split audio into parts" item for audio files', () => {
-			const mockMenu = new Menu();
-			const mockFile = new TFile();
-			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
-
-			fileMenuCallback(mockMenu, mockFile);
-
-			expect(mockMenu.addItem).toHaveBeenCalledTimes(5);
-
-			// Verify the split item configuration (3rd item: info, convert, split, delete)
-			const addItemCallback = (mockMenu.addItem as jest.Mock).mock
-				.calls[2][0];
-			const mockItem = {
-				setTitle: jest.fn().mockReturnThis(),
-				setIcon: jest.fn().mockReturnThis(),
-				setSection: jest.fn().mockReturnThis(),
-				onClick: jest.fn(),
-			};
-			addItemCallback(mockItem);
-
-			expect(mockItem.setTitle).toHaveBeenCalledWith(
-				'Split audio into parts',
-			);
-			expect(mockItem.setIcon).toHaveBeenCalledWith('scissors');
-			expect(mockItem.setSection).toHaveBeenCalledWith('aar');
-		});
-
-		it('should open SplitModal on "Split audio into parts" click', () => {
-			const { SplitModal } = jest.requireMock('../../src/ui/SplitModal');
-			const mockMenu = new Menu();
-			const mockFile = new TFile();
-			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
-
-			fileMenuCallback(mockMenu, mockFile);
-
-			const addItemCallback = (mockMenu.addItem as jest.Mock).mock
-				.calls[2][0];
-			const mockItem = {
-				setTitle: jest.fn().mockReturnThis(),
-				setIcon: jest.fn().mockReturnThis(),
-				setSection: jest.fn().mockReturnThis(),
-				onClick: jest.fn(),
-			};
-			addItemCallback(mockItem);
-
-			const clickHandler = mockItem.onClick.mock.calls[0][0];
-			clickHandler();
+			fileMenuCallback(menu, file);
+			await clickItem(menu, 'Split audio into parts');
 
 			expect(SplitModal).toHaveBeenCalledWith(
 				mockApp,
-				mockFile,
+				file,
 				expect.objectContaining({
 					deleteSourceAfterConversion: true,
 				}),
 			);
 		});
 
-		it('adds a "Clean up audio" item and opens AudioProcessingModal', () => {
+		it('opens AudioProcessingModal from "Clean up audio"', async () => {
 			const { AudioProcessingModal } = jest.requireMock(
-				'../../src/cleanup/AudioProcessingModal',
+				'src/cleanup/AudioProcessingModal',
 			);
-			const mockMenu = new Menu();
-			const mockFile = new TFile();
-			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
+			const menu = new Menu();
+			const file = makeAudioFile();
 
-			fileMenuCallback(mockMenu, mockFile);
+			fileMenuCallback(menu, file);
+			await clickItem(menu, 'Clean up audio');
 
-			// Order: info(0), convert(1), split(2), clean up(3), delete(4)
-			const addItemCallback = (mockMenu.addItem as jest.Mock).mock
-				.calls[3][0];
-			const mockItem = {
-				setTitle: jest.fn().mockReturnThis(),
-				setIcon: jest.fn().mockReturnThis(),
-				setSection: jest.fn().mockReturnThis(),
-				onClick: jest.fn(),
-			};
-			addItemCallback(mockItem);
-
-			expect(mockItem.setTitle).toHaveBeenCalledWith('Clean up audio');
-			expect(mockItem.setSection).toHaveBeenCalledWith('aar');
-
-			const clickHandler = mockItem.onClick.mock.calls[0][0];
-			clickHandler();
 			expect(AudioProcessingModal).toHaveBeenCalledWith(
 				mockApp,
-				mockFile,
+				file,
 				expect.any(Object),
 				expect.any(Function),
 			);
 		});
 
-		it('should not duplicate "Split audio into parts" when called twice on the same menu', () => {
-			const mockMenu = new Menu();
-			const mockFile = new TFile();
-			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
+		it('offers no actions for non-audio files', () => {
+			const menu = new Menu();
 
-			fileMenuCallback(mockMenu, mockFile);
-			fileMenuCallback(mockMenu, mockFile);
+			fileMenuCallback(menu, makeAudioFile('md'));
 
-			const calls = (mockMenu.addItem as jest.Mock).mock.calls;
-			const titles: string[] = [];
-			for (const call of calls) {
-				const mockItem = {
-					setTitle: jest.fn().mockReturnThis(),
-					setIcon: jest.fn().mockReturnThis(),
-					setSection: jest.fn().mockReturnThis(),
-					onClick: jest.fn(),
-				};
-				call[0](mockItem);
-				titles.push(mockItem.setTitle.mock.calls[0][0] as string);
-			}
-
-			const splitCount = titles.filter(
-				(t) => t === 'Split audio into parts',
-			).length;
-			expect(splitCount).toBe(1);
+			expect(titlesOf(menu)).toEqual([]);
 		});
 
-		it('should NOT add item for non-audio files', () => {
-			const mockMenu = new Menu();
-			const mockFile = new TFile();
-			Object.defineProperty(mockFile, 'extension', { value: 'md' });
+		it('trashes the file and confirms from "Delete recording"', async () => {
+			const menu = new Menu();
+			const file = makeAudioFile();
 
-			fileMenuCallback(mockMenu, mockFile);
+			fileMenuCallback(menu, file);
+			await clickItem(menu, 'Delete recording');
 
-			expect(mockMenu.addItem).not.toHaveBeenCalled();
-		});
-
-		it('should delete file on click', async () => {
-			const mockMenu = new Menu();
-			const mockFile = new TFile();
-			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
-
-			fileMenuCallback(mockMenu, mockFile);
-
-			const addItemCallback = (mockMenu.addItem as jest.Mock).mock
-				.calls[4][0];
-			const mockItem = {
-				setTitle: jest.fn().mockReturnThis(),
-				setIcon: jest.fn().mockReturnThis(),
-				setSection: jest.fn().mockReturnThis(),
-				onClick: jest.fn(),
-			};
-			addItemCallback(mockItem);
-
-			// Trigger click
-			const clickHandler = mockItem.onClick.mock.calls[0][0];
-			await clickHandler();
-
-			expect(mockFileManager.trashFile).toHaveBeenCalledWith(mockFile);
+			expect(mockFileManager.trashFile).toHaveBeenCalledWith(file);
 			expect(Notice).toHaveBeenCalledWith('Recording deleted');
 		});
 
-		it('should handle deletion error', async () => {
-			const mockMenu = new Menu();
-			const mockFile = new TFile();
-			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
+		it('reports a deletion failure without throwing', async () => {
+			const menu = new Menu();
 			(mockFileManager.trashFile as jest.Mock).mockRejectedValue(
 				new Error('Delete failed'),
 			);
@@ -494,20 +372,8 @@ describe('ContextMenu', () => {
 				.spyOn(console, 'error')
 				.mockImplementation(() => {});
 
-			fileMenuCallback(mockMenu, mockFile);
-
-			const addItemCallback = (mockMenu.addItem as jest.Mock).mock
-				.calls[4][0];
-			const mockItem = {
-				setTitle: jest.fn().mockReturnThis(),
-				setIcon: jest.fn().mockReturnThis(),
-				setSection: jest.fn().mockReturnThis(),
-				onClick: jest.fn(),
-			};
-			addItemCallback(mockItem);
-
-			const clickHandler = mockItem.onClick.mock.calls[0][0];
-			await clickHandler();
+			fileMenuCallback(menu, makeAudioFile());
+			await clickItem(menu, 'Delete recording');
 
 			expect(Notice).toHaveBeenCalledWith('Failed to delete recording');
 			expect(consoleSpy).toHaveBeenCalled();
@@ -539,9 +405,9 @@ describe('ContextMenu', () => {
 		});
 
 		test.each(AUDIO_EXTENSIONS)(
-			'should add "Delete recording & link" item for %s files',
+			'offers "Delete recording & link to file" for %s links',
 			(extension) => {
-				const mockMenu = new Menu();
+				const menu = new Menu();
 				(mockEditor.getLine as jest.Mock).mockReturnValue(
 					`[[audio.${extension}]]`,
 				);
@@ -549,123 +415,62 @@ describe('ContextMenu', () => {
 					line: 0,
 					ch: 2,
 				});
-
-				const mockFile = new TFile();
-				Object.defineProperty(mockFile, 'extension', {
-					value: extension,
-				});
 				(
 					mockMetadataCache.getFirstLinkpathDest as jest.Mock
-				).mockReturnValue(mockFile);
+				).mockReturnValue(makeAudioFile(extension));
 
-				editorMenuCallback(mockMenu, mockEditor, {});
+				editorMenuCallback(menu, mockEditor, {});
 
-				expect(mockMenu.addItem).toHaveBeenCalled();
+				expect(titlesOf(menu)).toContain(
+					'Delete recording & link to file',
+				);
 			},
 		);
 
-		it('should do nothing if no link at cursor', () => {
-			const mockMenu = new Menu();
+		it('offers nothing when no link is at the cursor', () => {
+			const menu = new Menu();
 			(mockEditor.getLine as jest.Mock).mockReturnValue('Just text');
 
-			editorMenuCallback(mockMenu, mockEditor, {});
+			editorMenuCallback(menu, mockEditor, {});
 
-			expect(mockMenu.addItem).not.toHaveBeenCalled();
+			expect(titlesOf(menu)).toEqual([]);
 		});
 
-		it('should do nothing if link resolves to non-audio file', () => {
-			const mockMenu = new Menu();
+		it('offers nothing when the link resolves to a non-audio file', () => {
+			const menu = new Menu();
 			(mockEditor.getLine as jest.Mock).mockReturnValue('[[note]]');
 			(mockEditor.getCursor as jest.Mock).mockReturnValue({
 				line: 0,
 				ch: 2,
-			}); // Inside link
-			(
-				mockMetadataCache.getFirstLinkpathDest as jest.Mock
-			).mockReturnValue(new TFile()); // Default check fails mostly on extension mock? Or default TFile mock
-
-			const mockFile = new TFile();
-			Object.defineProperty(mockFile, 'extension', { value: 'md' });
-			(
-				mockMetadataCache.getFirstLinkpathDest as jest.Mock
-			).mockReturnValue(mockFile);
-
-			editorMenuCallback(mockMenu, mockEditor, {});
-
-			expect(mockMenu.addItem).not.toHaveBeenCalled();
-		});
-
-		it('should add "Delete recording & link" if valid audio link', () => {
-			const mockMenu = new Menu();
-			(mockEditor.getLine as jest.Mock).mockReturnValue('[[audio.mp3]]');
-			(mockEditor.getCursor as jest.Mock).mockReturnValue({
-				line: 0,
-				ch: 2,
 			});
-
-			const mockFile = new TFile();
-			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
 			(
 				mockMetadataCache.getFirstLinkpathDest as jest.Mock
-			).mockReturnValue(mockFile);
+			).mockReturnValue(makeAudioFile('md'));
 
-			editorMenuCallback(mockMenu, mockEditor, {});
+			editorMenuCallback(menu, mockEditor, {});
 
-			expect(mockMenu.addItem).toHaveBeenCalledTimes(5);
-			const addItemCallback = (mockMenu.addItem as jest.Mock).mock
-				.calls[4][0]; // Delete recording & link is the fourth item (info, convert, split, delete&link)
-			const mockItem = {
-				setTitle: jest.fn().mockReturnThis(),
-				setIcon: jest.fn().mockReturnThis(),
-				setSection: jest.fn().mockReturnThis(),
-				onClick: jest.fn(),
-			};
-			addItemCallback(mockItem);
-
-			expect(mockItem.setTitle).toHaveBeenCalledWith(
-				'Delete recording & link to file',
-			);
+			expect(titlesOf(menu)).toEqual([]);
 		});
 
-		it('should delete file and remove link text on click', async () => {
-			const mockMenu = new Menu();
+		it('deletes the file and removes the link text on click', async () => {
+			const menu = new Menu();
 			(mockEditor.getLine as jest.Mock).mockReturnValue(
 				'Text [[audio.mp3]] Text',
 			);
-			// Cursor at link
 			(mockEditor.getCursor as jest.Mock).mockReturnValue({
 				line: 0,
 				ch: 7,
 			});
-
-			const mockFile = new TFile();
-			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
+			const file = makeAudioFile();
 			(
 				mockMetadataCache.getFirstLinkpathDest as jest.Mock
-			).mockReturnValue(mockFile);
+			).mockReturnValue(file);
 
-			editorMenuCallback(mockMenu, mockEditor, {});
+			editorMenuCallback(menu, mockEditor, {});
+			await clickItem(menu, 'Delete recording & link to file');
 
-			const addItemCallback = (mockMenu.addItem as jest.Mock).mock
-				.calls[4][0];
-			const mockItem = {
-				setTitle: jest.fn().mockReturnThis(),
-				setIcon: jest.fn().mockReturnThis(),
-				setSection: jest.fn().mockReturnThis(),
-				onClick: jest.fn(),
-			};
-			addItemCallback(mockItem);
-
-			const clickHandler = mockItem.onClick.mock.calls[0][0];
-			await clickHandler();
-
-			expect(mockFileManager.trashFile).toHaveBeenCalledWith(mockFile);
-			// Verify editor.replaceRange was called with correct range for [[audio.mp3]]
-			// "Text [[audio.mp3]] Text" -> Link is at index 5 to 18 (13 chars)
-			// But strict regex might handle it differently.
-			// Let's rely on the fact that existing logic finds it.
-			// Regex !?\[\[(.*?)(?:\|.*?)?\]\]
-			// For 'Text [[audio.mp3]] Text', match index is 5.
+			expect(mockFileManager.trashFile).toHaveBeenCalledWith(file);
+			// "Text [[audio.mp3]] Text": the link spans columns 5..18
 			expect(mockEditor.replaceRange).toHaveBeenCalledWith(
 				'',
 				{ line: 0, ch: 5 },
@@ -674,21 +479,16 @@ describe('ContextMenu', () => {
 			expect(Notice).toHaveBeenCalledWith('Recording and link deleted');
 		});
 
-		it('should handle deletion error in editor menu', async () => {
-			const mockMenu = new Menu();
+		it('reports a deletion failure from the editor menu', async () => {
+			const menu = new Menu();
 			(mockEditor.getLine as jest.Mock).mockReturnValue('[[audio.mp3]]');
 			(mockEditor.getCursor as jest.Mock).mockReturnValue({
 				line: 0,
 				ch: 2,
 			});
-
-			const mockFile = new TFile();
-			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
 			(
 				mockMetadataCache.getFirstLinkpathDest as jest.Mock
-			).mockReturnValue(mockFile);
-
-			// Mock delete failure
+			).mockReturnValue(makeAudioFile());
 			(mockFileManager.trashFile as jest.Mock).mockRejectedValue(
 				new Error('Delete failed'),
 			);
@@ -696,101 +496,72 @@ describe('ContextMenu', () => {
 				.spyOn(console, 'error')
 				.mockImplementation();
 
-			editorMenuCallback(mockMenu, mockEditor, {});
-
-			const addItemCallback = (mockMenu.addItem as jest.Mock).mock
-				.calls[4][0];
-			const mockItem = {
-				setTitle: jest.fn().mockReturnThis(),
-				setIcon: jest.fn().mockReturnThis(),
-				setSection: jest.fn().mockReturnThis(),
-				onClick: jest.fn(),
-			};
-			addItemCallback(mockItem);
-
-			const clickHandler = mockItem.onClick.mock.calls[0][0];
-			await clickHandler();
+			editorMenuCallback(menu, mockEditor, {});
+			await clickItem(menu, 'Delete recording & link to file');
 
 			expect(Notice).toHaveBeenCalledWith('Failed to delete recording');
 			expect(consoleSpy).toHaveBeenCalled();
 			consoleSpy.mockRestore();
 		});
 
-		it('should work with markdown links', () => {
-			const mockMenu = new Menu();
+		it('recognizes markdown-style links', () => {
+			const menu = new Menu();
 			(mockEditor.getLine as jest.Mock).mockReturnValue(
 				'[link](audio.mp3)',
 			);
-			// [link](audio.mp3) -> cursor at 5 (inside link text) or 10 (inside path)
-			// Regex: !?\[(.*?)\]\((.*?)\)
-			// Group 1: link, Group 2: audio.mp3
-			// Match index 0. Length: [link](audio.mp3) = 17 chars.
 			(mockEditor.getCursor as jest.Mock).mockReturnValue({
 				line: 0,
 				ch: 10,
 			});
-
-			const mockFile = new TFile();
-			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
 			(
 				mockMetadataCache.getFirstLinkpathDest as jest.Mock
-			).mockReturnValue(mockFile);
+			).mockReturnValue(makeAudioFile());
 
-			editorMenuCallback(mockMenu, mockEditor, {});
+			editorMenuCallback(menu, mockEditor, {});
 
-			expect(mockMenu.addItem).toHaveBeenCalled();
+			expect(titlesOf(menu)).toContain('Delete recording & link to file');
 		});
 
-		it('should handle view with no file', () => {
-			const mockMenu = new Menu();
+		it('resolves the link without a source path when the view has no file', () => {
+			const menu = new Menu();
 			(mockEditor.getLine as jest.Mock).mockReturnValue('[[audio.mp3]]');
 			(mockEditor.getCursor as jest.Mock).mockReturnValue({
 				line: 0,
 				ch: 2,
 			});
-
-			// view has no file property or it is null
-			const mockView = {};
-
-			const mockFile = new TFile();
-			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
-			// Should call getFirstLinkpathDest with sourcePath = ''
 			(
 				mockMetadataCache.getFirstLinkpathDest as jest.Mock
-			).mockReturnValue(mockFile);
+			).mockReturnValue(makeAudioFile());
 
-			editorMenuCallback(mockMenu, mockEditor, mockView);
+			editorMenuCallback(menu, mockEditor, {});
 
 			expect(mockMetadataCache.getFirstLinkpathDest).toHaveBeenCalledWith(
 				'audio.mp3',
 				'',
 			);
-			expect(mockMenu.addItem).toHaveBeenCalled();
+			expect(titlesOf(menu)).not.toEqual([]);
 		});
 
-		it('should handle view with file', () => {
-			const mockMenu = new Menu();
+		it("resolves the link against the view's file path", () => {
+			const menu = new Menu();
 			(mockEditor.getLine as jest.Mock).mockReturnValue('[[audio.mp3]]');
 			(mockEditor.getCursor as jest.Mock).mockReturnValue({
 				line: 0,
 				ch: 2,
 			});
-
-			const mockView = { file: { path: 'view.md' } };
-
-			const mockFile = new TFile();
-			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
 			(
 				mockMetadataCache.getFirstLinkpathDest as jest.Mock
-			).mockReturnValue(mockFile);
+			).mockReturnValue(makeAudioFile());
 
-			editorMenuCallback(mockMenu, mockEditor, mockView);
+			editorMenuCallback(menu, mockEditor, {
+				file: { path: 'view.md' },
+			});
 
 			expect(mockMetadataCache.getFirstLinkpathDest).toHaveBeenCalledWith(
 				'audio.mp3',
 				'view.md',
 			);
-			expect(mockMenu.addItem).toHaveBeenCalled();
+			expect(titlesOf(menu)).not.toEqual([]);
 		});
 	});
 
@@ -805,170 +576,123 @@ describe('ContextMenu', () => {
 			playerMenuCallback = call[2];
 		});
 
-		test.each(AUDIO_EXTENSIONS)(
-			'should resolve %s file and show context menu',
-			(extension) => {
-				const embed = document.createElement('div');
-				embed.className = 'internal-embed';
-				embed.setAttribute('src', `audio.${extension}`);
-				const target = document.createElement('span');
-				embed.appendChild(target);
-
-				const mockEvent = {
-					target: target,
-					pageX: 100,
-					pageY: 200,
-					preventDefault: jest.fn(),
-					stopPropagation: jest.fn(),
-				} as unknown as MouseEvent;
-
-				const mockFile = new TFile();
-				Object.defineProperty(mockFile, 'extension', {
-					value: extension,
-				});
-				(
-					mockMetadataCache.getFirstLinkpathDest as jest.Mock
-				).mockReturnValue(mockFile);
-				(mockWorkspace.getActiveFile as jest.Mock).mockReturnValue(
-					null,
-				);
-
-				playerMenuCallback(mockEvent);
-
-				expect(mockEvent.preventDefault).toHaveBeenCalled();
-				expect(mockWorkspace.trigger).toHaveBeenCalledWith(
-					'file-menu',
-					expect.any(Menu),
-					mockFile,
-					'audio-recorder-player-context-menu',
-				);
-			},
-		);
-
-		it('should do nothing if target is not part of internal-embed', () => {
-			const mockEvent = {
-				target: document.createElement('div'),
-			} as unknown as MouseEvent;
-
-			playerMenuCallback(mockEvent);
-
-			expect(
-				mockMetadataCache.getFirstLinkpathDest,
-			).not.toHaveBeenCalled();
-		});
-
-		it('should do nothing if embed has no src', () => {
+		function makeEmbedEvent(src = 'audio.mp3'): MouseEvent {
 			const embed = document.createElement('div');
 			embed.className = 'internal-embed';
-			// No src attribute
-
+			embed.setAttribute('src', src);
 			const target = document.createElement('span');
 			embed.appendChild(target);
-
-			const mockEvent = {
-				target: target,
-			} as unknown as MouseEvent;
-
-			playerMenuCallback(mockEvent);
-
-			expect(
-				mockMetadataCache.getFirstLinkpathDest,
-			).not.toHaveBeenCalled();
-		});
-
-		it('should resolve file and show menu if valid audio', () => {
-			const embed = document.createElement('div');
-			embed.className = 'internal-embed';
-			embed.setAttribute('src', 'audio.mp3');
-
-			const target = document.createElement('span');
-			embed.appendChild(target);
-
-			const mockEvent = {
-				target: target,
+			return {
+				target,
 				pageX: 100,
 				pageY: 200,
 				preventDefault: jest.fn(),
 				stopPropagation: jest.fn(),
 			} as unknown as MouseEvent;
+		}
 
-			const mockFile = new TFile();
-			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
+		/** The menu the player handler passed to workspace.trigger. */
+		function triggeredMenu(): Menu {
+			const call = (mockWorkspace.trigger as jest.Mock).mock.calls.find(
+				(c) => c[0] === 'file-menu',
+			);
+			if (!call) {
+				throw new Error('file-menu was not triggered');
+			}
+			return call[1] as Menu;
+		}
+
+		test.each(AUDIO_EXTENSIONS)(
+			'shows the context menu for %s embeds',
+			(extension) => {
+				const event = makeEmbedEvent(`audio.${extension}`);
+				const file = makeAudioFile(extension);
+				(
+					mockMetadataCache.getFirstLinkpathDest as jest.Mock
+				).mockReturnValue(file);
+				(mockWorkspace.getActiveFile as jest.Mock).mockReturnValue(
+					null,
+				);
+
+				playerMenuCallback(event);
+
+				expect(event.preventDefault).toHaveBeenCalled();
+				expect(mockWorkspace.trigger).toHaveBeenCalledWith(
+					'file-menu',
+					expect.any(Object),
+					file,
+					'audio-recorder-player-context-menu',
+				);
+			},
+		);
+
+		it('does nothing when the target is not inside an internal embed', () => {
+			playerMenuCallback({
+				target: document.createElement('div'),
+			} as unknown as MouseEvent);
+
+			expect(
+				mockMetadataCache.getFirstLinkpathDest,
+			).not.toHaveBeenCalled();
+		});
+
+		it('does nothing when the embed has no src', () => {
+			const embed = document.createElement('div');
+			embed.className = 'internal-embed';
+			const target = document.createElement('span');
+			embed.appendChild(target);
+
+			playerMenuCallback({ target } as unknown as MouseEvent);
+
+			expect(
+				mockMetadataCache.getFirstLinkpathDest,
+			).not.toHaveBeenCalled();
+		});
+
+		it('resolves the embed against the active file and shows the menu', () => {
+			const event = makeEmbedEvent();
+			const file = makeAudioFile();
 			(
 				mockMetadataCache.getFirstLinkpathDest as jest.Mock
-			).mockReturnValue(mockFile);
-
-			// Cover truthy activeFile branch
-			const mockActiveFile = new TFile();
-			mockActiveFile.path = 'active.md';
+			).mockReturnValue(file);
+			const activeFile = new TFile();
+			activeFile.path = 'active.md';
 			(mockWorkspace.getActiveFile as jest.Mock).mockReturnValue(
-				mockActiveFile,
+				activeFile,
 			);
 
-			playerMenuCallback(mockEvent);
+			playerMenuCallback(event);
 
-			expect(mockEvent.preventDefault).toHaveBeenCalled();
-			expect(mockEvent.stopPropagation).toHaveBeenCalled();
-			expect(mockWorkspace.trigger).toHaveBeenCalledWith(
-				'file-menu',
-				expect.any(Menu),
-				mockFile,
-				'audio-recorder-player-context-menu',
-			);
+			expect(event.preventDefault).toHaveBeenCalled();
+			expect(event.stopPropagation).toHaveBeenCalled();
 			expect(mockMetadataCache.getFirstLinkpathDest).toHaveBeenCalledWith(
 				'audio.mp3',
 				'active.md',
 			);
+			expect(
+				(triggeredMenu() as unknown as RecordedMenu).showAtPosition,
+			).toHaveBeenCalledWith({ x: 100, y: 200 });
 		});
 
-		it('should do nothing if file resolution fails', () => {
-			const embed = document.createElement('div');
-			embed.className = 'internal-embed';
-			embed.setAttribute('src', 'audio.mp3');
-			const target = document.createElement('span');
-			embed.appendChild(target);
-
-			const mockEvent = {
-				target: target,
-			} as unknown as MouseEvent;
-
+		it('does nothing when the file cannot be resolved', () => {
+			const event = makeEmbedEvent();
 			(
 				mockMetadataCache.getFirstLinkpathDest as jest.Mock
 			).mockReturnValue(null);
 
-			playerMenuCallback(mockEvent);
+			playerMenuCallback(event);
 
-			expect(mockEvent.preventDefault).not.toBeDefined(); // Event not passed to callback in this test setup actually, wait.
-			// The callback receives event. If we don't mock preventDefault it might be undefined properly.
-			// But we want to ensure we returned early.
-			// Check if triggers were called.
 			expect(mockWorkspace.trigger).not.toHaveBeenCalled();
 		});
 
-		it('should handle no active file in player menu', () => {
-			const embed = document.createElement('div');
-			embed.className = 'internal-embed';
-			embed.setAttribute('src', 'audio.mp3');
-			const target = document.createElement('span');
-			embed.appendChild(target);
-
-			const mockEvent = {
-				target: target,
-				preventDefault: jest.fn(),
-				stopPropagation: jest.fn(),
-			} as unknown as MouseEvent;
-
+		it('resolves without a source path when there is no active file', () => {
+			const event = makeEmbedEvent();
 			(mockWorkspace.getActiveFile as jest.Mock).mockReturnValue(null);
-
-			// We expect getFirstLinkpathDest to be called with sourcePath = ''
-			// and if it finds file, proceed.
-			const mockFile = new TFile();
-			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
 			(
 				mockMetadataCache.getFirstLinkpathDest as jest.Mock
-			).mockReturnValue(mockFile);
+			).mockReturnValue(makeAudioFile());
 
-			playerMenuCallback(mockEvent);
+			playerMenuCallback(event);
 
 			expect(mockMetadataCache.getFirstLinkpathDest).toHaveBeenCalledWith(
 				'audio.mp3',
@@ -977,117 +701,40 @@ describe('ContextMenu', () => {
 			expect(mockWorkspace.trigger).toHaveBeenCalled();
 		});
 
-		it('should attempt to find link in editor and add "Delete & Link" option', () => {
-			const embed = document.createElement('div');
-			embed.className = 'internal-embed';
-			embed.setAttribute('src', 'audio.mp3');
-			const target = document.createElement('span');
-			embed.appendChild(target);
-
-			const mockEvent = {
-				target: target,
-				pageX: 100,
-				pageY: 200,
-				preventDefault: jest.fn(),
-				stopPropagation: jest.fn(),
-			} as unknown as MouseEvent;
-
-			const mockFile = new TFile();
-			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
+		it('offers "Delete recording & link to file" when the embed maps to an editor link', () => {
+			const event = makeEmbedEvent();
 			(
 				mockMetadataCache.getFirstLinkpathDest as jest.Mock
-			).mockReturnValue(mockFile);
+			).mockReturnValue(makeAudioFile());
 
-			// Mock active view and editor
 			const mockEditor = {
 				offsetToPos: jest.fn().mockReturnValue({ line: 0, ch: 0 }),
 				getLine: jest.fn().mockReturnValue('[[audio.mp3]]'),
-				getCursor: jest.fn().mockReturnValue({ line: 10, ch: 10 }), // Should rely on offsetToPos result
+				getCursor: jest.fn().mockReturnValue({ line: 10, ch: 10 }),
 				replaceRange: jest.fn(),
 			} as unknown as Editor;
-
-			const editorViewOverride = {
-				posAtDOM: jest.fn().mockReturnValue(0),
-			};
-			// Mock casting editor to any to access cm/posAtDOM
 			Object.defineProperty(mockEditor, 'cm', {
-				get: () => editorViewOverride,
+				get: () => ({ posAtDOM: jest.fn().mockReturnValue(0) }),
 			});
-
 			(mockWorkspace.getActiveViewOfType as jest.Mock).mockReturnValue({
 				editor: mockEditor,
 			});
 
-			playerMenuCallback(mockEvent);
+			playerMenuCallback(event);
 
-			// With findLinkAtCursor working (line is '[[audio.mp3]]', cursor 0), it matches
-			// We expect the menu to have items.
-			// Since we create 'new Menu()' inside using mock, we check its calls.
-			// The class creates one Menu instance.
-			// We can't easily access that exact instance unless we spy on Menu constructor or check args passed to workspace.trigger
-
-			const triggerCall = (mockWorkspace.trigger as jest.Mock).mock
-				.calls[0];
-			const menuInstance = triggerCall[1];
-
-			expect(menuInstance.addItem).toHaveBeenCalled();
-
-			// Check if one of the items is "Delete recording & link"
-			// Since we manually add it inside registerPlayerMenu logic
-			// logic: if (linkMatch) { addDeleteRecordingAndLinkMenuItem(...) }
-
-			// We can check if addItem was called enough times or with specific title setup
-			const calls = (menuInstance.addItem as jest.Mock).mock.calls;
-			let foundDeleteLink = false;
-
-			for (const call of calls) {
-				const cb = call[0];
-				const mockItem = {
-					setTitle: jest.fn().mockReturnThis(),
-					setIcon: jest.fn().mockReturnThis(),
-					setSection: jest.fn().mockReturnThis(),
-					onClick: jest.fn(),
-				};
-				cb(mockItem);
-				if (
-					mockItem.setTitle.mock.calls.length > 0 &&
-					mockItem.setTitle.mock.calls[0][0] ===
-						'Delete recording & link to file'
-				) {
-					foundDeleteLink = true;
-					break;
-				}
-			}
-
-			expect(foundDeleteLink).toBe(true);
+			expect(titlesOf(triggeredMenu())).toContain(
+				'Delete recording & link to file',
+			);
 		});
 
-		it('should handle errors in link resolution gracefully', () => {
-			const embed = document.createElement('div');
-			embed.className = 'internal-embed';
-			embed.setAttribute('src', 'audio.mp3');
-			const target = document.createElement('span');
-			embed.appendChild(target);
-
-			const mockEvent = {
-				target: target,
-				pageX: 100,
-				pageY: 200,
-				preventDefault: jest.fn(),
-				stopPropagation: jest.fn(),
-			} as unknown as MouseEvent;
-
-			const mockFile = new TFile();
-			Object.defineProperty(mockFile, 'extension', { value: 'mp3' });
+		it('degrades gracefully when the editor link resolution throws', () => {
+			const event = makeEmbedEvent();
 			(
 				mockMetadataCache.getFirstLinkpathDest as jest.Mock
-			).mockReturnValue(mockFile);
-
+			).mockReturnValue(makeAudioFile());
 			const consoleSpy = jest
 				.spyOn(console, 'error')
 				.mockImplementation();
-
-			// Force error by returning an editor that throws inside posAtDOM
 			const mockEditor = {
 				get cm() {
 					return {
@@ -1101,7 +748,7 @@ describe('ContextMenu', () => {
 				editor: mockEditor,
 			});
 
-			playerMenuCallback(mockEvent);
+			playerMenuCallback(event);
 
 			expect(consoleSpy).toHaveBeenCalledWith(
 				'[AudioRecorder] Failed to resolve link position in editor:',

--- a/tests/unit/ContextMenu.test.ts
+++ b/tests/unit/ContextMenu.test.ts
@@ -66,7 +66,6 @@ jest.mock('../../src/cleanup/AudioProcessingModal', () => ({
 jest.mock('../../src/audio/AudioEncoder', () => ({
 	encodeAudioBuffer: jest.fn(),
 	isOfflineEncodingSupported: jest.fn().mockReturnValue(true),
-	getEncoderDescription: jest.fn().mockReturnValue('Test Encoder'),
 }));
 
 describe('ContextMenu', () => {

--- a/tests/unit/ContextMenu.test.ts
+++ b/tests/unit/ContextMenu.test.ts
@@ -7,7 +7,7 @@
 import { ContextMenu } from '../../src/ui/ContextMenu';
 import { FILE_ACTIONS } from '../../src/actions/fileActions';
 import { AUDIO_EXTENSIONS, FORMAT_MP4 } from '../../src/constants';
-import type { AudioRecorderSettings } from '../../src/settings/Settings';
+import type { AudioRecorderSettings } from '../../src/settings/settingsSchema';
 import * as AudioFileAnalyzer from '../../src/utils/AudioFileAnalyzer';
 import {
 	App,

--- a/tests/unit/ConversionModal.test.ts
+++ b/tests/unit/ConversionModal.test.ts
@@ -114,7 +114,6 @@ jest.mock('../../src/audio/AudioEncoder', () => ({
 		.fn()
 		.mockResolvedValue(new Blob(['encoded'], { type: 'audio/mp3' })),
 	isOfflineEncodingSupported: jest.fn().mockReturnValue(true),
-	getEncoderDescription: jest.fn().mockReturnValue('Test Encoder'),
 }));
 
 // Mock AudioCapabilityDetector

--- a/tests/unit/ConversionModal.test.ts
+++ b/tests/unit/ConversionModal.test.ts
@@ -2,11 +2,10 @@
  * Unit tests for ConversionModal module.
  * @module tests/unit/ConversionModal.test
  */
-/** @jest-environment jsdom */
 
-import { ConversionModal } from '../../src/ui/ConversionModal';
+import { ConversionModal } from 'src/ui/ConversionModal';
 import { App, TFile } from 'obsidian';
-import type { AudioRecorderSettings } from '../../src/settings/settingsSchema';
+import type { AudioRecorderSettings } from 'src/settings/settingsSchema';
 
 /**
  * Extends an HTMLElement with Obsidian's custom DOM methods.
@@ -92,7 +91,7 @@ jest.mock('obsidian', () => ({
 }));
 
 // Mock LinkUpdater: the vault-wide rewrite has its own suite
-jest.mock('../../src/utils/LinkUpdater', () => ({
+jest.mock('src/utils/LinkUpdater', () => ({
 	updateLinksInVault: jest.fn().mockResolvedValue({
 		updatedNotes: 1,
 		skippedReferences: 0,
@@ -101,7 +100,7 @@ jest.mock('../../src/utils/LinkUpdater', () => ({
 }));
 
 // Mock AudioFormatConverter: conversion pipelines have their own suite
-jest.mock('../../src/audio/AudioFormatConverter', () => ({
+jest.mock('src/audio/AudioFormatConverter', () => ({
 	decodeAudioBlob: jest.fn().mockResolvedValue({}),
 	convertBlobToFormat: jest
 		.fn()
@@ -109,7 +108,7 @@ jest.mock('../../src/audio/AudioFormatConverter', () => ({
 }));
 
 // Mock AudioEncoder
-jest.mock('../../src/audio/AudioEncoder', () => ({
+jest.mock('src/audio/AudioEncoder', () => ({
 	encodeAudioBuffer: jest
 		.fn()
 		.mockResolvedValue(new Blob(['encoded'], { type: 'audio/mp3' })),
@@ -117,7 +116,7 @@ jest.mock('../../src/audio/AudioEncoder', () => ({
 }));
 
 // Mock AudioCapabilityDetector
-jest.mock('../../src/audio/AudioCapabilityDetector', () => ({
+jest.mock('src/audio/AudioCapabilityDetector', () => ({
 	getSupportedBitrates: jest
 		.fn()
 		.mockReturnValue([64000, 96000, 128000, 192000, 256000, 320000]),
@@ -169,20 +168,12 @@ describe('ConversionModal', () => {
 	});
 
 	it('should instantiate with source file', () => {
-		const modal = new ConversionModal(
-			mockApp,
-			mockFile,
-			mockSettings as unknown as AudioRecorderSettings,
-		);
+		const modal = new ConversionModal(mockApp, mockFile, mockSettings);
 		expect(modal).toBeDefined();
 	});
 
 	it('should set up content on open', () => {
-		const modal = new ConversionModal(
-			mockApp,
-			mockFile,
-			mockSettings as unknown as AudioRecorderSettings,
-		);
+		const modal = new ConversionModal(mockApp, mockFile, mockSettings);
 		modal.onOpen();
 
 		// Heading is rendered via Setting.setHeading(); source file info is a <p>
@@ -192,11 +183,7 @@ describe('ConversionModal', () => {
 	});
 
 	it('should show source file name', () => {
-		const modal = new ConversionModal(
-			mockApp,
-			mockFile,
-			mockSettings as unknown as AudioRecorderSettings,
-		);
+		const modal = new ConversionModal(mockApp, mockFile, mockSettings);
 		modal.onOpen();
 
 		const source = modal.contentEl.querySelector('.aar-conversion-source');
@@ -204,11 +191,7 @@ describe('ConversionModal', () => {
 	});
 
 	it('should clear content on close', () => {
-		const modal = new ConversionModal(
-			mockApp,
-			mockFile,
-			mockSettings as unknown as AudioRecorderSettings,
-		);
+		const modal = new ConversionModal(mockApp, mockFile, mockSettings);
 		modal.onOpen();
 		modal.onClose();
 
@@ -232,7 +215,7 @@ describe('ConversionModal', () => {
 			const modal = new ConversionModal(mockApp, mockFile, {
 				...mockSettings,
 				...settings,
-			} as unknown as AudioRecorderSettings);
+			});
 			modal.onOpen();
 			// The Setting mock never invokes dropdown callbacks, so the
 			// format selection from onOpen does not run; pick the target
@@ -251,7 +234,7 @@ describe('ConversionModal', () => {
 
 		it('should update links vault-wide with the created file', async () => {
 			const { updateLinksInVault } = jest.requireMock(
-				'../../src/utils/LinkUpdater',
+				'src/utils/LinkUpdater',
 			);
 			const { modal, progressEl } = createModal();
 
@@ -274,7 +257,7 @@ describe('ConversionModal', () => {
 
 		it('should keep the source when some links could not be updated', async () => {
 			const { updateLinksInVault } = jest.requireMock(
-				'../../src/utils/LinkUpdater',
+				'src/utils/LinkUpdater',
 			);
 			updateLinksInVault.mockResolvedValueOnce({
 				updatedNotes: 1,
@@ -295,7 +278,7 @@ describe('ConversionModal', () => {
 
 		it('should report frontmatter links that stay on the source', async () => {
 			const { updateLinksInVault } = jest.requireMock(
-				'../../src/utils/LinkUpdater',
+				'src/utils/LinkUpdater',
 			);
 			updateLinksInVault.mockResolvedValueOnce({
 				updatedNotes: 0,
@@ -315,7 +298,7 @@ describe('ConversionModal', () => {
 
 		it('should skip link updates and deletion for the none action', async () => {
 			const { updateLinksInVault } = jest.requireMock(
-				'../../src/utils/LinkUpdater',
+				'src/utils/LinkUpdater',
 			);
 			const { modal, progressEl } = createModal({
 				conversionLinkAction: 'none',
@@ -330,7 +313,7 @@ describe('ConversionModal', () => {
 
 		it('should show a background notice when closed mid-conversion', async () => {
 			const { convertBlobToFormat } = jest.requireMock(
-				'../../src/audio/AudioFormatConverter',
+				'src/audio/AudioFormatConverter',
 			);
 			let resolveConversion: (blob: Blob) => void = () => undefined;
 			convertBlobToFormat.mockReturnValueOnce(

--- a/tests/unit/ConversionModal.test.ts
+++ b/tests/unit/ConversionModal.test.ts
@@ -6,7 +6,7 @@
 
 import { ConversionModal } from '../../src/ui/ConversionModal';
 import { App, TFile } from 'obsidian';
-import type { AudioRecorderSettings } from '../../src/settings/Settings';
+import type { AudioRecorderSettings } from '../../src/settings/settingsSchema';
 
 /**
  * Extends an HTMLElement with Obsidian's custom DOM methods.

--- a/tests/unit/ConversionModal.test.ts
+++ b/tests/unit/ConversionModal.test.ts
@@ -102,9 +102,7 @@ jest.mock('src/utils/LinkUpdater', () => ({
 // Mock AudioFormatConverter: conversion pipelines have their own suite
 jest.mock('src/audio/AudioFormatConverter', () => ({
 	decodeAudioBlob: jest.fn().mockResolvedValue({}),
-	convertBlobToFormat: jest
-		.fn()
-		.mockResolvedValue(new Blob(['converted'], { type: 'audio/webm' })),
+	convertBlobToFormatBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(8)),
 }));
 
 // Mock AudioEncoder
@@ -312,12 +310,13 @@ describe('ConversionModal', () => {
 		});
 
 		it('should show a background notice when closed mid-conversion', async () => {
-			const { convertBlobToFormat } = jest.requireMock(
+			const { convertBlobToFormatBuffer } = jest.requireMock(
 				'src/audio/AudioFormatConverter',
 			);
-			let resolveConversion: (blob: Blob) => void = () => undefined;
-			convertBlobToFormat.mockReturnValueOnce(
-				new Promise<Blob>((resolve) => {
+			let resolveConversion: (data: ArrayBuffer) => void = () =>
+				undefined;
+			convertBlobToFormatBuffer.mockReturnValueOnce(
+				new Promise<ArrayBuffer>((resolve) => {
 					resolveConversion = resolve;
 				}),
 			);
@@ -335,7 +334,7 @@ describe('ConversionModal', () => {
 			expect(background).toBeDefined();
 			expect(background?.timeout).toBe(0);
 
-			resolveConversion(new Blob(['converted']));
+			resolveConversion(new ArrayBuffer(8));
 			await conversionPromise;
 
 			// Progress was mirrored into the notice and it was hidden

--- a/tests/unit/ConversionService.test.ts
+++ b/tests/unit/ConversionService.test.ts
@@ -4,10 +4,9 @@
  * covers the service-level contract.
  * @module tests/unit/ConversionService.test
  */
-/** @jest-environment jsdom */
 
-import { ConversionService } from '../../src/recording/ConversionService';
-import type { ConversionRequest } from '../../src/recording/ConversionService';
+import { ConversionService } from 'src/recording/ConversionService';
+import type { ConversionRequest } from 'src/recording/ConversionService';
 import { TFile, App } from 'obsidian';
 
 jest.mock('obsidian', () => ({
@@ -23,20 +22,20 @@ jest.mock('obsidian', () => ({
 	normalizePath: (path: string) => path.replace(/\\/g, '/'),
 }));
 
-jest.mock('../../src/audio/AudioEncoder', () => ({
+jest.mock('src/audio/AudioEncoder', () => ({
 	encodeAudioBuffer: jest
 		.fn()
 		.mockResolvedValue(new Blob(['encoded'], { type: 'audio/wav' })),
 }));
 
-jest.mock('../../src/audio/AudioFormatConverter', () => ({
+jest.mock('src/audio/AudioFormatConverter', () => ({
 	decodeAudioBlob: jest.fn().mockResolvedValue({}),
 	convertBlobToFormat: jest
 		.fn()
 		.mockResolvedValue(new Blob(['converted'], { type: 'audio/webm' })),
 }));
 
-jest.mock('../../src/utils/LinkUpdater', () => ({
+jest.mock('src/utils/LinkUpdater', () => ({
 	updateLinksInVault: jest.fn().mockResolvedValue({
 		updatedNotes: 0,
 		skippedReferences: 0,
@@ -115,10 +114,10 @@ describe('ConversionService', () => {
 
 	it('should use the decode-and-encode path for WAV targets', async () => {
 		const { decodeAudioBlob } = jest.requireMock(
-			'../../src/audio/AudioFormatConverter',
+			'src/audio/AudioFormatConverter',
 		);
 		const { encodeAudioBuffer } = jest.requireMock(
-			'../../src/audio/AudioEncoder',
+			'src/audio/AudioEncoder',
 		);
 
 		await service.convert(

--- a/tests/unit/ConversionService.test.ts
+++ b/tests/unit/ConversionService.test.ts
@@ -30,9 +30,7 @@ jest.mock('src/audio/AudioEncoder', () => ({
 
 jest.mock('src/audio/AudioFormatConverter', () => ({
 	decodeAudioBlob: jest.fn().mockResolvedValue({}),
-	convertBlobToFormat: jest
-		.fn()
-		.mockResolvedValue(new Blob(['converted'], { type: 'audio/webm' })),
+	convertBlobToFormatBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(8)),
 }));
 
 jest.mock('src/utils/LinkUpdater', () => ({

--- a/tests/unit/DebugLogger.test.ts
+++ b/tests/unit/DebugLogger.test.ts
@@ -1,11 +1,10 @@
-/** @jest-environment jsdom */
 /**
  * Unit tests for DebugLogger.
  */
 
-import { DebugLogger } from '../../src/utils/DebugLogger';
-import type { AudioRecorderSettings } from '../../src/settings/settingsSchema';
-import { DEFAULT_SETTINGS } from '../../src/settings/settingsSchema';
+import { DebugLogger } from 'src/utils/DebugLogger';
+import type { AudioRecorderSettings } from 'src/settings/settingsSchema';
+import { DEFAULT_SETTINGS } from 'src/settings/settingsSchema';
 
 describe('DebugLogger', () => {
 	let consoleMock: jest.SpyInstance;

--- a/tests/unit/DebugLogger.test.ts
+++ b/tests/unit/DebugLogger.test.ts
@@ -4,8 +4,8 @@
  */
 
 import { DebugLogger } from '../../src/utils/DebugLogger';
-import type { AudioRecorderSettings } from '../../src/settings/Settings';
-import { DEFAULT_SETTINGS } from '../../src/settings/Settings';
+import type { AudioRecorderSettings } from '../../src/settings/settingsSchema';
+import { DEFAULT_SETTINGS } from '../../src/settings/settingsSchema';
 
 describe('DebugLogger', () => {
 	let consoleMock: jest.SpyInstance;

--- a/tests/unit/DeviceSelectionModal.test.ts
+++ b/tests/unit/DeviceSelectionModal.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Unit tests for DeviceSelectionModal: renders the device dropdown from
+ * the real modal DOM, invokes the selection callback with the chosen
+ * device, and confirms/closes after the callback settles. Also covers
+ * showDeviceSelectionModal's audio-input filtering and empty-list notice.
+ * @module tests/unit/DeviceSelectionModal.test
+ */
+
+import { App, Notice } from 'obsidian';
+import {
+	DeviceSelectionModal,
+	showDeviceSelectionModal,
+} from 'src/ui/DeviceSelectionModal';
+
+function makeDevice(
+	deviceId: string,
+	label: string,
+	kind: MediaDeviceKind = 'audioinput',
+): MediaDeviceInfo {
+	return { deviceId, label, kind, groupId: 'g' } as MediaDeviceInfo;
+}
+
+function openModal(
+	devices: MediaDeviceInfo[],
+	onSelected: jest.Mock = jest.fn().mockResolvedValue(undefined),
+): { modal: DeviceSelectionModal; onSelected: jest.Mock } {
+	const modal = new DeviceSelectionModal(new App(), devices, onSelected);
+	modal.onOpen();
+	return { modal, onSelected };
+}
+
+function dropdownOf(modal: DeviceSelectionModal): HTMLSelectElement {
+	const dropdown = modal.contentEl.querySelector('select');
+	if (!dropdown) {
+		throw new Error('device dropdown not rendered');
+	}
+	return dropdown;
+}
+
+function selectButtonOf(modal: DeviceSelectionModal): HTMLButtonElement {
+	const button = modal.contentEl.querySelector('button');
+	if (!button) {
+		throw new Error('select button not rendered');
+	}
+	return button;
+}
+
+const tick = (): Promise<void> =>
+	new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('DeviceSelectionModal', () => {
+	it('renders one option per device with its label', () => {
+		const { modal } = openModal([
+			makeDevice('mic-1', 'USB Microphone'),
+			makeDevice('mic-2', 'Headset'),
+		]);
+
+		const options = Array.from(dropdownOf(modal).options);
+		expect(options.map((option) => option.value)).toEqual([
+			'mic-1',
+			'mic-2',
+		]);
+		expect(options.map((option) => option.text)).toEqual([
+			'USB Microphone',
+			'Headset',
+		]);
+	});
+
+	it('falls back to a truncated device id when the label is empty', () => {
+		const { modal } = openModal([makeDevice('abcdefgh-1234-5678', '')]);
+
+		expect(dropdownOf(modal).options[0].text).toBe('Device abcdefgh');
+	});
+
+	it('invokes the callback with the selected device and closes on success', async () => {
+		const { modal, onSelected } = openModal([
+			makeDevice('mic-1', 'USB Microphone'),
+			makeDevice('mic-2', 'Headset'),
+		]);
+		const close = jest.spyOn(modal, 'close');
+
+		dropdownOf(modal).value = 'mic-2';
+		selectButtonOf(modal).click();
+		await tick();
+
+		expect(onSelected).toHaveBeenCalledWith('mic-2', 'Headset');
+		expect(Notice as unknown as jest.Mock).toHaveBeenCalledWith(
+			'Selected audio device: Headset',
+		);
+		expect(close).toHaveBeenCalled();
+	});
+
+	it('empties the content on close', () => {
+		const { modal } = openModal([makeDevice('mic-1', 'USB Microphone')]);
+		expect(modal.contentEl.childElementCount).toBeGreaterThan(0);
+
+		modal.onClose();
+
+		expect(modal.contentEl.childElementCount).toBe(0);
+	});
+});
+
+describe('showDeviceSelectionModal', () => {
+	afterEach(() => {
+		delete (navigator as { mediaDevices?: unknown }).mediaDevices;
+	});
+
+	function mockEnumerate(devices: MediaDeviceInfo[]): void {
+		Object.defineProperty(navigator, 'mediaDevices', {
+			configurable: true,
+			value: {
+				enumerateDevices: jest.fn().mockResolvedValue(devices),
+			},
+		});
+	}
+
+	it('notifies and does not open when no audio inputs exist', async () => {
+		mockEnumerate([makeDevice('cam-1', 'Webcam', 'videoinput')]);
+
+		await showDeviceSelectionModal(new App(), jest.fn());
+
+		expect(Notice as unknown as jest.Mock).toHaveBeenCalledWith(
+			'No audio input devices found',
+		);
+	});
+
+	it('opens the modal listing only audio inputs', async () => {
+		mockEnumerate([
+			makeDevice('cam-1', 'Webcam', 'videoinput'),
+			makeDevice('mic-1', 'USB Microphone'),
+		]);
+		const openSpy = jest.spyOn(DeviceSelectionModal.prototype, 'open');
+		const onOpenSpy = jest.spyOn(DeviceSelectionModal.prototype, 'onOpen');
+
+		try {
+			await showDeviceSelectionModal(new App(), jest.fn());
+
+			expect(openSpy).toHaveBeenCalled();
+			const modal = onOpenSpy.mock
+				.instances[0] as unknown as DeviceSelectionModal;
+			const options = Array.from(dropdownOf(modal).options);
+			expect(options.map((option) => option.value)).toEqual(['mic-1']);
+		} finally {
+			openSpy.mockRestore();
+			onOpenSpy.mockRestore();
+		}
+	});
+});

--- a/tests/unit/DeviceSelectionModal.test.ts
+++ b/tests/unit/DeviceSelectionModal.test.ts
@@ -84,9 +84,7 @@ describe('DeviceSelectionModal', () => {
 		await tick();
 
 		expect(onSelected).toHaveBeenCalledWith('mic-2', 'Headset');
-		expect(Notice as unknown as jest.Mock).toHaveBeenCalledWith(
-			'Selected audio device: Headset',
-		);
+		expect(Notice).toHaveBeenCalledWith('Selected audio device: Headset');
 		expect(close).toHaveBeenCalled();
 	});
 
@@ -119,9 +117,7 @@ describe('showDeviceSelectionModal', () => {
 
 		await showDeviceSelectionModal(new App(), jest.fn());
 
-		expect(Notice as unknown as jest.Mock).toHaveBeenCalledWith(
-			'No audio input devices found',
-		);
+		expect(Notice).toHaveBeenCalledWith('No audio input devices found');
 	});
 
 	it('opens the modal listing only audio inputs', async () => {

--- a/tests/unit/DeviceUtils.test.ts
+++ b/tests/unit/DeviceUtils.test.ts
@@ -1,5 +1,4 @@
 /**
- * @jest-environment jsdom
  */
 
 /**
@@ -11,7 +10,7 @@ import {
 	getAudioInputDevices,
 	findDefaultDevice,
 	getDefaultDeviceId,
-} from '../../src/utils/DeviceUtils';
+} from 'src/utils/DeviceUtils';
 
 // Mock navigator.mediaDevices
 const mockEnumerateDevices = jest.fn();

--- a/tests/unit/EncodingWorkerClient.test.ts
+++ b/tests/unit/EncodingWorkerClient.test.ts
@@ -2,10 +2,9 @@
  * Unit tests for EncodingWorkerClient module.
  * @module tests/unit/EncodingWorkerClient.test
  */
-/** @jest-environment jsdom */
 
-import { EncodingWorkerClient } from '../../src/audio/EncodingWorkerClient';
-import type { WorkerResponse } from '../../src/audio/encodingWorker';
+import { EncodingWorkerClient } from 'src/audio/EncodingWorkerClient';
+import type { WorkerResponse } from 'src/audio/encodingWorker';
 
 /** Captured worker doubles created by the client. */
 interface WorkerDouble {

--- a/tests/unit/EnhancedPlayerRegistrar.test.ts
+++ b/tests/unit/EnhancedPlayerRegistrar.test.ts
@@ -166,7 +166,7 @@ function setup(
 		embedRegistry: { embedByExtension },
 		vault: {
 			getResourcePath: () => 'app://media',
-			getAbstractFileByPath: (path: string) => fileFromPath(path),
+			getFileByPath: (path: string) => fileFromPath(path),
 			on: jest.fn(() => ({})),
 		},
 		metadataCache: {

--- a/tests/unit/EnhancedPlayerRegistrar.test.ts
+++ b/tests/unit/EnhancedPlayerRegistrar.test.ts
@@ -1,4 +1,3 @@
-/** @jest-environment jsdom */
 /**
  * Regression guard for two recurring defect families in the enhanced
  * player integration:

--- a/tests/unit/EnhancedPlayerRegistrar.test.ts
+++ b/tests/unit/EnhancedPlayerRegistrar.test.ts
@@ -28,8 +28,8 @@ import { probeMediaKind } from 'src/player/mediaProbe';
 import type { MediaKind, MediaProbeResult } from 'src/player/mediaProbe';
 import type { MediaKindStore } from 'src/player/MediaKindStore';
 import { AUDIO_EXTENSIONS } from 'src/constants';
-import { DEFAULT_SETTINGS } from 'src/settings/Settings';
-import type { AudioRecorderSettings } from 'src/settings/Settings';
+import { DEFAULT_SETTINGS } from 'src/settings/settingsSchema';
+import type { AudioRecorderSettings } from 'src/settings/settingsSchema';
 import type { EmbedInfo } from 'src/obsidian/embedRegistry';
 import type { MarkerStore } from 'src/markers/MarkerStore';
 

--- a/tests/unit/LinkUpdater.test.ts
+++ b/tests/unit/LinkUpdater.test.ts
@@ -130,7 +130,7 @@ describe('updateLinksInVault', () => {
 				),
 			},
 			vault: {
-				getAbstractFileByPath: jest.fn((path: string) =>
+				getFileByPath: jest.fn((path: string) =>
 					path in notes ? createFile(path) : null,
 				),
 				process: processMock,

--- a/tests/unit/LinkUpdater.test.ts
+++ b/tests/unit/LinkUpdater.test.ts
@@ -3,7 +3,7 @@
  * @module tests/unit/LinkUpdater.test
  */
 
-import { updateLinksInVault } from '../../src/utils/LinkUpdater';
+import { updateLinksInVault } from 'src/utils/LinkUpdater';
 import { App, TFile } from 'obsidian';
 
 jest.mock('obsidian', () => ({

--- a/tests/unit/MarkerListView.test.ts
+++ b/tests/unit/MarkerListView.test.ts
@@ -1,4 +1,3 @@
-/** @jest-environment jsdom */
 /**
  * Unit tests for the marker/chapter view extracted from the player. They
  * cover the rendering of the list and ticks, the delegated jump/delete/rename

--- a/tests/unit/MarkerModal.test.ts
+++ b/tests/unit/MarkerModal.test.ts
@@ -6,10 +6,10 @@
  */
 
 import { App } from 'obsidian';
-import { RecordingMarkerModal } from '../../src/ui/MarkerModal';
-import { MARKER_KIND } from '../../src/markers/markerModel';
-import type { MarkerKind } from '../../src/markers/markerModel';
-import type { RecordingMarkerHandle } from '../../src/recording/recordingMarkers';
+import { RecordingMarkerModal } from 'src/ui/MarkerModal';
+import { MARKER_KIND } from 'src/markers/markerModel';
+import type { MarkerKind } from 'src/markers/markerModel';
+import type { RecordingMarkerHandle } from 'src/recording/recordingMarkers';
 
 /** Builds a draft handle double with call-recording commit/cancel. */
 function makeHandle(initialKind: MarkerKind = MARKER_KIND.bookmark): {

--- a/tests/unit/NoteInserter.test.ts
+++ b/tests/unit/NoteInserter.test.ts
@@ -3,9 +3,8 @@
  * Tests cursor context capture and audio link insertion into notes.
  * @module tests/unit/NoteInserter.test
  */
-/** @jest-environment jsdom */
 
-import type { InsertionContext } from '../../src/types';
+import type { InsertionContext } from 'src/types';
 import type { App } from 'obsidian';
 
 // Mock MarkdownView class used for instanceof checks
@@ -39,7 +38,7 @@ import {
 	captureInsertionContext,
 	insertFileLinks,
 	insertProcessedAudioEmbed,
-} from '../../src/recording/NoteInserter';
+} from 'src/recording/NoteInserter';
 import type { TFile } from 'obsidian';
 
 // DebugLogger mock

--- a/tests/unit/NoteInserter.test.ts
+++ b/tests/unit/NoteInserter.test.ts
@@ -435,7 +435,7 @@ describe('NoteInserter', () => {
 					},
 				},
 				vault: {
-					getAbstractFileByPath: (path: string): MockTFile =>
+					getFileByPath: (path: string): MockTFile =>
 						new MockTFile(path),
 					process: (
 						_note: unknown,

--- a/tests/unit/PartRotationController.test.ts
+++ b/tests/unit/PartRotationController.test.ts
@@ -15,7 +15,7 @@ import type { RecordingSessionConfig, RecordingTarget } from '../../src/types';
 import {
 	DEFAULT_SETTINGS,
 	AudioRecorderSettings,
-} from '../../src/settings/Settings';
+} from '../../src/settings/settingsSchema';
 import { MS_PER_MINUTE } from '../../src/constants';
 import type { App } from 'obsidian';
 

--- a/tests/unit/PartRotationController.test.ts
+++ b/tests/unit/PartRotationController.test.ts
@@ -4,19 +4,16 @@
  * and part finalization error paths.
  * @module tests/unit/PartRotationController.test
  */
-/** @jest-environment jsdom */
 
-import { PartRotationController } from '../../src/recording/PartRotationController';
-import type { TrackWriteQueue } from '../../src/recording/TrackWriteQueue';
-import type { RecordingFinalizer } from '../../src/recording/RecordingFinalizer';
-import { DebugLogger } from '../../src/utils/DebugLogger';
-import { RecordingStatus } from '../../src/types';
-import type { RecordingSessionConfig, RecordingTarget } from '../../src/types';
+import { PartRotationController } from 'src/recording/PartRotationController';
+import { DebugLogger } from 'src/utils/DebugLogger';
+import { RecordingStatus } from 'src/types';
+import type { RecordingSessionConfig, RecordingTarget } from 'src/types';
 import {
 	DEFAULT_SETTINGS,
 	AudioRecorderSettings,
-} from '../../src/settings/settingsSchema';
-import { MS_PER_MINUTE } from '../../src/constants';
+} from 'src/settings/settingsSchema';
+import { MS_PER_MINUTE } from 'src/constants';
 import type { App } from 'obsidian';
 
 jest.mock('obsidian', () => ({
@@ -85,8 +82,8 @@ describe('PartRotationController', () => {
 		controller = new PartRotationController(
 			mockApp,
 			mockSettings,
-			writeQueue as unknown as TrackWriteQueue,
-			finalizer as unknown as RecordingFinalizer,
+			writeQueue,
+			finalizer,
 			new DebugLogger(mockSettings),
 			hooks,
 		);

--- a/tests/unit/PcmStreamRecorder.test.ts
+++ b/tests/unit/PcmStreamRecorder.test.ts
@@ -3,9 +3,8 @@
  * Tests real-time PCM capture from MediaStream using AudioWorkletNode.
  * @module tests/unit/PcmStreamRecorder.test
  */
-/** @jest-environment jsdom */
 
-import { PcmStreamRecorder } from '../../src/recording/PcmStreamRecorder';
+import { PcmStreamRecorder } from 'src/recording/PcmStreamRecorder';
 
 // Track messages sent to the worklet port
 let workletPortMessages: Array<{ type: string }> = [];

--- a/tests/unit/RecordingBanner.test.ts
+++ b/tests/unit/RecordingBanner.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for RecordingBanner, the only recording-in-progress
+ * indicator on mobile (no ribbon icon there). DOM-driven: renders the
+ * real banner into the document, asserts on the rendered output and the
+ * stop callback, and covers the pause-state and teardown behavior a
+ * phone-only regression would otherwise hide.
+ * @module tests/unit/RecordingBanner.test
+ */
+
+import { RecordingBanner } from 'src/ui/RecordingBanner';
+import { addObsidianDomExtensions } from '../mocks/obsidian';
+
+// The banner mounts onto activeDocument.body, which Obsidian extends with
+// createDiv/createSpan at runtime; mirror that on jsdom's body once.
+beforeAll(() => {
+	addObsidianDomExtensions(document.body);
+});
+
+function bannerEl(): HTMLElement {
+	const el = document.body.querySelector<HTMLElement>(
+		'.aar-recording-banner',
+	);
+	if (!el) {
+		throw new Error('banner not rendered');
+	}
+	return el;
+}
+
+function stopEl(): HTMLElement {
+	const el = bannerEl().querySelector<HTMLElement>(
+		'.aar-recording-banner-stop',
+	);
+	if (!el) {
+		throw new Error('stop control not rendered');
+	}
+	return el;
+}
+
+afterEach(() => {
+	document.body.innerHTML = '';
+});
+
+describe('RecordingBanner', () => {
+	it('renders the dot, timer, and an accessible stop control', () => {
+		new RecordingBanner(jest.fn()).show(false);
+
+		expect(
+			bannerEl().querySelector('.aar-recording-banner-dot'),
+		).not.toBeNull();
+		expect(
+			bannerEl().querySelector('.aar-recording-banner-time')?.textContent,
+		).toBe('0:00');
+		const stop = stopEl();
+		expect(stop.getAttribute('role')).toBe('button');
+		expect(stop.getAttribute('aria-label')).toBe('Stop recording');
+		expect(stop.getAttribute('tabindex')).toBe('0');
+	});
+
+	it('creates the banner once across repeated show calls', () => {
+		const banner = new RecordingBanner(jest.fn());
+		banner.show(false);
+		banner.show(true);
+		banner.show(false);
+
+		expect(
+			document.body.querySelectorAll('.aar-recording-banner'),
+		).toHaveLength(1);
+	});
+
+	it('reflects the paused state on the banner class', () => {
+		const banner = new RecordingBanner(jest.fn());
+		banner.show(true);
+		expect(bannerEl().classList.contains('is-paused')).toBe(true);
+
+		banner.show(false);
+		expect(bannerEl().classList.contains('is-paused')).toBe(false);
+	});
+
+	it('updates the elapsed time, prefixing Paused while paused', () => {
+		const banner = new RecordingBanner(jest.fn());
+		banner.show(false);
+
+		banner.update(65_000, false);
+		expect(
+			bannerEl().querySelector('.aar-recording-banner-time')?.textContent,
+		).toBe('1:05');
+
+		banner.update(65_000, true);
+		expect(
+			bannerEl().querySelector('.aar-recording-banner-time')?.textContent,
+		).toBe('Paused 1:05');
+	});
+
+	it('fires the stop callback on click', () => {
+		const onStop = jest.fn();
+		new RecordingBanner(onStop).show(false);
+
+		stopEl().click();
+
+		expect(onStop).toHaveBeenCalledTimes(1);
+	});
+
+	it.each([['Enter'], [' ']])(
+		'fires the stop callback on %s for keyboard users',
+		(key) => {
+			const onStop = jest.fn();
+			new RecordingBanner(onStop).show(false);
+
+			stopEl().dispatchEvent(
+				new KeyboardEvent('keydown', { key, bubbles: true }),
+			);
+
+			expect(onStop).toHaveBeenCalledTimes(1);
+		},
+	);
+
+	it('ignores other keys on the stop control', () => {
+		const onStop = jest.fn();
+		new RecordingBanner(onStop).show(false);
+
+		stopEl().dispatchEvent(
+			new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+		);
+
+		expect(onStop).not.toHaveBeenCalled();
+	});
+
+	it('hide removes the banner and a later show recreates it', () => {
+		const banner = new RecordingBanner(jest.fn());
+		banner.show(false);
+		banner.hide();
+
+		expect(document.body.querySelector('.aar-recording-banner')).toBeNull();
+
+		banner.show(true);
+		expect(bannerEl().classList.contains('is-paused')).toBe(true);
+	});
+});

--- a/tests/unit/RecordingFileManager.test.ts
+++ b/tests/unit/RecordingFileManager.test.ts
@@ -3,14 +3,13 @@
  * Tests file I/O operations: path resolution, saving, cleanup, and rollback.
  * @module tests/unit/RecordingFileManager.test
  */
-/** @jest-environment jsdom */
 
 import type { App } from 'obsidian';
 import {
 	DEFAULT_SETTINGS,
 	AudioRecorderSettings,
-} from '../../src/settings/settingsSchema';
-import type { RecordingTarget } from '../../src/types';
+} from 'src/settings/settingsSchema';
+import type { RecordingTarget } from 'src/types';
 import {
 	getActiveFileDirectory,
 	getBaseSaveDirectory,
@@ -20,7 +19,7 @@ import {
 	saveAudioFile,
 	removeTemporaryArtifacts,
 	cleanupIntermediateFiles,
-} from '../../src/audio/RecordingFileManager';
+} from 'src/audio/RecordingFileManager';
 
 // Mock obsidian module
 jest.mock('obsidian', () => ({

--- a/tests/unit/RecordingFileManager.test.ts
+++ b/tests/unit/RecordingFileManager.test.ts
@@ -9,7 +9,7 @@ import type { App } from 'obsidian';
 import {
 	DEFAULT_SETTINGS,
 	AudioRecorderSettings,
-} from '../../src/settings/Settings';
+} from '../../src/settings/settingsSchema';
 import type { RecordingTarget } from '../../src/types';
 import {
 	getActiveFileDirectory,

--- a/tests/unit/RecordingFinalizer.test.ts
+++ b/tests/unit/RecordingFinalizer.test.ts
@@ -36,12 +36,8 @@ jest.mock('src/audio/AudioFormatConverter', () => ({
 	mergeAudioTracks: jest
 		.fn()
 		.mockResolvedValue(new Blob(['merged'], { type: 'audio/wav' })),
-	convertBlobToWav: jest
-		.fn()
-		.mockResolvedValue(new Blob(['wav'], { type: 'audio/wav' })),
-	convertBlobToFormat: jest
-		.fn()
-		.mockResolvedValue(new Blob(['encoded'], { type: 'audio/mp3' })),
+	convertBlobToWavBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(8)),
+	convertBlobToFormatBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(8)),
 	getRecorderMediaType: jest.fn((format: string) => `audio/${format}`),
 	isOfflineOnlyFormat: jest.fn(
 		(format: string, recorderFormat: string) =>
@@ -210,18 +206,18 @@ describe('RecordingFinalizer', () => {
 
 		it('should convert to WAV when the output format is wav', async () => {
 			buildFinalizer(createSession({ outputFormat: 'wav' }));
-			const { convertBlobToWav } = jest.requireMock(
+			const { convertBlobToWavBuffer } = jest.requireMock(
 				'src/audio/AudioFormatConverter',
 			);
 
 			await finalizer.finalizeSegmentsToFile(['seg1.tmp'], 'final.wav');
 
-			expect(convertBlobToWav).toHaveBeenCalled();
+			expect(convertBlobToWavBuffer).toHaveBeenCalled();
 		});
 
 		it('should re-encode offline-only formats with remux allowed and mapped progress', async () => {
 			buildFinalizer(createSession({ outputFormat: 'mp3' }));
-			const { convertBlobToFormat } = jest.requireMock(
+			const { convertBlobToFormatBuffer } = jest.requireMock(
 				'src/audio/AudioFormatConverter',
 			);
 
@@ -231,7 +227,7 @@ describe('RecordingFinalizer', () => {
 				true,
 			);
 
-			expect(convertBlobToFormat).toHaveBeenCalledWith(
+			expect(convertBlobToFormatBuffer).toHaveBeenCalledWith(
 				expect.any(Blob),
 				'mp3',
 				128000,
@@ -239,8 +235,8 @@ describe('RecordingFinalizer', () => {
 				{ allowRemux: true, workerClient: null },
 			);
 			// The encoder progress callback maps into the 40-60% band
-			const progressCallback = (convertBlobToFormat as jest.Mock).mock
-				.calls[0][3] as (percent: number) => void;
+			const progressCallback = (convertBlobToFormatBuffer as jest.Mock)
+				.mock.calls[0][3] as (percent: number) => void;
 			progressCallback(50);
 			expect(onProgress).toHaveBeenCalledWith({
 				percent: 50,

--- a/tests/unit/RecordingFinalizer.test.ts
+++ b/tests/unit/RecordingFinalizer.test.ts
@@ -13,7 +13,7 @@ import type { RecordingSessionConfig, RecordingTarget } from '../../src/types';
 import {
 	DEFAULT_SETTINGS,
 	AudioRecorderSettings,
-} from '../../src/settings/Settings';
+} from '../../src/settings/settingsSchema';
 import type { App } from 'obsidian';
 
 jest.mock('obsidian', () => ({

--- a/tests/unit/RecordingFinalizer.test.ts
+++ b/tests/unit/RecordingFinalizer.test.ts
@@ -4,16 +4,15 @@
  * deduplication.
  * @module tests/unit/RecordingFinalizer.test
  */
-/** @jest-environment jsdom */
 
-import { RecordingFinalizer } from '../../src/recording/RecordingFinalizer';
-import { TrackWriteQueue } from '../../src/recording/TrackWriteQueue';
-import { DebugLogger } from '../../src/utils/DebugLogger';
-import type { RecordingSessionConfig, RecordingTarget } from '../../src/types';
+import { RecordingFinalizer } from 'src/recording/RecordingFinalizer';
+import { TrackWriteQueue } from 'src/recording/TrackWriteQueue';
+import { DebugLogger } from 'src/utils/DebugLogger';
+import type { RecordingSessionConfig, RecordingTarget } from 'src/types';
 import {
 	DEFAULT_SETTINGS,
 	AudioRecorderSettings,
-} from '../../src/settings/settingsSchema';
+} from 'src/settings/settingsSchema';
 import type { App } from 'obsidian';
 
 jest.mock('obsidian', () => ({
@@ -21,19 +20,19 @@ jest.mock('obsidian', () => ({
 	normalizePath: (path: string) => path.replace(/\\/g, '/'),
 }));
 
-jest.mock('../../src/audio/WavEncoder', () => ({
+jest.mock('src/audio/WavEncoder', () => ({
 	assembleWavFromPcmSegmentFiles: jest
 		.fn()
 		.mockResolvedValue(new ArrayBuffer(50)),
 }));
 
-jest.mock('../../src/audio/AudioEncoder', () => ({
+jest.mock('src/audio/AudioEncoder', () => ({
 	isOfflineEncodingSupported: jest.fn((format: string) =>
 		['mp3', 'flac', 'webm', 'ogg', 'mp4', 'm4a', 'aac'].includes(format),
 	),
 }));
 
-jest.mock('../../src/audio/AudioFormatConverter', () => ({
+jest.mock('src/audio/AudioFormatConverter', () => ({
 	mergeAudioTracks: jest
 		.fn()
 		.mockResolvedValue(new Blob(['merged'], { type: 'audio/wav' })),
@@ -53,11 +52,11 @@ jest.mock('../../src/audio/AudioFormatConverter', () => ({
 		.mockResolvedValue(new Blob(['output'], { type: 'audio/webm' })),
 }));
 
-jest.mock('../../src/recording/NoteInserter', () => ({
+jest.mock('src/recording/NoteInserter', () => ({
 	insertFileLinks: jest.fn(),
 }));
 
-jest.mock('../../src/recording/StreamingMixer', () => ({
+jest.mock('src/recording/StreamingMixer', () => ({
 	canStreamMix: jest.fn().mockReturnValue(true),
 	mixPcmTracksToWav: jest.fn().mockResolvedValue(new ArrayBuffer(50)),
 }));
@@ -212,7 +211,7 @@ describe('RecordingFinalizer', () => {
 		it('should convert to WAV when the output format is wav', async () => {
 			buildFinalizer(createSession({ outputFormat: 'wav' }));
 			const { convertBlobToWav } = jest.requireMock(
-				'../../src/audio/AudioFormatConverter',
+				'src/audio/AudioFormatConverter',
 			);
 
 			await finalizer.finalizeSegmentsToFile(['seg1.tmp'], 'final.wav');
@@ -223,7 +222,7 @@ describe('RecordingFinalizer', () => {
 		it('should re-encode offline-only formats with remux allowed and mapped progress', async () => {
 			buildFinalizer(createSession({ outputFormat: 'mp3' }));
 			const { convertBlobToFormat } = jest.requireMock(
-				'../../src/audio/AudioFormatConverter',
+				'src/audio/AudioFormatConverter',
 			);
 
 			await finalizer.finalizeSegmentsToFile(
@@ -273,7 +272,7 @@ describe('RecordingFinalizer', () => {
 	describe('assembleWavFile', () => {
 		it('should delegate assembly to the shared single-allocation helper', async () => {
 			const { assembleWavFromPcmSegmentFiles } = jest.requireMock(
-				'../../src/audio/WavEncoder',
+				'src/audio/WavEncoder',
 			);
 			const target = createTarget({
 				segmentPaths: ['pcm1.tmp', 'pcm2.tmp'],
@@ -344,7 +343,7 @@ describe('RecordingFinalizer', () => {
 			await finalizer.saveRecording(targets, 'stamp', null);
 
 			const { insertFileLinks } = jest.requireMock(
-				'../../src/recording/NoteInserter',
+				'src/recording/NoteInserter',
 			);
 			expect(insertFileLinks).toHaveBeenCalledWith(
 				[expect.any(String), expect.any(String)],
@@ -371,7 +370,7 @@ describe('RecordingFinalizer', () => {
 			// path inserted into must be threaded back out of saveRecording.
 			buildFinalizer(createSession({ outputMode: 'multiple' }));
 			const { insertFileLinks } = jest.requireMock(
-				'../../src/recording/NoteInserter',
+				'src/recording/NoteInserter',
 			);
 			(insertFileLinks as jest.Mock).mockReturnValue('notes/daily.md');
 			const targets = [
@@ -517,11 +516,11 @@ describe('RecordingFinalizer', () => {
 			await finalizer.saveRecording(targets, 'stamp', null);
 
 			const { mergeAudioTracks } = jest.requireMock(
-				'../../src/audio/AudioFormatConverter',
+				'src/audio/AudioFormatConverter',
 			);
 			expect(mergeAudioTracks).not.toHaveBeenCalled();
 			const { insertFileLinks } = jest.requireMock(
-				'../../src/recording/NoteInserter',
+				'src/recording/NoteInserter',
 			);
 			expect(insertFileLinks).toHaveBeenCalledWith(
 				expect.arrayContaining(['a-part1.webm']),
@@ -557,10 +556,10 @@ describe('RecordingFinalizer', () => {
 
 		it('should stream-mix PCM sessions with WAV output', async () => {
 			const { canStreamMix, mixPcmTracksToWav } = jest.requireMock(
-				'../../src/recording/StreamingMixer',
+				'src/recording/StreamingMixer',
 			);
 			const { mergeAudioTracks } = jest.requireMock(
-				'../../src/audio/AudioFormatConverter',
+				'src/audio/AudioFormatConverter',
 			);
 			buildFinalizer(
 				createSession({
@@ -606,10 +605,10 @@ describe('RecordingFinalizer', () => {
 
 		it('should fall back to the Web Audio mix when streaming is not possible', async () => {
 			const { canStreamMix, mixPcmTracksToWav } = jest.requireMock(
-				'../../src/recording/StreamingMixer',
+				'src/recording/StreamingMixer',
 			);
 			const { mergeAudioTracks } = jest.requireMock(
-				'../../src/audio/AudioFormatConverter',
+				'src/audio/AudioFormatConverter',
 			);
 			(canStreamMix as jest.Mock).mockReturnValueOnce(false);
 			buildFinalizer(
@@ -642,10 +641,10 @@ describe('RecordingFinalizer', () => {
 
 		it('should keep compressed merged outputs on the Web Audio mix', async () => {
 			const { mixPcmTracksToWav } = jest.requireMock(
-				'../../src/recording/StreamingMixer',
+				'src/recording/StreamingMixer',
 			);
 			const { mergeAudioTracks } = jest.requireMock(
-				'../../src/audio/AudioFormatConverter',
+				'src/audio/AudioFormatConverter',
 			);
 			buildFinalizer(
 				createSession({

--- a/tests/unit/RecordingManager.fallback.test.ts
+++ b/tests/unit/RecordingManager.fallback.test.ts
@@ -11,7 +11,7 @@ import { RecordingStatus } from '../../src/types';
 import {
 	DEFAULT_SETTINGS,
 	AudioRecorderSettings,
-} from '../../src/settings/Settings';
+} from '../../src/settings/settingsSchema';
 import { AudioStreamError } from '../../src/errors';
 import { PLUGIN_LOG_PREFIX } from '../../src/constants';
 import type { App } from 'obsidian';

--- a/tests/unit/RecordingManager.fallback.test.ts
+++ b/tests/unit/RecordingManager.fallback.test.ts
@@ -4,16 +4,15 @@
  * partially opened session.
  * @module tests/unit/RecordingManager.fallback.test
  */
-/** @jest-environment jsdom */
 
-import { RecordingManager } from '../../src/recording/RecordingManager';
-import { RecordingStatus } from '../../src/types';
+import { RecordingManager } from 'src/recording/RecordingManager';
+import { RecordingStatus } from 'src/types';
 import {
 	DEFAULT_SETTINGS,
 	AudioRecorderSettings,
-} from '../../src/settings/settingsSchema';
-import { AudioStreamError } from '../../src/errors';
-import { PLUGIN_LOG_PREFIX } from '../../src/constants';
+} from 'src/settings/settingsSchema';
+import { AudioStreamError } from 'src/errors';
+import { PLUGIN_LOG_PREFIX } from 'src/constants';
 import type { App } from 'obsidian';
 import {
 	createRecordingMockApp,
@@ -50,7 +49,7 @@ jest.mock('obsidian', () => ({
 }));
 
 // Mock WavEncoder
-jest.mock('../../src/audio/WavEncoder', () => ({
+jest.mock('src/audio/WavEncoder', () => ({
 	assembleWavFromPcmSegmentFiles: jest
 		.fn()
 		.mockResolvedValue(new ArrayBuffer(44)),

--- a/tests/unit/RecordingManager.journal.test.ts
+++ b/tests/unit/RecordingManager.journal.test.ts
@@ -9,7 +9,7 @@ import { RecordingManager } from '../../src/recording/RecordingManager';
 import {
 	DEFAULT_SETTINGS,
 	AudioRecorderSettings,
-} from '../../src/settings/Settings';
+} from '../../src/settings/settingsSchema';
 import type { App } from 'obsidian';
 import {
 	createDesktopRecorder,

--- a/tests/unit/RecordingManager.journal.test.ts
+++ b/tests/unit/RecordingManager.journal.test.ts
@@ -3,13 +3,12 @@
  * gets journaled on start, flush, stop, failure, and cleanup.
  * @module tests/unit/RecordingManager.journal.test
  */
-/** @jest-environment jsdom */
 
-import { RecordingManager } from '../../src/recording/RecordingManager';
+import { RecordingManager } from 'src/recording/RecordingManager';
 import {
 	DEFAULT_SETTINGS,
 	AudioRecorderSettings,
-} from '../../src/settings/settingsSchema';
+} from 'src/settings/settingsSchema';
 import type { App } from 'obsidian';
 import {
 	createDesktopRecorder,
@@ -29,7 +28,7 @@ jest.mock('obsidian', () => ({
 }));
 
 // Mock AudioStreamHandler
-jest.mock('../../src/recording/AudioStreamHandler', () => ({
+jest.mock('src/recording/AudioStreamHandler', () => ({
 	getAudioStreams: jest.fn(),
 	getAudioSourceName: jest.fn().mockResolvedValue('TestDevice'),
 	stopAllStreams: jest.fn(),
@@ -37,7 +36,7 @@ jest.mock('../../src/recording/AudioStreamHandler', () => ({
 }));
 
 // Mock AudioEncoder module to avoid mediabunny TextDecoder requirement
-jest.mock('../../src/audio/AudioEncoder', () => ({
+jest.mock('src/audio/AudioEncoder', () => ({
 	encodeAudioBuffer: jest
 		.fn()
 		.mockResolvedValue(new Blob(['encoded'], { type: 'audio/webm' })),
@@ -49,14 +48,14 @@ jest.mock('../../src/audio/AudioEncoder', () => ({
 }));
 
 // Mock WavEncoder
-jest.mock('../../src/audio/WavEncoder', () => ({
+jest.mock('src/audio/WavEncoder', () => ({
 	assembleWavFromPcmSegmentFiles: jest
 		.fn()
 		.mockResolvedValue(new ArrayBuffer(44)),
 }));
 
 // Mock PcmStreamRecorder
-jest.mock('../../src/recording/PcmStreamRecorder', () => ({
+jest.mock('src/recording/PcmStreamRecorder', () => ({
 	PcmStreamRecorder: jest.fn().mockImplementation(() => ({
 		channels: 1,
 		sampleRate: 44100,
@@ -253,7 +252,7 @@ describe('RecordingManager', () => {
 			manager.cleanup();
 
 			const { PcmStreamRecorder } = jest.requireMock(
-				'../../src/recording/PcmStreamRecorder',
+				'src/recording/PcmStreamRecorder',
 			);
 			const recorderInstance = (PcmStreamRecorder as jest.Mock).mock
 				.results[0].value as { stop: jest.Mock };

--- a/tests/unit/RecordingManager.lifecycle.test.ts
+++ b/tests/unit/RecordingManager.lifecycle.test.ts
@@ -11,7 +11,7 @@ import { RecordingStatus } from '../../src/types';
 import {
 	DEFAULT_SETTINGS,
 	AudioRecorderSettings,
-} from '../../src/settings/Settings';
+} from '../../src/settings/settingsSchema';
 import type { App } from 'obsidian';
 import {
 	createRecordingMockApp,

--- a/tests/unit/RecordingManager.lifecycle.test.ts
+++ b/tests/unit/RecordingManager.lifecycle.test.ts
@@ -4,14 +4,13 @@
  * transitions, and error handling around start and stop.
  * @module tests/unit/RecordingManager.lifecycle.test
  */
-/** @jest-environment jsdom */
 
-import { RecordingManager } from '../../src/recording/RecordingManager';
-import { RecordingStatus } from '../../src/types';
+import { RecordingManager } from 'src/recording/RecordingManager';
+import { RecordingStatus } from 'src/types';
 import {
 	DEFAULT_SETTINGS,
 	AudioRecorderSettings,
-} from '../../src/settings/settingsSchema';
+} from 'src/settings/settingsSchema';
 import type { App } from 'obsidian';
 import {
 	createRecordingMockApp,
@@ -30,7 +29,7 @@ jest.mock('obsidian', () => ({
 }));
 
 // Mock AudioStreamHandler
-jest.mock('../../src/recording/AudioStreamHandler', () => ({
+jest.mock('src/recording/AudioStreamHandler', () => ({
 	getAudioStreams: jest.fn(),
 	getAudioSourceName: jest.fn().mockResolvedValue('TestDevice'),
 	stopAllStreams: jest.fn(),
@@ -38,7 +37,7 @@ jest.mock('../../src/recording/AudioStreamHandler', () => ({
 }));
 
 // Mock AudioEncoder module to avoid mediabunny TextDecoder requirement
-jest.mock('../../src/audio/AudioEncoder', () => ({
+jest.mock('src/audio/AudioEncoder', () => ({
 	encodeAudioBuffer: jest
 		.fn()
 		.mockResolvedValue(new Blob(['encoded'], { type: 'audio/webm' })),
@@ -50,14 +49,14 @@ jest.mock('../../src/audio/AudioEncoder', () => ({
 }));
 
 // Mock WavEncoder
-jest.mock('../../src/audio/WavEncoder', () => ({
+jest.mock('src/audio/WavEncoder', () => ({
 	assembleWavFromPcmSegmentFiles: jest
 		.fn()
 		.mockResolvedValue(new ArrayBuffer(44)),
 }));
 
 // Mock PcmStreamRecorder
-jest.mock('../../src/recording/PcmStreamRecorder', () => ({
+jest.mock('src/recording/PcmStreamRecorder', () => ({
 	PcmStreamRecorder: jest.fn().mockImplementation(() => ({
 		channels: 1,
 		sampleRate: 44100,
@@ -161,7 +160,7 @@ describe('RecordingManager', () => {
 
 			// Mock getAudioStreams
 			const { getAudioStreams } = jest.requireMock(
-				'../../src/recording/AudioStreamHandler',
+				'src/recording/AudioStreamHandler',
 			);
 			getAudioStreams.mockResolvedValue({
 				streams: [
@@ -232,7 +231,7 @@ describe('RecordingManager', () => {
 				jest.fn().mockReturnValue(true);
 
 			const { getAudioStreams } = jest.requireMock(
-				'../../src/recording/AudioStreamHandler',
+				'src/recording/AudioStreamHandler',
 			);
 			getAudioStreams.mockResolvedValue({
 				streams: [
@@ -307,7 +306,7 @@ describe('RecordingManager', () => {
 				jest.fn().mockReturnValue(true);
 
 			const { getAudioStreams } = jest.requireMock(
-				'../../src/recording/AudioStreamHandler',
+				'src/recording/AudioStreamHandler',
 			);
 			getAudioStreams.mockResolvedValue({
 				streams: [{ getTracks: () => [{ stop: jest.fn() }] }],
@@ -351,7 +350,7 @@ describe('RecordingManager', () => {
 				jest.fn().mockReturnValue(true);
 
 			const { getAudioStreams } = jest.requireMock(
-				'../../src/recording/AudioStreamHandler',
+				'src/recording/AudioStreamHandler',
 			);
 			getAudioStreams.mockResolvedValue({
 				streams: [{ getTracks: () => [{ stop: jest.fn() }] }],
@@ -374,7 +373,7 @@ describe('RecordingManager', () => {
 
 		it('should stop all streams', () => {
 			const { stopAllStreams } = jest.requireMock(
-				'../../src/recording/AudioStreamHandler',
+				'src/recording/AudioStreamHandler',
 			);
 
 			manager.cleanup();
@@ -413,7 +412,7 @@ describe('RecordingManager', () => {
 				jest.fn().mockReturnValue(true);
 
 			const { getAudioStreams } = jest.requireMock(
-				'../../src/recording/AudioStreamHandler',
+				'src/recording/AudioStreamHandler',
 			);
 			getAudioStreams.mockResolvedValue({
 				streams: [
@@ -448,7 +447,7 @@ describe('RecordingManager', () => {
 
 		it('should stop streams even when save fails', async () => {
 			const { stopAllStreams } = jest.requireMock(
-				'../../src/recording/AudioStreamHandler',
+				'src/recording/AudioStreamHandler',
 			);
 
 			await manager.startRecording();
@@ -509,7 +508,7 @@ describe('RecordingManager', () => {
 				jest.fn().mockReturnValue(true);
 
 			const { getAudioStreams } = jest.requireMock(
-				'../../src/recording/AudioStreamHandler',
+				'src/recording/AudioStreamHandler',
 			);
 			getAudioStreams.mockResolvedValue({
 				streams: [
@@ -547,7 +546,7 @@ describe('RecordingManager', () => {
 			};
 
 			const { getAudioStreams } = jest.requireMock(
-				'../../src/recording/AudioStreamHandler',
+				'src/recording/AudioStreamHandler',
 			);
 			getAudioStreams.mockRejectedValue(new Error('Permission denied'));
 
@@ -583,7 +582,7 @@ describe('RecordingManager', () => {
 				jest.fn().mockReturnValue(true);
 
 			const { getAudioStreams } = jest.requireMock(
-				'../../src/recording/AudioStreamHandler',
+				'src/recording/AudioStreamHandler',
 			);
 			getAudioStreams.mockResolvedValue({
 				streams: [

--- a/tests/unit/RecordingManager.markers.test.ts
+++ b/tests/unit/RecordingManager.markers.test.ts
@@ -12,7 +12,7 @@ import type { PlayerMarker } from '../../src/markers/markerModel';
 import {
 	DEFAULT_SETTINGS,
 	AudioRecorderSettings,
-} from '../../src/settings/Settings';
+} from '../../src/settings/settingsSchema';
 import type { App } from 'obsidian';
 import {
 	createRecordingMockApp,

--- a/tests/unit/RecordingManager.markers.test.ts
+++ b/tests/unit/RecordingManager.markers.test.ts
@@ -3,16 +3,15 @@
  * cancel, and persistence to the marker sidecar around session stop.
  * @module tests/unit/RecordingManager.markers.test
  */
-/** @jest-environment jsdom */
 
-import { RecordingManager } from '../../src/recording/RecordingManager';
-import { RecordingStatus } from '../../src/types';
-import { MARKER_KIND } from '../../src/markers/markerModel';
-import type { PlayerMarker } from '../../src/markers/markerModel';
+import { RecordingManager } from 'src/recording/RecordingManager';
+import { RecordingStatus } from 'src/types';
+import { MARKER_KIND } from 'src/markers/markerModel';
+import type { PlayerMarker } from 'src/markers/markerModel';
 import {
 	DEFAULT_SETTINGS,
 	AudioRecorderSettings,
-} from '../../src/settings/settingsSchema';
+} from 'src/settings/settingsSchema';
 import type { App } from 'obsidian';
 import {
 	createRecordingMockApp,
@@ -33,7 +32,7 @@ jest.mock('obsidian', () => ({
 }));
 
 // Mock AudioStreamHandler
-jest.mock('../../src/recording/AudioStreamHandler', () => ({
+jest.mock('src/recording/AudioStreamHandler', () => ({
 	getAudioStreams: jest.fn(),
 	getAudioSourceName: jest.fn().mockResolvedValue('TestDevice'),
 	stopAllStreams: jest.fn(),
@@ -41,7 +40,7 @@ jest.mock('../../src/recording/AudioStreamHandler', () => ({
 }));
 
 // Mock AudioEncoder module to avoid mediabunny TextDecoder requirement
-jest.mock('../../src/audio/AudioEncoder', () => ({
+jest.mock('src/audio/AudioEncoder', () => ({
 	encodeAudioBuffer: jest
 		.fn()
 		.mockResolvedValue(new Blob(['encoded'], { type: 'audio/webm' })),
@@ -53,14 +52,14 @@ jest.mock('../../src/audio/AudioEncoder', () => ({
 }));
 
 // Mock WavEncoder
-jest.mock('../../src/audio/WavEncoder', () => ({
+jest.mock('src/audio/WavEncoder', () => ({
 	assembleWavFromPcmSegmentFiles: jest
 		.fn()
 		.mockResolvedValue(new ArrayBuffer(44)),
 }));
 
 // Mock PcmStreamRecorder
-jest.mock('../../src/recording/PcmStreamRecorder', () => ({
+jest.mock('src/recording/PcmStreamRecorder', () => ({
 	PcmStreamRecorder: jest.fn().mockImplementation(() => ({
 		channels: 1,
 		sampleRate: 44100,
@@ -141,7 +140,7 @@ describe('RecordingManager', () => {
 				jest.fn().mockReturnValue(true);
 
 			const { getAudioStreams } = jest.requireMock(
-				'../../src/recording/AudioStreamHandler',
+				'src/recording/AudioStreamHandler',
 			);
 			getAudioStreams.mockResolvedValue({
 				streams: [{ getTracks: () => [{ stop: jest.fn() }] }],

--- a/tests/unit/RecordingManager.output.test.ts
+++ b/tests/unit/RecordingManager.output.test.ts
@@ -4,14 +4,13 @@
  * link insertion.
  * @module tests/unit/RecordingManager.output.test
  */
-/** @jest-environment jsdom */
 
-import { RecordingManager } from '../../src/recording/RecordingManager';
-import { RecordingStatus } from '../../src/types';
+import { RecordingManager } from 'src/recording/RecordingManager';
+import { RecordingStatus } from 'src/types';
 import {
 	DEFAULT_SETTINGS,
 	AudioRecorderSettings,
-} from '../../src/settings/settingsSchema';
+} from 'src/settings/settingsSchema';
 import type { App } from 'obsidian';
 import {
 	createRecordingMockApp,
@@ -30,7 +29,7 @@ jest.mock('obsidian', () => ({
 }));
 
 // Mock AudioStreamHandler
-jest.mock('../../src/recording/AudioStreamHandler', () => ({
+jest.mock('src/recording/AudioStreamHandler', () => ({
 	getAudioStreams: jest.fn(),
 	getAudioSourceName: jest.fn().mockResolvedValue('TestDevice'),
 	stopAllStreams: jest.fn(),
@@ -38,7 +37,7 @@ jest.mock('../../src/recording/AudioStreamHandler', () => ({
 }));
 
 // Mock AudioEncoder module to avoid mediabunny TextDecoder requirement
-jest.mock('../../src/audio/AudioEncoder', () => ({
+jest.mock('src/audio/AudioEncoder', () => ({
 	encodeAudioBuffer: jest
 		.fn()
 		.mockResolvedValue(new Blob(['encoded'], { type: 'audio/webm' })),
@@ -50,7 +49,7 @@ jest.mock('../../src/audio/AudioEncoder', () => ({
 }));
 
 // Mock WavEncoder
-jest.mock('../../src/audio/WavEncoder', () => ({
+jest.mock('src/audio/WavEncoder', () => ({
 	assembleWavFromPcmSegmentFiles: jest
 		.fn()
 		.mockResolvedValue(new ArrayBuffer(44)),
@@ -58,7 +57,7 @@ jest.mock('../../src/audio/WavEncoder', () => ({
 
 // Mock PcmStreamRecorder
 let capturedPcmChunkCallback: ((data: ArrayBuffer) => void) | null = null;
-jest.mock('../../src/recording/PcmStreamRecorder', () => ({
+jest.mock('src/recording/PcmStreamRecorder', () => ({
 	PcmStreamRecorder: jest
 		.fn()
 		.mockImplementation(
@@ -142,7 +141,7 @@ describe('RecordingManager', () => {
 					);
 
 			const { getAudioStreams } = jest.requireMock(
-				'../../src/recording/AudioStreamHandler',
+				'src/recording/AudioStreamHandler',
 			);
 			getAudioStreams.mockResolvedValue({
 				streams: [
@@ -154,7 +153,7 @@ describe('RecordingManager', () => {
 
 			// The mixed render encodes to an empty blob: nothing to save
 			const { encodeAudioBuffer } = jest.requireMock(
-				'../../src/audio/AudioEncoder',
+				'src/audio/AudioEncoder',
 			);
 			encodeAudioBuffer.mockResolvedValueOnce(new Blob([]));
 
@@ -212,7 +211,7 @@ describe('RecordingManager', () => {
 				jest.fn().mockReturnValue(true);
 
 			const { getAudioStreams } = jest.requireMock(
-				'../../src/recording/AudioStreamHandler',
+				'src/recording/AudioStreamHandler',
 			);
 			getAudioStreams.mockResolvedValue({
 				streams: [
@@ -263,7 +262,7 @@ describe('RecordingManager', () => {
 
 		it('should keep plain source names when they are unique', async () => {
 			const { getAudioSourceName } = jest.requireMock(
-				'../../src/recording/AudioStreamHandler',
+				'src/recording/AudioStreamHandler',
 			);
 			getAudioSourceName
 				.mockResolvedValueOnce('DeviceA')
@@ -344,7 +343,7 @@ describe('RecordingManager', () => {
 				jest.fn().mockReturnValue(true);
 
 			const { getAudioStreams } = jest.requireMock(
-				'../../src/recording/AudioStreamHandler',
+				'src/recording/AudioStreamHandler',
 			);
 			getAudioStreams.mockResolvedValue({
 				streams: [
@@ -435,7 +434,7 @@ describe('RecordingManager', () => {
 				jest.fn().mockReturnValue(true);
 
 			const { getAudioStreams } = jest.requireMock(
-				'../../src/recording/AudioStreamHandler',
+				'src/recording/AudioStreamHandler',
 			);
 			getAudioStreams.mockResolvedValue({
 				streams: [
@@ -555,7 +554,7 @@ describe('RecordingManager', () => {
 				jest.fn().mockReturnValue(true);
 
 			const { getAudioStreams } = jest.requireMock(
-				'../../src/recording/AudioStreamHandler',
+				'src/recording/AudioStreamHandler',
 			);
 			getAudioStreams.mockResolvedValue({
 				streams: [
@@ -614,7 +613,7 @@ describe('RecordingManager', () => {
 					);
 
 			const { getAudioStreams } = jest.requireMock(
-				'../../src/recording/AudioStreamHandler',
+				'src/recording/AudioStreamHandler',
 			);
 			getAudioStreams.mockResolvedValue({
 				streams: [
@@ -681,7 +680,7 @@ describe('RecordingManager', () => {
 				jest.fn().mockReturnValue(true);
 
 			const { getAudioStreams } = jest.requireMock(
-				'../../src/recording/AudioStreamHandler',
+				'src/recording/AudioStreamHandler',
 			);
 			getAudioStreams.mockResolvedValue({
 				streams: [{ getTracks: () => [{ stop: jest.fn() }] }],
@@ -744,7 +743,7 @@ describe('RecordingManager', () => {
 				jest.fn().mockReturnValue(true);
 
 			const { getAudioStreams } = jest.requireMock(
-				'../../src/recording/AudioStreamHandler',
+				'src/recording/AudioStreamHandler',
 			);
 			getAudioStreams.mockResolvedValue({
 				streams: [{ getTracks: () => [{ stop: jest.fn() }] }],
@@ -811,7 +810,7 @@ describe('RecordingManager', () => {
 				jest.fn().mockReturnValue(true);
 
 			const { getAudioStreams } = jest.requireMock(
-				'../../src/recording/AudioStreamHandler',
+				'src/recording/AudioStreamHandler',
 			);
 			getAudioStreams.mockResolvedValue({
 				streams: [{ getTracks: () => [{ stop: jest.fn() }] }],
@@ -869,7 +868,7 @@ describe('RecordingManager', () => {
 				jest.fn().mockReturnValue(true);
 
 			const { getAudioStreams } = jest.requireMock(
-				'../../src/recording/AudioStreamHandler',
+				'src/recording/AudioStreamHandler',
 			);
 			getAudioStreams.mockResolvedValue({
 				streams: [{ getTracks: () => [{ stop: jest.fn() }] }],
@@ -942,7 +941,7 @@ describe('RecordingManager', () => {
 				jest.fn().mockReturnValue(true);
 
 			const { getAudioStreams } = jest.requireMock(
-				'../../src/recording/AudioStreamHandler',
+				'src/recording/AudioStreamHandler',
 			);
 			getAudioStreams.mockResolvedValue({
 				streams: [{ getTracks: () => [{ stop: jest.fn() }] }],
@@ -1007,7 +1006,7 @@ describe('RecordingManager', () => {
 				jest.fn().mockReturnValue(true);
 
 			const { getAudioStreams } = jest.requireMock(
-				'../../src/recording/AudioStreamHandler',
+				'src/recording/AudioStreamHandler',
 			);
 			getAudioStreams.mockResolvedValue({
 				streams: [{ getTracks: () => [{ stop: jest.fn() }] }],

--- a/tests/unit/RecordingManager.output.test.ts
+++ b/tests/unit/RecordingManager.output.test.ts
@@ -11,7 +11,7 @@ import { RecordingStatus } from '../../src/types';
 import {
 	DEFAULT_SETTINGS,
 	AudioRecorderSettings,
-} from '../../src/settings/Settings';
+} from '../../src/settings/settingsSchema';
 import type { App } from 'obsidian';
 import {
 	createRecordingMockApp,

--- a/tests/unit/RecordingManager.streaming.test.ts
+++ b/tests/unit/RecordingManager.streaming.test.ts
@@ -4,14 +4,13 @@
  * rotation.
  * @module tests/unit/RecordingManager.streaming.test
  */
-/** @jest-environment jsdom */
 
-import { RecordingManager } from '../../src/recording/RecordingManager';
-import { RecordingStatus } from '../../src/types';
+import { RecordingManager } from 'src/recording/RecordingManager';
+import { RecordingStatus } from 'src/types';
 import {
 	DEFAULT_SETTINGS,
 	AudioRecorderSettings,
-} from '../../src/settings/settingsSchema';
+} from 'src/settings/settingsSchema';
 import type { App } from 'obsidian';
 import {
 	createDesktopRecorder,
@@ -35,7 +34,7 @@ jest.mock('obsidian', () => ({
 }));
 
 // Mock AudioStreamHandler
-jest.mock('../../src/recording/AudioStreamHandler', () => ({
+jest.mock('src/recording/AudioStreamHandler', () => ({
 	getAudioStreams: jest.fn(),
 	getAudioSourceName: jest.fn().mockResolvedValue('TestDevice'),
 	stopAllStreams: jest.fn(),
@@ -43,7 +42,7 @@ jest.mock('../../src/recording/AudioStreamHandler', () => ({
 }));
 
 // Mock AudioEncoder module to avoid mediabunny TextDecoder requirement
-jest.mock('../../src/audio/AudioEncoder', () => ({
+jest.mock('src/audio/AudioEncoder', () => ({
 	encodeAudioBuffer: jest
 		.fn()
 		.mockResolvedValue(new Blob(['encoded'], { type: 'audio/webm' })),
@@ -55,7 +54,7 @@ jest.mock('../../src/audio/AudioEncoder', () => ({
 }));
 
 // Mock WavEncoder
-jest.mock('../../src/audio/WavEncoder', () => ({
+jest.mock('src/audio/WavEncoder', () => ({
 	assembleWavFromPcmSegmentFiles: jest
 		.fn()
 		.mockResolvedValue(new ArrayBuffer(44)),
@@ -63,7 +62,7 @@ jest.mock('../../src/audio/WavEncoder', () => ({
 
 // Mock PcmStreamRecorder
 let capturedPcmChunkCallback: ((data: ArrayBuffer) => void) | null = null;
-jest.mock('../../src/recording/PcmStreamRecorder', () => ({
+jest.mock('src/recording/PcmStreamRecorder', () => ({
 	PcmStreamRecorder: jest
 		.fn()
 		.mockImplementation(
@@ -149,7 +148,7 @@ describe('RecordingManager', () => {
 				jest.fn().mockReturnValue(true);
 
 			const { getAudioStreams } = jest.requireMock(
-				'../../src/recording/AudioStreamHandler',
+				'src/recording/AudioStreamHandler',
 			);
 			getAudioStreams.mockResolvedValue({
 				streams: [
@@ -207,7 +206,7 @@ describe('RecordingManager', () => {
 				jest.fn().mockReturnValue(true);
 
 			const { getAudioStreams } = jest.requireMock(
-				'../../src/recording/AudioStreamHandler',
+				'src/recording/AudioStreamHandler',
 			);
 			getAudioStreams.mockResolvedValue({
 				streams: [
@@ -265,7 +264,7 @@ describe('RecordingManager', () => {
 				jest.fn().mockReturnValue(true);
 
 			const { getAudioStreams } = jest.requireMock(
-				'../../src/recording/AudioStreamHandler',
+				'src/recording/AudioStreamHandler',
 			);
 			getAudioStreams.mockResolvedValue({
 				streams: [
@@ -330,7 +329,7 @@ describe('RecordingManager', () => {
 					);
 
 			const { getAudioStreams } = jest.requireMock(
-				'../../src/recording/AudioStreamHandler',
+				'src/recording/AudioStreamHandler',
 			);
 			getAudioStreams.mockResolvedValue({
 				streams: [
@@ -470,7 +469,7 @@ describe('RecordingManager', () => {
 			);
 
 			const { getAudioStreams } = jest.requireMock(
-				'../../src/recording/AudioStreamHandler',
+				'src/recording/AudioStreamHandler',
 			);
 			getAudioStreams.mockResolvedValue({
 				streams: [{ getTracks: () => [{ stop: jest.fn() }] }],
@@ -576,7 +575,7 @@ describe('RecordingManager', () => {
 
 		function setupStreams(count: number): void {
 			const { getAudioStreams } = jest.requireMock(
-				'../../src/recording/AudioStreamHandler',
+				'src/recording/AudioStreamHandler',
 			);
 			getAudioStreams.mockResolvedValue({
 				streams: Array.from({ length: count }, () => ({

--- a/tests/unit/RecordingManager.streaming.test.ts
+++ b/tests/unit/RecordingManager.streaming.test.ts
@@ -11,7 +11,7 @@ import { RecordingStatus } from '../../src/types';
 import {
 	DEFAULT_SETTINGS,
 	AudioRecorderSettings,
-} from '../../src/settings/Settings';
+} from '../../src/settings/settingsSchema';
 import type { App } from 'obsidian';
 import {
 	createDesktopRecorder,

--- a/tests/unit/RecoveryModal.test.ts
+++ b/tests/unit/RecoveryModal.test.ts
@@ -2,10 +2,9 @@
  * Unit tests for RecoveryModal module.
  * @module tests/unit/RecoveryModal.test
  */
-/** @jest-environment jsdom */
 
-import { RecoveryModal } from '../../src/ui/RecoveryModal';
-import type { JournalSession } from '../../src/recording/SessionJournal';
+import { RecoveryModal } from 'src/ui/RecoveryModal';
+import type { JournalSession } from 'src/recording/SessionJournal';
 import { App } from 'obsidian';
 
 /** Captured action buttons rendered by the modal. */

--- a/tests/unit/RecoveryService.test.ts
+++ b/tests/unit/RecoveryService.test.ts
@@ -4,29 +4,25 @@
  * discard semantics.
  * @module tests/unit/RecoveryService.test
  */
-/** @jest-environment jsdom */
 
 import {
 	collectRecoverableSessions,
 	recoverSession,
 	discardSession,
-} from '../../src/recording/RecoveryService';
-import {
-	SessionJournal,
-	JOURNAL_VERSION,
-} from '../../src/recording/SessionJournal';
+} from 'src/recording/RecoveryService';
+import { SessionJournal, JOURNAL_VERSION } from 'src/recording/SessionJournal';
 import type {
 	JournalFile,
 	JournalSession,
 	JournalTrack,
-} from '../../src/recording/SessionJournal';
+} from 'src/recording/SessionJournal';
 import type { App } from 'obsidian';
 
 jest.mock('obsidian', () => ({
 	normalizePath: (path: string) => path.replace(/\\/g, '/'),
 }));
 
-jest.mock('../../src/audio/WavEncoder', () => ({
+jest.mock('src/audio/WavEncoder', () => ({
 	assembleWavFromPcmSegmentFiles: jest.fn((segmentPaths: string[]) =>
 		Promise.resolve(new Uint8Array(44 + segmentPaths.length).buffer),
 	),
@@ -240,7 +236,7 @@ describe('RecoveryService', () => {
 			const result = await recoverSession(session, journal, mockApp);
 
 			const { assembleWavFromPcmSegmentFiles } = jest.requireMock(
-				'../../src/audio/WavEncoder',
+				'src/audio/WavEncoder',
 			);
 			// Streamed straight from the segment files: recovery must not
 			// read the whole track into memory before assembly

--- a/tests/unit/RibbonIcon.test.ts
+++ b/tests/unit/RibbonIcon.test.ts
@@ -3,13 +3,9 @@
  * Tests the ribbon icon state changes during recording.
  * @module tests/unit/RibbonIcon.test
  */
-/** @jest-environment jsdom */
 
-import {
-	updateRibbonIcon,
-	initializeRibbonIcon,
-} from '../../src/ui/RibbonIcon';
-import { RecordingStatus } from '../../src/types';
+import { updateRibbonIcon, initializeRibbonIcon } from 'src/ui/RibbonIcon';
+import { RecordingStatus } from 'src/types';
 
 // Mock the setIcon function from obsidian
 jest.mock('obsidian', () => ({

--- a/tests/unit/SessionJournal.test.ts
+++ b/tests/unit/SessionJournal.test.ts
@@ -3,16 +3,9 @@
  * Tests journal persistence, write coalescing, and failure tolerance.
  * @module tests/unit/SessionJournal.test
  */
-/** @jest-environment jsdom */
 
-import {
-	SessionJournal,
-	JOURNAL_VERSION,
-} from '../../src/recording/SessionJournal';
-import type {
-	JournalFile,
-	JournalSession,
-} from '../../src/recording/SessionJournal';
+import { SessionJournal, JOURNAL_VERSION } from 'src/recording/SessionJournal';
+import type { JournalFile, JournalSession } from 'src/recording/SessionJournal';
 import type { App } from 'obsidian';
 
 jest.mock('obsidian', () => ({

--- a/tests/unit/Settings.player.test.ts
+++ b/tests/unit/Settings.player.test.ts
@@ -5,7 +5,8 @@
  * the rest.
  */
 
-import { DEFAULT_SETTINGS, mergeSettings } from 'src/settings/Settings';
+import { DEFAULT_SETTINGS } from 'src/settings/settingsSchema';
+import { mergeSettings } from 'src/settings/settingsSerialization';
 import {
 	resolvePlayerSettings,
 	playerSettingsEqual,

--- a/tests/unit/Settings.test.ts
+++ b/tests/unit/Settings.test.ts
@@ -11,11 +11,13 @@ import {
 	AudioRecorderSettings,
 	AudioRecorderSettingsInput,
 	DEFAULT_SETTINGS,
-	mergeSettings,
-	mergeSettingsAsync,
 	OutputMode,
 	TrackAudioSources,
-} from '../../src/settings/Settings';
+} from '../../src/settings/settingsSchema';
+import {
+	mergeSettings,
+	mergeSettingsAsync,
+} from '../../src/settings/settingsSerialization';
 
 describe('Settings', () => {
 	describe('DEFAULT_SETTINGS', () => {

--- a/tests/unit/Settings.test.ts
+++ b/tests/unit/Settings.test.ts
@@ -1,5 +1,4 @@
 /**
- * @jest-environment jsdom
  */
 
 /**
@@ -13,11 +12,11 @@ import {
 	DEFAULT_SETTINGS,
 	OutputMode,
 	TrackAudioSources,
-} from '../../src/settings/settingsSchema';
+} from 'src/settings/settingsSchema';
 import {
 	mergeSettings,
 	mergeSettingsAsync,
-} from '../../src/settings/settingsSerialization';
+} from 'src/settings/settingsSerialization';
 
 describe('Settings', () => {
 	describe('DEFAULT_SETTINGS', () => {
@@ -327,7 +326,7 @@ describe('Settings', () => {
 				llmProvider: 'openai-compatible',
 				llmApiKey: 'sk-legacy',
 				llmModel: 'gpt-legacy',
-			} as unknown as AudioRecorderSettingsInput);
+			});
 
 			expect(result.whisperApiKey).toBe('sk-legacy');
 			expect(result.llmOpenAiModel).toBe('gpt-legacy');
@@ -338,7 +337,7 @@ describe('Settings', () => {
 				llmProvider: 'gemini',
 				geminiApiKey: 'gm-current',
 				llmApiKey: 'gm-legacy',
-			} as unknown as AudioRecorderSettingsInput);
+			});
 
 			expect(result.geminiApiKey).toBe('gm-current');
 		});

--- a/tests/unit/Settings.validation.test.ts
+++ b/tests/unit/Settings.validation.test.ts
@@ -6,9 +6,9 @@
 import {
 	AudioRecorderSettings,
 	DEFAULT_SETTINGS,
-} from '../../src/settings/settingsSchema';
-import { validateSettings } from '../../src/settings/settingsValidation';
-import { SettingsValidationError } from '../../src/errors';
+} from 'src/settings/settingsSchema';
+import { validateSettings } from 'src/settings/settingsValidation';
+import { SettingsValidationError } from 'src/errors';
 
 describe('validateSettings', () => {
 	it('should throw SettingsValidationError when audioDeviceId is empty', () => {

--- a/tests/unit/Settings.validation.test.ts
+++ b/tests/unit/Settings.validation.test.ts
@@ -6,8 +6,8 @@
 import {
 	AudioRecorderSettings,
 	DEFAULT_SETTINGS,
-	validateSettings,
-} from '../../src/settings/Settings';
+} from '../../src/settings/settingsSchema';
+import { validateSettings } from '../../src/settings/settingsValidation';
 import { SettingsValidationError } from '../../src/errors';
 
 describe('validateSettings', () => {

--- a/tests/unit/SettingsTab.test.ts
+++ b/tests/unit/SettingsTab.test.ts
@@ -10,7 +10,7 @@ import { AudioRecorderSettingTab } from '../../src/settings/SettingsTab';
 import {
 	DEFAULT_SETTINGS,
 	AudioRecorderSettings,
-} from '../../src/settings/Settings';
+} from '../../src/settings/settingsSchema';
 
 // Mock AudioEncoder to avoid loading mediabunny in jsdom
 jest.mock('../../src/audio/AudioEncoder', () => ({

--- a/tests/unit/SettingsTab.test.ts
+++ b/tests/unit/SettingsTab.test.ts
@@ -3,17 +3,16 @@
  * Tests device-change listener lifecycle and test recording cleanup.
  * @module tests/unit/SettingsTab.test
  */
-/** @jest-environment jsdom */
 
 import { App } from 'obsidian';
-import { AudioRecorderSettingTab } from '../../src/settings/SettingsTab';
+import { AudioRecorderSettingTab } from 'src/settings/SettingsTab';
 import {
 	DEFAULT_SETTINGS,
 	AudioRecorderSettings,
-} from '../../src/settings/settingsSchema';
+} from 'src/settings/settingsSchema';
 
 // Mock AudioEncoder to avoid loading mediabunny in jsdom
-jest.mock('../../src/audio/AudioEncoder', () => ({
+jest.mock('src/audio/AudioEncoder', () => ({
 	encodeAudioBuffer: jest.fn(),
 	isOfflineEncodingSupported: jest.fn((format: string) =>
 		['mp3', 'flac', 'wav', 'webm', 'ogg', 'mp4', 'm4a'].includes(format),
@@ -22,7 +21,7 @@ jest.mock('../../src/audio/AudioEncoder', () => ({
 
 // Mock SystemDiagnostics: pulled in by the settings tab but exercised
 // in its own suite
-jest.mock('../../src/diagnostics/SystemDiagnostics', () => ({
+jest.mock('src/diagnostics/SystemDiagnostics', () => ({
 	SystemDiagnostics: { collect: jest.fn() },
 }));
 
@@ -64,10 +63,7 @@ describe('AudioRecorderSettingTab', () => {
 			settings: mockSettings,
 			saveSettings: jest.fn().mockResolvedValue(undefined),
 		};
-		tab = new AudioRecorderSettingTab(
-			new App(),
-			mockPlugin as unknown as AudioRecorderSettingTab['plugin'],
-		);
+		tab = new AudioRecorderSettingTab(new App(), mockPlugin);
 	});
 
 	describe('device-change listener lifecycle', () => {

--- a/tests/unit/SettingsTab.test.ts
+++ b/tests/unit/SettingsTab.test.ts
@@ -18,7 +18,6 @@ jest.mock('../../src/audio/AudioEncoder', () => ({
 	isOfflineEncodingSupported: jest.fn((format: string) =>
 		['mp3', 'flac', 'wav', 'webm', 'ogg', 'mp4', 'm4a'].includes(format),
 	),
-	getEncoderDescription: jest.fn().mockReturnValue('Test Encoder'),
 }));
 
 // Mock SystemDiagnostics: pulled in by the settings tab but exercised

--- a/tests/unit/SplitModal.test.ts
+++ b/tests/unit/SplitModal.test.ts
@@ -8,7 +8,7 @@ import { SplitModal } from '../../src/ui/SplitModal';
 import { App, Notice, TFile } from 'obsidian';
 import { createWavHeader } from '../../src/audio/WavEncoder';
 import { createMockAudioBuffer } from '../helpers/createMockAudioBuffer';
-import type { AudioRecorderSettings } from '../../src/settings/Settings';
+import type { AudioRecorderSettings } from '../../src/settings/settingsSchema';
 
 /**
  * Extends an HTMLElement with Obsidian's custom DOM methods.

--- a/tests/unit/SplitModal.test.ts
+++ b/tests/unit/SplitModal.test.ts
@@ -2,13 +2,12 @@
  * Unit tests for SplitModal module.
  * @module tests/unit/SplitModal.test
  */
-/** @jest-environment jsdom */
 
-import { SplitModal } from '../../src/ui/SplitModal';
+import { SplitModal } from 'src/ui/SplitModal';
 import { App, Notice, TFile } from 'obsidian';
-import { createWavHeader } from '../../src/audio/WavEncoder';
+import { createWavHeader } from 'src/audio/WavEncoder';
 import { createMockAudioBuffer } from '../helpers/createMockAudioBuffer';
-import type { AudioRecorderSettings } from '../../src/settings/settingsSchema';
+import type { AudioRecorderSettings } from 'src/settings/settingsSchema';
 
 /**
  * Extends an HTMLElement with Obsidian's custom DOM methods.
@@ -182,7 +181,7 @@ jest.mock('obsidian', () => ({
 }));
 
 // Mock AudioEncoder
-jest.mock('../../src/audio/AudioEncoder', () => ({
+jest.mock('src/audio/AudioEncoder', () => ({
 	encodeAudioBuffer: jest
 		.fn()
 		.mockResolvedValue(new Blob(['encoded'], { type: 'audio/webm' })),
@@ -190,19 +189,19 @@ jest.mock('../../src/audio/AudioEncoder', () => ({
 }));
 
 // Mock AudioCapabilityDetector
-jest.mock('../../src/audio/AudioCapabilityDetector', () => ({
+jest.mock('src/audio/AudioCapabilityDetector', () => ({
 	getSupportedBitrates: jest
 		.fn()
 		.mockReturnValue([64000, 96000, 128000, 192000, 256000, 320000]),
 }));
 
 // Mock the decoder: the compressed path decodes once via this function
-jest.mock('../../src/audio/AudioFormatConverter', () => ({
+jest.mock('src/audio/AudioFormatConverter', () => ({
 	decodeAudioBlob: jest.fn(),
 }));
 
 // Mock the vault-wide link updater
-jest.mock('../../src/utils/LinkUpdater', () => ({
+jest.mock('src/utils/LinkUpdater', () => ({
 	updateLinksInVault: jest.fn().mockResolvedValue({
 		updatedNotes: 1,
 		skippedReferences: 0,
@@ -210,9 +209,9 @@ jest.mock('../../src/utils/LinkUpdater', () => ({
 	}),
 }));
 
-import { encodeAudioBuffer } from '../../src/audio/AudioEncoder';
-import { decodeAudioBlob } from '../../src/audio/AudioFormatConverter';
-import { updateLinksInVault } from '../../src/utils/LinkUpdater';
+import { encodeAudioBuffer } from 'src/audio/AudioEncoder';
+import { decodeAudioBlob } from 'src/audio/AudioFormatConverter';
+import { updateLinksInVault } from 'src/utils/LinkUpdater';
 
 /** WAV header size produced by createWavHeader. */
 const WAV_HEADER_SIZE = 44;
@@ -252,7 +251,7 @@ interface SplitModalInternals {
 }
 
 function internals(modal: SplitModal): SplitModalInternals {
-	return modal as unknown as SplitModalInternals;
+	return modal;
 }
 
 describe('SplitModal', () => {
@@ -344,7 +343,7 @@ describe('SplitModal', () => {
 		const modal = new SplitModal(mockApp, mockFile, {
 			...mockSettings,
 			conversionLinkAction: 'after',
-		} as unknown as AudioRecorderSettings);
+		});
 
 		expect(internals(modal).linkAction).toBe('after');
 	});
@@ -384,7 +383,7 @@ describe('SplitModal', () => {
 
 	it('should show the WAV extension in the example when encoding falls back', () => {
 		const { isOfflineEncodingSupported } = jest.requireMock(
-			'../../src/audio/AudioEncoder',
+			'src/audio/AudioEncoder',
 		);
 		(isOfflineEncodingSupported as jest.Mock).mockReturnValue(false);
 		configureFile('recording.webm', 'webm');
@@ -454,27 +453,29 @@ describe('SplitModal', () => {
 		expect(notice.hide).toHaveBeenCalled();
 	});
 
-	it('should fall back to the default suffix for an invalid configured suffix', () => {
+	it.each([
+		['an invalid configured suffix', 'bad/suffix', 'part'],
+		['a blank configured suffix', '', 'part'],
+		['a valid configured suffix (kept)', 'track', 'track'],
+	])('normalizes %s', (_case, splitPartSuffix, expected) => {
 		const modal = new SplitModal(mockApp, mockFile, {
 			...mockSettings,
-			splitPartSuffix: 'bad/suffix',
+			splitPartSuffix,
 		});
 
-		expect(internals(modal).partSuffix).toBe('part');
+		expect(internals(modal).partSuffix).toBe(expected);
 	});
 
-	it('should clamp out-of-range configured part durations', () => {
-		const tooLarge = new SplitModal(mockApp, mockFile, {
+	it.each([
+		['an oversized duration', 10000, 180],
+		['a non-finite duration', Number.NaN, 15],
+		['a zero duration', 0, 1],
+	])('clamps %s', (_case, splitChunkMinutes, expected) => {
+		const modal = new SplitModal(mockApp, mockFile, {
 			...mockSettings,
-			splitChunkMinutes: 10000,
+			splitChunkMinutes,
 		});
-		expect(internals(tooLarge).partMinutes).toBe(180);
-
-		const nonFinite = new SplitModal(mockApp, mockFile, {
-			...mockSettings,
-			splitChunkMinutes: Number.NaN,
-		});
-		expect(internals(nonFinite).partMinutes).toBe(15);
+		expect(internals(modal).partMinutes).toBe(expected);
 	});
 
 	it('should render source file info on open and clear on close', () => {
@@ -509,30 +510,22 @@ describe('SplitModal', () => {
 		expect(internals(modal).linkAction).toBe('after');
 	});
 
-	it('should toggle the invalid-input class on the suffix field', () => {
+	it.each([
+		['an invalid suffix', 'bad/suffix', true],
+		['a valid suffix', 'good-suffix', false],
+		// Empty input is valid: it falls back to the default suffix
+		['a blank suffix', '', false],
+	])('toggles the invalid-input class for %s', (_case, input, invalid) => {
 		const modal = new SplitModal(mockApp, mockFile, mockSettings);
 		modal.onOpen();
 
 		const handler = mockCapturedControls.texts[0];
 		const inputEl = mockCapturedControls.textInputs[0];
 
-		handler('bad/suffix');
+		handler(input);
 		expect(inputEl.toggleClass).toHaveBeenLastCalledWith(
 			'aar-input-invalid',
-			true,
-		);
-
-		handler('good-suffix');
-		expect(inputEl.toggleClass).toHaveBeenLastCalledWith(
-			'aar-input-invalid',
-			false,
-		);
-
-		// Empty input is valid: it falls back to the default suffix
-		handler('');
-		expect(inputEl.toggleClass).toHaveBeenLastCalledWith(
-			'aar-input-invalid',
-			false,
+			invalid,
 		);
 	});
 
@@ -1040,7 +1033,7 @@ describe('SplitModal', () => {
 
 		it('should fall back to WAV when the source format cannot be encoded', async () => {
 			const { isOfflineEncodingSupported } = jest.requireMock(
-				'../../src/audio/AudioEncoder',
+				'src/audio/AudioEncoder',
 			);
 			(isOfflineEncodingSupported as jest.Mock).mockReturnValue(false);
 			const modal = new SplitModal(mockApp, mockFile, mockSettings);

--- a/tests/unit/SplitModal.test.ts
+++ b/tests/unit/SplitModal.test.ts
@@ -187,7 +187,6 @@ jest.mock('../../src/audio/AudioEncoder', () => ({
 		.fn()
 		.mockResolvedValue(new Blob(['encoded'], { type: 'audio/webm' })),
 	isOfflineEncodingSupported: jest.fn().mockReturnValue(true),
-	getEncoderDescription: jest.fn().mockReturnValue('Test Encoder'),
 }));
 
 // Mock AudioCapabilityDetector

--- a/tests/unit/SplitService.test.ts
+++ b/tests/unit/SplitService.test.ts
@@ -4,10 +4,9 @@
  * the service-level contract.
  * @module tests/unit/SplitService.test
  */
-/** @jest-environment jsdom */
 
-import { SplitService } from '../../src/recording/SplitService';
-import type { SplitRequest } from '../../src/recording/SplitService';
+import { SplitService } from 'src/recording/SplitService';
+import type { SplitRequest } from 'src/recording/SplitService';
 import { TFile, App } from 'obsidian';
 
 jest.mock('obsidian', () => ({
@@ -23,7 +22,7 @@ jest.mock('obsidian', () => ({
 	normalizePath: (path: string) => path.replace(/\\/g, '/'),
 }));
 
-jest.mock('../../src/audio/AudioEncoder', () => ({
+jest.mock('src/audio/AudioEncoder', () => ({
 	encodeAudioBuffer: jest
 		.fn()
 		.mockResolvedValue(new Blob(['encoded'], { type: 'audio/mp3' })),
@@ -32,7 +31,7 @@ jest.mock('../../src/audio/AudioEncoder', () => ({
 	),
 }));
 
-jest.mock('../../src/audio/AudioFormatConverter', () => ({
+jest.mock('src/audio/AudioFormatConverter', () => ({
 	decodeAudioBlob: jest.fn().mockResolvedValue({
 		length: 882000,
 		sampleRate: 44100,
@@ -41,17 +40,17 @@ jest.mock('../../src/audio/AudioFormatConverter', () => ({
 	}),
 }));
 
-jest.mock('../../src/recording/AudioSplitter', () => {
+jest.mock('src/recording/AudioSplitter', () => {
 	const actual = jest.requireActual<
-		typeof import('../../src/recording/AudioSplitter')
-	>('../../src/recording/AudioSplitter');
+		typeof import('src/recording/AudioSplitter')
+	>('src/recording/AudioSplitter');
 	return {
 		...actual,
 		sliceAudioBuffer: jest.fn().mockReturnValue({}),
 	};
 });
 
-jest.mock('../../src/utils/LinkUpdater', () => ({
+jest.mock('src/utils/LinkUpdater', () => ({
 	updateLinksInVault: jest.fn().mockResolvedValue({
 		updatedNotes: 0,
 		skippedReferences: 0,

--- a/tests/unit/StatusBar.test.ts
+++ b/tests/unit/StatusBar.test.ts
@@ -3,15 +3,14 @@
  * Tests the status bar state changes during recording and saving.
  * @module tests/unit/StatusBar.test
  */
-/** @jest-environment jsdom */
 
 import {
 	updateStatusBar,
 	initializeStatusBar,
 	renderTranscriptionStatusBar,
-} from '../../src/ui/StatusBar';
-import { RecordingStatus } from '../../src/types';
-import type { RecordingControls } from '../../src/types';
+} from 'src/ui/StatusBar';
+import { RecordingStatus } from 'src/types';
+import type { RecordingControls } from 'src/types';
 
 jest.mock('obsidian', () => ({
 	setIcon: jest.fn(),

--- a/tests/unit/StreamingMixer.test.ts
+++ b/tests/unit/StreamingMixer.test.ts
@@ -3,13 +3,9 @@
  * Mixes synthetic PCM fixtures and verifies exact sample values.
  * @module tests/unit/StreamingMixer.test
  */
-/** @jest-environment jsdom */
 
-import {
-	canStreamMix,
-	mixPcmTracksToWav,
-} from '../../src/recording/StreamingMixer';
-import type { PcmMixTrack } from '../../src/recording/StreamingMixer';
+import { canStreamMix, mixPcmTracksToWav } from 'src/recording/StreamingMixer';
+import type { PcmMixTrack } from 'src/recording/StreamingMixer';
 import type { App } from 'obsidian';
 
 jest.mock('obsidian', () => ({

--- a/tests/unit/SystemDiagnostics.test.ts
+++ b/tests/unit/SystemDiagnostics.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { SystemDiagnostics } from 'src/diagnostics/SystemDiagnostics';
-import type { AudioRecorderSettings } from 'src/settings/Settings';
+import type { AudioRecorderSettings } from 'src/settings/settingsSchema';
 import * as AudioCapabilityDetector from 'src/audio/AudioCapabilityDetector';
 import {
 	FORMAT_WEBM,

--- a/tests/unit/SystemDiagnostics.test.ts
+++ b/tests/unit/SystemDiagnostics.test.ts
@@ -1,4 +1,3 @@
-/** @jest-environment jsdom */
 /**
  * Unit tests for SystemDiagnostics.
  * @module tests/unit/SystemDiagnostics

--- a/tests/unit/SystemDiagnostics.test.ts
+++ b/tests/unit/SystemDiagnostics.test.ts
@@ -102,11 +102,10 @@ describe('SystemDiagnostics.collectEnvironment', () => {
 			originalProcess;
 	});
 
-	it('reads apiVersion from app', () => {
-		const app = makeApp('1.7.3');
-		const result = SystemDiagnostics.collectEnvironment(app);
+	it("reads the API version from obsidian's module export", () => {
+		const result = SystemDiagnostics.collectEnvironment(makeApp());
 
-		expect(result.obsidianVersion).toBe('1.7.3');
+		expect(result.obsidianVersion).toBe('1.12.3');
 	});
 
 	it('reads electron and node versions from process.versions', () => {
@@ -142,15 +141,6 @@ describe('SystemDiagnostics.collectEnvironment', () => {
 		expect(result.electronVersion).toBe('unknown');
 		expect(result.nodeVersion).toBe('unknown');
 		expect(result.arch).toBe('unknown');
-	});
-
-	it('returns "unknown" obsidianVersion when app has no apiVersion', () => {
-		const app = {} as Parameters<
-			typeof SystemDiagnostics.collectEnvironment
-		>[0];
-		const result = SystemDiagnostics.collectEnvironment(app);
-
-		expect(result.obsidianVersion).toBe('unknown');
 	});
 
 	it('returns "unknown" for userAgent', () => {
@@ -460,7 +450,7 @@ describe('SystemDiagnostics.collect', () => {
 		expect(result).toHaveProperty('audioDevices');
 		expect(result).toHaveProperty('audioCapabilities');
 		expect(result).toHaveProperty('activeRecordingConfig');
-		expect(result.environment.obsidianVersion).toBe('1.6.0');
+		expect(result.environment.obsidianVersion).toBe('1.12.3');
 		expect(result.pluginSettings.recordingFormat).toBe(FORMAT_WEBM);
 		expect(Array.isArray(result.audioDevices)).toBe(true);
 	});

--- a/tests/unit/SystemInfoModal.test.ts
+++ b/tests/unit/SystemInfoModal.test.ts
@@ -1,4 +1,3 @@
-/** @jest-environment jsdom */
 /**
  * Unit tests for SystemInfoModal.
  * @module tests/unit/SystemInfoModal

--- a/tests/unit/TrackWriteQueue.test.ts
+++ b/tests/unit/TrackWriteQueue.test.ts
@@ -3,14 +3,13 @@
  * Tests chain serialization, failure containment, and buffer flushes.
  * @module tests/unit/TrackWriteQueue.test
  */
-/** @jest-environment jsdom */
 
-import { TrackWriteQueue } from '../../src/recording/TrackWriteQueue';
-import type { RecordingSessionConfig, RecordingTarget } from '../../src/types';
+import { TrackWriteQueue } from 'src/recording/TrackWriteQueue';
+import type { RecordingSessionConfig, RecordingTarget } from 'src/types';
 import {
 	DEFAULT_SETTINGS,
 	AudioRecorderSettings,
-} from '../../src/settings/settingsSchema';
+} from 'src/settings/settingsSchema';
 import type { App } from 'obsidian';
 
 jest.mock('obsidian', () => ({
@@ -19,7 +18,7 @@ jest.mock('obsidian', () => ({
 }));
 
 // Mock AudioFormatConverter: the mobile flush pipeline has its own suite
-jest.mock('../../src/audio/AudioFormatConverter', () => ({
+jest.mock('src/audio/AudioFormatConverter', () => ({
 	buildOutputBlob: jest
 		.fn()
 		.mockResolvedValue(new Blob(['output'], { type: 'audio/webm' })),
@@ -287,7 +286,7 @@ describe('TrackWriteQueue', () => {
 			await queue.flushChunkBuffer(target);
 
 			const { buildOutputBlob } = jest.requireMock(
-				'../../src/audio/AudioFormatConverter',
+				'src/audio/AudioFormatConverter',
 			);
 			expect(buildOutputBlob).toHaveBeenCalledWith(
 				chunks,

--- a/tests/unit/TrackWriteQueue.test.ts
+++ b/tests/unit/TrackWriteQueue.test.ts
@@ -10,7 +10,7 @@ import type { RecordingSessionConfig, RecordingTarget } from '../../src/types';
 import {
 	DEFAULT_SETTINGS,
 	AudioRecorderSettings,
-} from '../../src/settings/Settings';
+} from '../../src/settings/settingsSchema';
 import type { App } from 'obsidian';
 
 jest.mock('obsidian', () => ({

--- a/tests/unit/TranscriptionModal.test.ts
+++ b/tests/unit/TranscriptionModal.test.ts
@@ -2,12 +2,11 @@
  * Unit tests for TranscriptionModal background/minimize behavior.
  * @module tests/unit/TranscriptionModal.test
  */
-/** @jest-environment jsdom */
 
 import { App, TFile } from 'obsidian';
-import { DEFAULT_SETTINGS } from '../../src/settings/settingsSchema';
-import { TranscriptionModal } from '../../src/ui/TranscriptionModal';
-import type { AudioRecorderSettings } from '../../src/settings/settingsSchema';
+import { DEFAULT_SETTINGS } from 'src/settings/settingsSchema';
+import { TranscriptionModal } from 'src/ui/TranscriptionModal';
+import type { AudioRecorderSettings } from 'src/settings/settingsSchema';
 
 type TranscriptionModalInternals = {
 	setRunning: (running: boolean) => void;

--- a/tests/unit/TranscriptionModal.test.ts
+++ b/tests/unit/TranscriptionModal.test.ts
@@ -5,9 +5,9 @@
 /** @jest-environment jsdom */
 
 import { App, TFile } from 'obsidian';
-import { DEFAULT_SETTINGS } from '../../src/settings/Settings';
+import { DEFAULT_SETTINGS } from '../../src/settings/settingsSchema';
 import { TranscriptionModal } from '../../src/ui/TranscriptionModal';
-import type { AudioRecorderSettings } from '../../src/settings/Settings';
+import type { AudioRecorderSettings } from '../../src/settings/settingsSchema';
 
 type TranscriptionModalInternals = {
 	setRunning: (running: boolean) => void;

--- a/tests/unit/WavEncoder.test.ts
+++ b/tests/unit/WavEncoder.test.ts
@@ -2,7 +2,6 @@
  * Unit tests for WavEncoder module.
  * @module tests/unit/WavEncoder.test
  */
-/** @jest-environment jsdom */
 
 import type { App } from 'obsidian';
 import {
@@ -10,7 +9,7 @@ import {
 	createWavHeader,
 	assembleWavFromPcmSegments,
 	assembleWavFromPcmSegmentFiles,
-} from '../../src/audio/WavEncoder';
+} from 'src/audio/WavEncoder';
 
 describe('WavEncoder', () => {
 	describe('getWavHeaderInfo', () => {

--- a/tests/unit/WaveformCanvas.test.ts
+++ b/tests/unit/WaveformCanvas.test.ts
@@ -1,4 +1,3 @@
-/** @jest-environment jsdom */
 /**
  * Unit tests for the waveform renderer. The central regression guard is that
  * moving the playhead (setProgress) does no canvas work - it only updates the

--- a/tests/unit/addModelPicker.test.ts
+++ b/tests/unit/addModelPicker.test.ts
@@ -12,7 +12,7 @@ import {
 	addModelPicker,
 	type SettingsSectionContext,
 } from '../../src/settings/settingControls';
-import type { AudioRecorderSettings } from '../../src/settings/Settings';
+import type { AudioRecorderSettings } from '../../src/settings/settingsSchema';
 
 interface DropdownCapture {
 	options: { value: string; label: string }[];

--- a/tests/unit/addModelPicker.test.ts
+++ b/tests/unit/addModelPicker.test.ts
@@ -6,13 +6,12 @@
  * for each engine.
  * @module tests/unit/addModelPicker.test
  */
-/** @jest-environment jsdom */
 
 import {
 	addModelPicker,
 	type SettingsSectionContext,
-} from '../../src/settings/settingControls';
-import type { AudioRecorderSettings } from '../../src/settings/settingsSchema';
+} from 'src/settings/settingControls';
+import type { AudioRecorderSettings } from 'src/settings/settingsSchema';
 
 interface DropdownCapture {
 	options: { value: string; label: string }[];

--- a/tests/unit/audioDsp.test.ts
+++ b/tests/unit/audioDsp.test.ts
@@ -10,7 +10,7 @@ import {
 	hasActiveStage,
 	resolveAudioDspConfig,
 } from 'src/cleanup/audioDsp';
-import { mergeSettings } from 'src/settings/Settings';
+import { mergeSettings } from 'src/settings/settingsSerialization';
 import {
 	DEFAULT_CLEANUP_HIGHPASS_HZ,
 	MAX_CLEANUP_GATE_THRESHOLD_DB,

--- a/tests/unit/audioPlayerEmbedContract.test.ts
+++ b/tests/unit/audioPlayerEmbedContract.test.ts
@@ -1,5 +1,4 @@
 /**
- * @jest-environment jsdom
  */
 
 /**

--- a/tests/unit/encodingWorker.test.ts
+++ b/tests/unit/encodingWorker.test.ts
@@ -3,13 +3,9 @@
  * thin wrapper; the handler is tested directly with mocked mediabunny.
  * @module tests/unit/encodingWorker.test
  */
-/** @jest-environment jsdom */
 
-import { handleEncodingMessage } from '../../src/audio/encodingWorker';
-import type {
-	WorkerRequest,
-	WorkerResponse,
-} from '../../src/audio/encodingWorker';
+import { handleEncodingMessage } from 'src/audio/encodingWorker';
+import type { WorkerRequest, WorkerResponse } from 'src/audio/encodingWorker';
 
 const mockConversionExecute = jest.fn().mockResolvedValue(undefined);
 const mockConversionInit = jest.fn();
@@ -33,7 +29,7 @@ jest.mock('mediabunny', () => ({
 	},
 }));
 
-jest.mock('../../src/audio/AudioEncoder', () => ({
+jest.mock('src/audio/AudioEncoder', () => ({
 	ensureEncoderRegistered: jest.fn().mockResolvedValue(undefined),
 	createOutputFormat: jest.fn().mockReturnValue({}),
 	FORMAT_CODEC_MAP: {

--- a/tests/unit/formatDescriptions.test.ts
+++ b/tests/unit/formatDescriptions.test.ts
@@ -3,7 +3,7 @@
  * @module tests/unit/formatDescriptions.test
  */
 
-import { getEncoderDescription } from '../../src/ui/formatDescriptions';
+import { getEncoderDescription } from 'src/ui/formatDescriptions';
 
 describe('getEncoderDescription', () => {
 	it.each([

--- a/tests/unit/formatDescriptions.test.ts
+++ b/tests/unit/formatDescriptions.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Unit tests for the UI-layer format description lookup.
+ * @module tests/unit/formatDescriptions.test
+ */
+
+import { getEncoderDescription } from '../../src/ui/formatDescriptions';
+
+describe('getEncoderDescription', () => {
+	it.each([
+		['wav', 'PCM (built-in)'],
+		['webm', 'AudioEncoder (Opus) + Mediabunny'],
+		['ogg', 'AudioEncoder (Opus) + Mediabunny'],
+		['mp4', 'AudioEncoder (AAC) + Mediabunny'],
+		['m4a', 'AudioEncoder (AAC) + Mediabunny'],
+		['aac', 'AudioEncoder (AAC) + Mediabunny'],
+		['mp3', 'Mediabunny MP3 Encoder'],
+		['flac', 'Mediabunny FLAC Encoder'],
+	])('describes %s as %s', (format, description) => {
+		expect(getEncoderDescription(format)).toBe(description);
+	});
+
+	it('returns Unknown for unsupported formats', () => {
+		expect(getEncoderDescription('xyz')).toBe('Unknown');
+	});
+});

--- a/tests/unit/helpers/recordingManagerTestKit.ts
+++ b/tests/unit/helpers/recordingManagerTestKit.ts
@@ -8,9 +8,9 @@
  */
 
 import type { App } from 'obsidian';
-import type { RecordingManager } from '../../../src/recording/RecordingManager';
-import type { MarkerStore } from '../../../src/markers/MarkerStore';
-import type { PlayerMarker } from '../../../src/markers/markerModel';
+import type { RecordingManager } from 'src/recording/RecordingManager';
+import type { MarkerStore } from 'src/markers/MarkerStore';
+import type { PlayerMarker } from 'src/markers/markerModel';
 
 /**
  * Installs the AudioContext, OfflineAudioContext, and AudioBuffer
@@ -129,7 +129,7 @@ export const createDesktopRecorder = (): MockMediaRecorder => {
 		.fn()
 		.mockReturnValue(true);
 	const { getAudioStreams } = jest.requireMock(
-		'../../../src/recording/AudioStreamHandler',
+		'src/recording/AudioStreamHandler',
 	);
 	getAudioStreams.mockResolvedValue({
 		streams: [{ getTracks: () => [{ stop: jest.fn() }] }],

--- a/tests/unit/httpClient.test.ts
+++ b/tests/unit/httpClient.test.ts
@@ -6,12 +6,15 @@
 
 import {
 	friendlyHttpHint,
+	HttpError,
+	requestRaw,
 	uploadTimeoutMs,
 } from 'src/transcription/httpClient';
 import {
 	TRANSCRIBE_MAX_REQUEST_TIMEOUT_MS,
 	TRANSCRIBE_REQUEST_TIMEOUT_MS,
 } from 'src/constants';
+import { __setRequestUrlHandler } from '../mocks/obsidian';
 
 describe('friendlyHttpHint', () => {
 	it('flags an OpenAI insufficient_quota 429 as a billing problem', () => {
@@ -107,5 +110,113 @@ describe('uploadTimeoutMs', () => {
 		expect(uploadTimeoutMs(10 * 1024 * 1024)).toBeLessThanOrEqual(
 			uploadTimeoutMs(20 * 1024 * 1024),
 		);
+	});
+});
+
+describe('requestRaw abort support', () => {
+	afterEach(() => {
+		__setRequestUrlHandler(null);
+		delete (globalThis as { fetch?: unknown }).fetch;
+	});
+
+	function mockFetch(impl: (typeof globalThis)['fetch']): jest.Mock {
+		const mock = jest.fn(impl);
+		(globalThis as { fetch?: unknown }).fetch = mock;
+		return mock;
+	}
+
+	/** A minimal Response stand-in (jsdom ships no Response constructor). */
+	function fakeResponse(
+		status: number,
+		body: string,
+		headers: Record<string, string> = {},
+	): Response {
+		return {
+			status,
+			text: () => Promise.resolve(body),
+			headers: new Map(Object.entries(headers)),
+		} as unknown as Response;
+	}
+
+	it('sends the request through fetch when a signal is provided', async () => {
+		const fetchMock = mockFetch(() =>
+			Promise.resolve(
+				fakeResponse(200, '{"ok":true}', { 'x-test': 'yes' }),
+			),
+		);
+
+		const response = await requestRaw({
+			url: 'https://api.example.com/v1/transcribe',
+			method: 'POST',
+			body: 'payload',
+			signal: new AbortController().signal,
+		});
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(response.status).toBe(200);
+		expect(response.text).toBe('{"ok":true}');
+		expect(response.headers['x-test']).toBe('yes');
+	});
+
+	it('rejects with a cancellation HttpError when the signal aborts mid-flight', async () => {
+		const controller = new AbortController();
+		mockFetch(
+			(_url, init) =>
+				new Promise((_resolve, reject) => {
+					init?.signal?.addEventListener('abort', () => {
+						reject(
+							new DOMException(
+								'The operation was aborted.',
+								'AbortError',
+							),
+						);
+					});
+				}),
+		);
+
+		const pending = requestRaw({
+			url: 'https://api.example.com/v1/transcribe',
+			method: 'POST',
+			signal: controller.signal,
+		});
+		controller.abort();
+
+		await expect(pending).rejects.toThrow(HttpError);
+		await expect(pending).rejects.toThrow(/was cancelled/);
+	});
+
+	it('falls back to requestUrl when fetch fails at the network layer (CORS)', async () => {
+		mockFetch(() => Promise.reject(new TypeError('Failed to fetch')));
+		__setRequestUrlHandler(() => ({
+			status: 200,
+			headers: {},
+			text: '{"via":"requestUrl"}',
+		}));
+
+		const response = await requestRaw({
+			url: 'https://api.example.com/v1/transcribe',
+			method: 'POST',
+			signal: new AbortController().signal,
+		});
+
+		expect(response.text).toBe('{"via":"requestUrl"}');
+	});
+
+	it('does not touch fetch when no signal is provided', async () => {
+		const fetchMock = mockFetch(() =>
+			Promise.resolve(fakeResponse(200, '')),
+		);
+		__setRequestUrlHandler(() => ({
+			status: 200,
+			headers: {},
+			text: 'ok',
+		}));
+
+		await requestRaw({
+			url: 'https://api.example.com/v1/transcribe',
+			method: 'GET',
+		});
+
+		expect(fetchMock).not.toHaveBeenCalled();
 	});
 });

--- a/tests/unit/llmProviderDefaults.test.ts
+++ b/tests/unit/llmProviderDefaults.test.ts
@@ -5,7 +5,8 @@
  * switched here - each provider keeps its own selected model.
  */
 
-import { applyLlmProviderDefaults, mergeSettings } from 'src/settings/Settings';
+import { applyLlmProviderDefaults } from 'src/settings/settingsSchema';
+import { mergeSettings } from 'src/settings/settingsSerialization';
 import {
 	DEFAULT_LLM_OPENAI_BASE_URL,
 	DEFAULT_LLM_ANTHROPIC_BASE_URL,

--- a/tests/unit/llmProviderIds.test.ts
+++ b/tests/unit/llmProviderIds.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { LLM_PROVIDER_IDS } from 'src/constants';
-import { LLM_PROVIDER_LABELS } from 'src/settings/Settings';
+import { LLM_PROVIDER_LABELS } from 'src/settings/labels';
 import {
 	AnthropicLlmProvider,
 	GeminiLlmProvider,

--- a/tests/unit/llmProviderOptions.test.ts
+++ b/tests/unit/llmProviderOptions.test.ts
@@ -5,12 +5,9 @@
  * @module tests/unit/llmProviderOptions.test
  */
 
-import {
-	LLM_PROVIDER_LABELS,
-	LLM_PROVIDER_OPTIONS,
-	mergeSettings,
-	type LlmProviderId,
-} from 'src/settings/Settings';
+import type { LlmProviderId } from 'src/settings/settingsSchema';
+import { mergeSettings } from 'src/settings/settingsSerialization';
+import { LLM_PROVIDER_LABELS, LLM_PROVIDER_OPTIONS } from 'src/settings/labels';
 import { createLlmProvider } from 'src/transcription/factories';
 
 describe('LLM provider options (single source of truth)', () => {

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -5,7 +5,7 @@
 
 import { App } from 'obsidian';
 import AudioRecorderPlugin from '../../src/main';
-import { DEFAULT_SETTINGS } from '../../src/settings/Settings';
+import { DEFAULT_SETTINGS } from '../../src/settings/settingsSchema';
 import type { SaveProgress } from '../../src/types';
 import type { TranscriptionModalOptions } from '../../src/ui/TranscriptionModal';
 

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -4,12 +4,12 @@
  */
 
 import { App } from 'obsidian';
-import AudioRecorderPlugin from '../../src/main';
-import { DEFAULT_SETTINGS } from '../../src/settings/settingsSchema';
-import type { SaveProgress } from '../../src/types';
-import type { TranscriptionModalOptions } from '../../src/ui/TranscriptionModal';
+import AudioRecorderPlugin from 'src/main';
+import { DEFAULT_SETTINGS } from 'src/settings/settingsSchema';
+import type { SaveProgress } from 'src/types';
+import type { TranscriptionModalOptions } from 'src/ui/TranscriptionModal';
 
-jest.mock('../../src/recording/RecordingManager', () => ({
+jest.mock('src/recording/RecordingManager', () => ({
 	RecordingManager: jest.fn().mockImplementation(() => ({
 		toggleRecording: jest.fn(),
 		togglePauseResume: jest.fn(),
@@ -20,13 +20,13 @@ jest.mock('../../src/recording/RecordingManager', () => ({
 	})),
 }));
 
-jest.mock('../../src/ui/ContextMenu', () => ({
+jest.mock('src/ui/ContextMenu', () => ({
 	ContextMenu: jest.fn().mockImplementation(() => ({
 		register: jest.fn(),
 	})),
 }));
 
-jest.mock('../../src/player/EnhancedPlayerRegistrar', () => ({
+jest.mock('src/player/EnhancedPlayerRegistrar', () => ({
 	EnhancedPlayerRegistrar: jest.fn().mockImplementation(() => ({
 		register: jest.fn(),
 		dispose: jest.fn(),
@@ -35,22 +35,22 @@ jest.mock('../../src/player/EnhancedPlayerRegistrar', () => ({
 	})),
 }));
 
-jest.mock('../../src/ui/StatusBar', () => ({
+jest.mock('src/ui/StatusBar', () => ({
 	updateStatusBar: jest.fn(),
 	initializeStatusBar: jest.fn(),
 	renderTranscriptionStatusBar: jest.fn(),
 }));
 
-jest.mock('../../src/ui/RibbonIcon', () => ({
+jest.mock('src/ui/RibbonIcon', () => ({
 	updateRibbonIcon: jest.fn(),
 	initializeRibbonIcon: jest.fn(),
 }));
 
-jest.mock('../../src/ui/DeviceSelectionModal', () => ({
+jest.mock('src/ui/DeviceSelectionModal', () => ({
 	showDeviceSelectionModal: jest.fn(),
 }));
 
-jest.mock('../../src/recording/RecoveryService', () => ({
+jest.mock('src/recording/RecoveryService', () => ({
 	collectRecoverableSessions: jest.fn().mockResolvedValue([]),
 	recoverSession: jest
 		.fn()
@@ -58,7 +58,7 @@ jest.mock('../../src/recording/RecoveryService', () => ({
 	discardSession: jest.fn().mockResolvedValue([]),
 }));
 
-jest.mock('../../src/ui/RecoveryModal', () => ({
+jest.mock('src/ui/RecoveryModal', () => ({
 	RecoveryModal: jest.fn().mockImplementation(() => ({
 		open: jest.fn(),
 	})),
@@ -96,7 +96,7 @@ interface PluginHarness {
  */
 function createPlugin(loadDataResults: LoadDataResult[]): PluginHarness {
 	const app = new App();
-	const plugin = new AudioRecorderPlugin(app, MANIFEST as never);
+	const plugin = new AudioRecorderPlugin(app, MANIFEST);
 
 	const loadData = jest.fn();
 	for (const result of loadDataResults) {
@@ -321,7 +321,7 @@ describe('AudioRecorderPlugin settings persistence', () => {
 		await onloadWithTimers(plugin);
 
 		const { RecordingManager } = jest.requireMock(
-			'../../src/recording/RecordingManager',
+			'src/recording/RecordingManager',
 		);
 		const manager = (RecordingManager as jest.Mock).mock.results[0]
 			.value as { updateSettings: jest.Mock };
@@ -343,7 +343,7 @@ describe('AudioRecorderPlugin settings persistence', () => {
 		await onloadWithTimers(plugin);
 
 		const { RecordingManager } = jest.requireMock(
-			'../../src/recording/RecordingManager',
+			'src/recording/RecordingManager',
 		);
 		const onRecordingSaved = (RecordingManager as jest.Mock).mock
 			.calls[0][4] as (result: {
@@ -351,7 +351,7 @@ describe('AudioRecorderPlugin settings persistence', () => {
 			notePath: string | null;
 		}) => void;
 		const { EnhancedPlayerRegistrar } = jest.requireMock(
-			'../../src/player/EnhancedPlayerRegistrar',
+			'src/player/EnhancedPlayerRegistrar',
 		);
 		const registrar = (EnhancedPlayerRegistrar as jest.Mock).mock.results[0]
 			.value as {
@@ -480,7 +480,7 @@ describe('AudioRecorderPlugin crash recovery wiring', () => {
 		await onloadWithTimers(plugin);
 
 		const { RecordingManager } = jest.requireMock(
-			'../../src/recording/RecordingManager',
+			'src/recording/RecordingManager',
 		);
 		const journalArg = (RecordingManager as jest.Mock).mock.calls[0][3] as {
 			readJournal?: unknown;
@@ -494,15 +494,13 @@ describe('AudioRecorderPlugin crash recovery wiring', () => {
 		await onloadWithTimers(plugin);
 		await jest.advanceTimersByTimeAsync(0);
 
-		const { RecoveryModal } = jest.requireMock(
-			'../../src/ui/RecoveryModal',
-		);
+		const { RecoveryModal } = jest.requireMock('src/ui/RecoveryModal');
 		expect(RecoveryModal).not.toHaveBeenCalled();
 	});
 
 	it('opens the recovery modal for recoverable sessions', async () => {
 		const { collectRecoverableSessions } = jest.requireMock(
-			'../../src/recording/RecoveryService',
+			'src/recording/RecoveryService',
 		);
 		const session = createTestSession();
 		collectRecoverableSessions.mockResolvedValueOnce([session]);
@@ -511,9 +509,7 @@ describe('AudioRecorderPlugin crash recovery wiring', () => {
 		await onloadWithTimers(plugin);
 		await jest.advanceTimersByTimeAsync(0);
 
-		const { RecoveryModal } = jest.requireMock(
-			'../../src/ui/RecoveryModal',
-		);
+		const { RecoveryModal } = jest.requireMock('src/ui/RecoveryModal');
 		expect(RecoveryModal).toHaveBeenCalledWith(
 			plugin.app,
 			[session],
@@ -529,7 +525,7 @@ describe('AudioRecorderPlugin crash recovery wiring', () => {
 
 	it('recovers every offered session through the callback', async () => {
 		const { collectRecoverableSessions, recoverSession } = jest.requireMock(
-			'../../src/recording/RecoveryService',
+			'src/recording/RecoveryService',
 		);
 		const sessions = [createTestSession(), createTestSession()];
 		collectRecoverableSessions.mockResolvedValueOnce(sessions);
@@ -538,9 +534,7 @@ describe('AudioRecorderPlugin crash recovery wiring', () => {
 		await onloadWithTimers(plugin);
 		await jest.advanceTimersByTimeAsync(0);
 
-		const { RecoveryModal } = jest.requireMock(
-			'../../src/ui/RecoveryModal',
-		);
+		const { RecoveryModal } = jest.requireMock('src/ui/RecoveryModal');
 		const callbacks = (RecoveryModal as jest.Mock).mock.calls[0][2] as {
 			onRecover: () => Promise<void>;
 		};
@@ -554,7 +548,7 @@ describe('AudioRecorderPlugin crash recovery wiring', () => {
 			.spyOn(console, 'error')
 			.mockImplementation();
 		const { collectRecoverableSessions } = jest.requireMock(
-			'../../src/recording/RecoveryService',
+			'src/recording/RecoveryService',
 		);
 		collectRecoverableSessions.mockRejectedValueOnce(
 			new Error('journal exploded'),
@@ -606,7 +600,7 @@ describe('AudioRecorderPlugin background transcription status bar', () => {
 		await onloadWithTimers(plugin);
 
 		const { renderTranscriptionStatusBar, updateStatusBar } =
-			jest.requireMock('../../src/ui/StatusBar');
+			jest.requireMock('src/ui/StatusBar');
 		(renderTranscriptionStatusBar as jest.Mock).mockClear();
 
 		const first = buildBackgroundProgress(plugin);
@@ -643,9 +637,8 @@ describe('AudioRecorderPlugin background transcription status bar', () => {
 		const { plugin } = createPlugin([null]);
 		await onloadWithTimers(plugin);
 
-		const { renderTranscriptionStatusBar } = jest.requireMock(
-			'../../src/ui/StatusBar',
-		);
+		const { renderTranscriptionStatusBar } =
+			jest.requireMock('src/ui/StatusBar');
 
 		const first = buildBackgroundProgress(plugin);
 		const second = buildBackgroundProgress(plugin);

--- a/tests/unit/markerFactory.test.ts
+++ b/tests/unit/markerFactory.test.ts
@@ -3,7 +3,6 @@
  * generation reused by both the player and recording-time marker capture.
  * @module tests/unit/markerFactory.test
  */
-/** @jest-environment jsdom */
 
 import {
 	defaultMarkerLabel,

--- a/tests/unit/mediaProbe.test.ts
+++ b/tests/unit/mediaProbe.test.ts
@@ -1,4 +1,3 @@
-/** @jest-environment jsdom */
 /**
  * Tests for the media-kind probe that decides whether the enhanced player
  * takes over a file (audio) or Obsidian's built-in embed is left in place

--- a/tests/unit/modelList.test.ts
+++ b/tests/unit/modelList.test.ts
@@ -12,7 +12,8 @@ import {
 	normalizeModelId,
 	removeModelFromList,
 } from 'src/settings/modelList';
-import { DEFAULT_SETTINGS, mergeSettings } from 'src/settings/Settings';
+import { DEFAULT_SETTINGS } from 'src/settings/settingsSchema';
+import { mergeSettings } from 'src/settings/settingsSerialization';
 import {
 	DEEPGRAM_MODEL_SUGGESTIONS,
 	WHISPER_API_MODEL_SUGGESTIONS,

--- a/tests/unit/playerEmbedActions.test.ts
+++ b/tests/unit/playerEmbedActions.test.ts
@@ -1,4 +1,3 @@
-/** @jest-environment jsdom */
 /**
  * Tests for the embed-to-actions association the context menu uses to drive
  * a live player without importing the DOM-heavy player module. The link is a

--- a/tests/unit/playerMode.test.ts
+++ b/tests/unit/playerMode.test.ts
@@ -1,4 +1,3 @@
-/** @jest-environment jsdom */
 /**
  * Guards the player's mode/decision single source of truth - the logic
  * behind two recurring regressions: Reading view wrongly showing editable

--- a/tests/unit/providerCapabilities.test.ts
+++ b/tests/unit/providerCapabilities.test.ts
@@ -19,7 +19,7 @@ import {
 	WHISPER_API_CAPABILITIES,
 } from 'src/transcription/providers/capabilities';
 import { TRANSCRIPTION_PROVIDER_IDS } from 'src/constants';
-import { TRANSCRIPTION_PROVIDER_LABELS } from 'src/settings/Settings';
+import { TRANSCRIPTION_PROVIDER_LABELS } from 'src/settings/labels';
 import { WhisperApiProvider } from 'src/transcription/providers/WhisperApiProvider';
 import { DeepgramProvider } from 'src/transcription/providers/DeepgramProvider';
 import { GeminiProvider } from 'src/transcription/providers/GeminiProvider';

--- a/tests/unit/providerCapabilities.test.ts
+++ b/tests/unit/providerCapabilities.test.ts
@@ -7,7 +7,6 @@
  * id constants as the single source for the provider ids and map keys.
  * @module tests/unit/providerCapabilities.test
  */
-/** @jest-environment jsdom */
 
 import {
 	DEEPGRAM_CAPABILITIES,

--- a/tests/unit/recordingErrors.test.ts
+++ b/tests/unit/recordingErrors.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Unit tests for recording-start error descriptions.
+ * @module tests/unit/recordingErrors.test
+ */
+
+import { describeRecordingError } from '../../src/recording/recordingErrors';
+
+describe('describeRecordingError', () => {
+	it.each([
+		[
+			'NotAllowedError',
+			'Microphone access denied. Please grant permission in browser settings.',
+		],
+		[
+			'NotFoundError',
+			'No microphone found. Please connect an audio input device.',
+		],
+		['NotReadableError', 'Microphone is in use by another application.'],
+	])('maps DOMException %s to specific guidance', (name, expected) => {
+		expect(describeRecordingError(new DOMException('denied', name))).toBe(
+			expected,
+		);
+	});
+
+	it('falls back to the DOMException message for other names', () => {
+		expect(
+			describeRecordingError(new DOMException('boom', 'AbortError')),
+		).toBe('Recording error: boom');
+	});
+
+	it('uses the Error message for plain errors', () => {
+		expect(describeRecordingError(new Error('device lost'))).toBe(
+			'Error starting recording: device lost',
+		);
+	});
+
+	it('stringifies non-Error values', () => {
+		expect(describeRecordingError('nope')).toBe(
+			'Error starting recording: nope',
+		);
+	});
+});

--- a/tests/unit/recordingErrors.test.ts
+++ b/tests/unit/recordingErrors.test.ts
@@ -3,7 +3,7 @@
  * @module tests/unit/recordingErrors.test
  */
 
-import { describeRecordingError } from '../../src/recording/recordingErrors';
+import { describeRecordingError } from 'src/recording/recordingErrors';
 
 describe('describeRecordingError', () => {
 	it.each([

--- a/tests/unit/registerActionCommands.test.ts
+++ b/tests/unit/registerActionCommands.test.ts
@@ -46,7 +46,6 @@ jest.mock('../../src/cleanup/AudioProcessingModal', () => ({
 jest.mock('../../src/audio/AudioEncoder', () => ({
 	encodeAudioBuffer: jest.fn(),
 	isOfflineEncodingSupported: jest.fn().mockReturnValue(true),
-	getEncoderDescription: jest.fn().mockReturnValue('Test Encoder'),
 }));
 
 /** Command registered through the plugin double. */

--- a/tests/unit/registerActionCommands.test.ts
+++ b/tests/unit/registerActionCommands.test.ts
@@ -20,7 +20,7 @@ import type {
 	ActionServices,
 	FileAction,
 } from '../../src/actions/PluginAction';
-import type { AudioRecorderSettings } from '../../src/settings/Settings';
+import type { AudioRecorderSettings } from '../../src/settings/settingsSchema';
 
 jest.mock('../../src/ui/AudioFileInfoModal', () => ({
 	AudioFileInfoModal: jest

--- a/tests/unit/registerActionCommands.test.ts
+++ b/tests/unit/registerActionCommands.test.ts
@@ -11,39 +11,36 @@ import type { App, Plugin } from 'obsidian';
 import {
 	registerFileActionCommands,
 	registerRecordingActionCommands,
-} from '../../src/actions/registerActionCommands';
-import { FILE_ACTIONS } from '../../src/actions/fileActions';
-import { createRecordingMarkerActions } from '../../src/actions/recordingMarkerActions';
-import { COMMAND_IDS } from '../../src/constants';
-import { MARKER_KIND } from '../../src/markers/markerModel';
-import type {
-	ActionServices,
-	FileAction,
-} from '../../src/actions/PluginAction';
-import type { AudioRecorderSettings } from '../../src/settings/settingsSchema';
+} from 'src/actions/registerActionCommands';
+import { FILE_ACTIONS } from 'src/actions/fileActions';
+import { createRecordingMarkerActions } from 'src/actions/recordingMarkerActions';
+import { COMMAND_IDS } from 'src/constants';
+import { MARKER_KIND } from 'src/markers/markerModel';
+import type { ActionServices, FileAction } from 'src/actions/PluginAction';
+import type { AudioRecorderSettings } from 'src/settings/settingsSchema';
 
-jest.mock('../../src/ui/AudioFileInfoModal', () => ({
+jest.mock('src/ui/AudioFileInfoModal', () => ({
 	AudioFileInfoModal: jest
 		.fn()
 		.mockImplementation(() => ({ open: jest.fn() })),
 }));
-jest.mock('../../src/ui/ConversionModal', () => ({
+jest.mock('src/ui/ConversionModal', () => ({
 	ConversionModal: jest.fn().mockImplementation(() => ({ open: jest.fn() })),
 }));
-jest.mock('../../src/ui/SplitModal', () => ({
+jest.mock('src/ui/SplitModal', () => ({
 	SplitModal: jest.fn().mockImplementation(() => ({ open: jest.fn() })),
 }));
-jest.mock('../../src/ui/TranscriptionModal', () => ({
+jest.mock('src/ui/TranscriptionModal', () => ({
 	TranscriptionModal: jest
 		.fn()
 		.mockImplementation(() => ({ open: jest.fn() })),
 }));
-jest.mock('../../src/cleanup/AudioProcessingModal', () => ({
+jest.mock('src/cleanup/AudioProcessingModal', () => ({
 	AudioProcessingModal: jest
 		.fn()
 		.mockImplementation(() => ({ open: jest.fn() })),
 }));
-jest.mock('../../src/audio/AudioEncoder', () => ({
+jest.mock('src/audio/AudioEncoder', () => ({
 	encodeAudioBuffer: jest.fn(),
 	isOfflineEncodingSupported: jest.fn().mockReturnValue(true),
 }));

--- a/tests/unit/settingControls.test.ts
+++ b/tests/unit/settingControls.test.ts
@@ -7,15 +7,14 @@
  * The capturing Setting mock is shared from tests/helpers/captureSettings.
  * @module tests/unit/settingControls.test
  */
-/** @jest-environment jsdom */
 
 import {
 	addText,
 	addToggle,
 	SETTING_DISABLED_CLASS,
 	type SettingsSectionContext,
-} from '../../src/settings/settingControls';
-import type { AudioRecorderSettings } from '../../src/settings/settingsSchema';
+} from 'src/settings/settingControls';
+import type { AudioRecorderSettings } from 'src/settings/settingsSchema';
 import { capturedSettings } from '../helpers/captureSettings';
 
 jest.mock('obsidian', () => ({

--- a/tests/unit/settingControls.test.ts
+++ b/tests/unit/settingControls.test.ts
@@ -15,7 +15,7 @@ import {
 	SETTING_DISABLED_CLASS,
 	type SettingsSectionContext,
 } from '../../src/settings/settingControls';
-import type { AudioRecorderSettings } from '../../src/settings/Settings';
+import type { AudioRecorderSettings } from '../../src/settings/settingsSchema';
 import { capturedSettings } from '../helpers/captureSettings';
 
 jest.mock('obsidian', () => ({

--- a/tests/unit/settingHelpers.test.ts
+++ b/tests/unit/settingHelpers.test.ts
@@ -2,13 +2,12 @@
  * Unit tests for the shared setting builders.
  * @module tests/unit/settingHelpers.test
  */
-/** @jest-environment jsdom */
 
 import {
 	addBitrateSetting,
 	addDeleteSourceSetting,
 	addLinkActionSetting,
-} from '../../src/ui/settingHelpers';
+} from 'src/ui/settingHelpers';
 
 /** Captured dropdowns and toggles rendered through the Setting mock. */
 interface DropdownCapture {
@@ -88,7 +87,7 @@ jest.mock('obsidian', () => ({
 	},
 }));
 
-jest.mock('../../src/audio/AudioCapabilityDetector', () => ({
+jest.mock('src/audio/AudioCapabilityDetector', () => ({
 	getSupportedBitrates: jest
 		.fn()
 		.mockReturnValue([64000, 96000, 128000, 192000]),

--- a/tests/unit/streamingConversion.test.ts
+++ b/tests/unit/streamingConversion.test.ts
@@ -3,9 +3,8 @@
  * the main-thread pipeline and the encoding worker.
  * @module tests/unit/streamingConversion.test
  */
-/** @jest-environment jsdom */
 
-import { runStreamingConversion } from '../../src/audio/streamingConversion';
+import { runStreamingConversion } from 'src/audio/streamingConversion';
 
 const mockConversionExecute = jest.fn().mockResolvedValue(undefined);
 const mockConversionInit = jest.fn();
@@ -29,7 +28,7 @@ jest.mock('mediabunny', () => ({
 	},
 }));
 
-jest.mock('../../src/audio/AudioEncoder', () => ({
+jest.mock('src/audio/AudioEncoder', () => ({
 	ensureEncoderRegistered: jest.fn().mockResolvedValue(undefined),
 	createOutputFormat: jest.fn().mockReturnValue({}),
 	FORMAT_CODEC_MAP: {

--- a/tests/unit/transcriptionCore.test.ts
+++ b/tests/unit/transcriptionCore.test.ts
@@ -19,7 +19,7 @@ import {
 	parseArgs,
 	ProviderConfigError,
 } from 'src/transcription/factories';
-import { mergeSettings } from 'src/settings/Settings';
+import { mergeSettings } from 'src/settings/settingsSerialization';
 import {
 	TRANSCRIBE_BYTES_PER_SEC,
 	DEFAULT_LLM_CLEANUP_PROMPT,

--- a/tests/unit/transcriptionDiarizeGating.test.ts
+++ b/tests/unit/transcriptionDiarizeGating.test.ts
@@ -14,10 +14,8 @@ import type {
 	TranscribeOptions,
 	TranscriptionProvider,
 } from 'src/transcription/providers/TranscriptionProvider';
-import {
-	mergeSettings,
-	type TranscriptionProviderId,
-} from 'src/settings/Settings';
+import type { TranscriptionProviderId } from 'src/settings/settingsSchema';
+import { mergeSettings } from 'src/settings/settingsSerialization';
 import { TRANSCRIPTION_PROVIDER_IDS } from 'src/constants';
 import type {
 	Transcript,

--- a/tests/unit/transcriptionServiceCancel.test.ts
+++ b/tests/unit/transcriptionServiceCancel.test.ts
@@ -16,7 +16,7 @@ import {
 } from 'src/transcription/TranscriptionService';
 import { transcribeFile } from 'src/transcription/runTranscription';
 import type { TranscriptionProvider } from 'src/transcription/providers/TranscriptionProvider';
-import { mergeSettings } from 'src/settings/Settings';
+import { mergeSettings } from 'src/settings/settingsSerialization';
 
 const audioFile = {
 	name: 'rec.webm',

--- a/tests/unit/transcriptionServicePartFailure.test.ts
+++ b/tests/unit/transcriptionServicePartFailure.test.ts
@@ -21,7 +21,7 @@ import type { TranscriptionProvider } from 'src/transcription/providers/Transcri
 import { prepareAudio } from 'src/transcription/audioPrep';
 import { TranscriptTruncatedError } from 'src/transcription/transcriptionErrors';
 import type { LlmProvider } from 'src/transcription/llm/LlmProvider';
-import { mergeSettings } from 'src/settings/Settings';
+import { mergeSettings } from 'src/settings/settingsSerialization';
 
 jest.mock('obsidian', () => {
 	const actual = jest.requireActual('../mocks/obsidian');

--- a/tests/unit/transcriptionServicePartFailure.test.ts
+++ b/tests/unit/transcriptionServicePartFailure.test.ts
@@ -1,5 +1,4 @@
 /**
- * @jest-environment jsdom
  */
 
 /**

--- a/tests/unit/transcriptionSettingsSection.test.ts
+++ b/tests/unit/transcriptionSettingsSection.test.ts
@@ -8,16 +8,15 @@
  * drops the disabled flag on any of these controls.
  * @module tests/unit/transcriptionSettingsSection.test
  */
-/** @jest-environment jsdom */
 
-import { renderTranscriptionSection } from '../../src/settings/sections/transcriptionSettingsSection';
+import { renderTranscriptionSection } from 'src/settings/sections/transcriptionSettingsSection';
 import type {
 	AudioRecorderSettings,
 	TranscriptionProviderId,
-} from '../../src/settings/settingsSchema';
-import { mergeSettings } from '../../src/settings/settingsSerialization';
-import type { SettingsSectionContext } from '../../src/settings/settingControls';
-import { TRANSCRIPTION_PROVIDER_IDS } from '../../src/constants';
+} from 'src/settings/settingsSchema';
+import { mergeSettings } from 'src/settings/settingsSerialization';
+import type { SettingsSectionContext } from 'src/settings/settingControls';
+import { TRANSCRIPTION_PROVIDER_IDS } from 'src/constants';
 import {
 	capturedSettings,
 	isSettingDisabled,

--- a/tests/unit/transcriptionSettingsSection.test.ts
+++ b/tests/unit/transcriptionSettingsSection.test.ts
@@ -11,11 +11,11 @@
 /** @jest-environment jsdom */
 
 import { renderTranscriptionSection } from '../../src/settings/sections/transcriptionSettingsSection';
-import {
-	mergeSettings,
-	type AudioRecorderSettings,
-	type TranscriptionProviderId,
-} from '../../src/settings/Settings';
+import type {
+	AudioRecorderSettings,
+	TranscriptionProviderId,
+} from '../../src/settings/settingsSchema';
+import { mergeSettings } from '../../src/settings/settingsSerialization';
 import type { SettingsSectionContext } from '../../src/settings/settingControls';
 import { TRANSCRIPTION_PROVIDER_IDS } from '../../src/constants';
 import {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
 		"noImplicitOverride": true,
+		"noUncheckedIndexedAccess": true,
 		"useUnknownInCatchVariables": true,
 		"esModuleInterop": true,
 		"moduleResolution": "node",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,37 +1,28 @@
 {
-  "compilerOptions": {
-    "baseUrl": "./src",
-    "rootDir": "./src",
-    "outDir": "./dist",
-    "module": "ESNext",
-    "target": "ES2022",
-    "lib": [
-      "DOM",
-      "ES2022"
-    ],
-    "strict": true,
-    "noImplicitAny": true,
-    "strictNullChecks": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitOverride": true,
-    "useUnknownInCatchVariables": true,
-    "esModuleInterop": true,
-    "moduleResolution": "node",
-    "importHelpers": true,
-    "isolatedModules": true,
-    "inlineSourceMap": true,
-    "inlineSources": true,
-    "skipLibCheck": true
-  },
-  "include": [
-    "src/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules",
-    "tests",
-    "dist"
-  ]
+	"compilerOptions": {
+		"baseUrl": "./src",
+		"rootDir": "./src",
+		"outDir": "./dist",
+		"module": "ESNext",
+		"target": "ES2022",
+		"lib": ["DOM", "ES2022", "ESNext.Disposable"],
+		"strict": true,
+		"noImplicitAny": true,
+		"strictNullChecks": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noImplicitOverride": true,
+		"useUnknownInCatchVariables": true,
+		"esModuleInterop": true,
+		"moduleResolution": "node",
+		"importHelpers": true,
+		"isolatedModules": true,
+		"inlineSourceMap": true,
+		"inlineSources": true,
+		"skipLibCheck": true
+	},
+	"include": ["src/**/*.ts"],
+	"exclude": ["node_modules", "tests", "dist"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,14 @@
 {
 	"compilerOptions": {
-		"baseUrl": "./src",
 		"rootDir": "./src",
 		"outDir": "./dist",
+		"paths": {
+			"src/*": ["./src/*"]
+		},
 		"module": "ESNext",
 		"target": "ES2022",
 		"lib": ["DOM", "ES2022", "ESNext.Disposable"],
+		"types": ["node"],
 		"strict": true,
 		"noImplicitAny": true,
 		"strictNullChecks": true,
@@ -17,7 +20,7 @@
 		"noUncheckedIndexedAccess": true,
 		"useUnknownInCatchVariables": true,
 		"esModuleInterop": true,
-		"moduleResolution": "node",
+		"moduleResolution": "bundler",
 		"importHelpers": true,
 		"isolatedModules": true,
 		"inlineSourceMap": true,


### PR DESCRIPTION
One big PR, built as ten self-contained commits, closing all five audit follow-up tasks that remained after #52. Each commit passed the full type check, lint, and test suite on its own; the branch ends with 1437 tests green, a clean production build, and TypeScript 6.

## 1. God-object decomposition (findings 2.4, 2.6, 2.8, 2.9, 2.11)

- **`Settings.ts` is gone** (`3c82281`): types and defaults live in `settings/settingsSchema.ts`, load/save/migrate in `settings/settingsSerialization.ts`, recording-path validation in `settings/settingsValidation.ts`, and UI copy in `settings/labels.ts`. Every importer references the module it actually needs.
- **`AudioPlayer.ts` decomposed** (`c1aec2f`): 1605 → ~1100 lines. `PlayerControlsView` (control row), `SeekController` (pointer/keyboard seek + clientX→time mapping), `DurationProbe` (Infinity/zero-duration resolution), `WaveformController` (lazy decode + progressive render), and `PlayerMarkerController` (marker CRUD + persistence) are wired by `AudioPlayer` as a coordinator. **All standing invariants preserved**: the shared ref-counted `<audio>` element is acquired only through `AudioPlayerRegistry` (the player never calls `new Audio()`), `applySettings()` re-renders only the player's own container DOM and no-ops on unchanged toggles, the `#t=` start stays a display-only per-embed hint until an explicit engage (`engageStart()`, drag, Home/End), media kind still comes only from probing, and no in-place native↔enhanced swap was introduced. The existing regression suite passes unchanged, and a new integration suite (`AudioPlayer.decomposition.test.ts`) drives the **real AudioPlayer through real DOM events** (clicks, keydowns, pointer drags, duration probes, marker persistence) so coordinator wiring can't hide behind mocked collaborators.
- **UI facades** (`4930741`): the conversion/split/transcription/marker/recovery modals import through `recording/api.ts` and `transcription/api.ts` instead of domain internals. Encoder description strings moved from `formatRegistry`/`AudioEncoder` to a UI-layer lookup (`ui/formatDescriptions.ts`).
- **`RecordingManager` slimmed** (`c79602d`): marker drafts and their persistence races extracted to `RecordingMarkerCoordinator`, capture-primitive creation to `RecorderFactory`, DOMException mapping to a standalone `describeRecordingError`.

## 2. Duplication and magic values (3.7, 4.11; 3.8 partially)

`utils/ids.ts` now owns `sessionTimestamp()` and `randomToken()` (previously three divergent encodings); `BYTES_PER_MB`, the WAV fmt-chunk literals, and the mono channel count are named (`444f224`). The optional `notify()` wrapper from 3.8 is deliberately skipped — the audit marked it a nice-to-have and the call sites are correct.

## 3. Mobile test coverage and hygiene (5.2, 5.7, 5.9)

DOM-driven suites for `DeviceSelectionModal` and `RecordingBanner` (the only mobile recording indicator, including Enter/Space activation); `it.each` conversions in `AudioFormatConverter.test.ts` and `SplitModal.test.ts`; 56 redundant `@jest-environment jsdom` docblocks removed; all test imports unified on the bare `src/...` form; `ContextMenu.test.ts` rewritten around a recording Menu fake that asserts visible item titles and click effects instead of `setIcon`/`setSection` call structure (`b0c7f04`).

## 4. Memory and performance (6.2, 6.7, 6.9, 6.11, 6.12, 6.13; 6.4/6.8 documented)

- **Abortable transcription HTTP**: the modal's Cancel now aborts the in-flight request. An `AbortSignal` flows from the cancellation token through provider options into the HTTP client, which sends signal-bearing requests over `fetch`; endpoints that refuse browser (CORS) requests fall back to `requestUrl` where cancellation remains between-chunks, exactly as before (documented on `RequestOptions.signal`).
- `AudioFileAnalyzer` probes container headers via mediabunny instead of decoding the whole file to PCM (decode kept as fallback).
- `encodeMonoWav` converts float→int16 in slices with event-loop yields — no more hundreds of milliseconds of UI jank per 25 MB chunk.
- New `convertBlobToFormatBuffer`/`convertBlobToWavBuffer` hand streaming-conversion bytes straight to `createBinary`, dropping a Blob wrap plus a whole-file read-back in the finalizer and conversion service.
- 6.13 hygiene: recorder handlers detached whenever recorders are dropped or replaced, worker handlers cleared before `terminate()`, registry ref-count clamped at zero, RAF loops cancelled explicitly.
- The two deliberately-deferred items are documented in place: `mergeAudioTracks`' full-decode fallback memory profile (6.4) and `audioPrep`'s full-PCM retention trade-off (6.8).

## 5. TypeScript strictness and API modernization (7.4, 7.6–7.10 + TS 6)

- **`noUncheckedIndexedAccess` enabled** (`ae9d479`) with real narrowing at all ~100 sites — hoisted per-iteration guards for parallel arrays, named first-element locals, and the neutral element (`?? 0`) in the hot PCM loops where reads are in bounds by construction. No blanket `!` assertions.
- `FORMAT_CODEC_MAP` (string-widened `Record`) deleted in favor of the registry lookup; literal tables get `as const satisfies`; `isRecord` replaces the `as unknown as` double casts; `webkitAudioContext` declared once in `globals.d.ts`.
- `using`/`await using` adopted at the converter resource sites via `utils/disposables.ts` (mediabunny `Input`, `AudioContext`); the bundle carries the `Symbol.dispose` polyfill.
- Obsidian API polish: `vault.getFileByPath` everywhere, `apiVersion` imported from `obsidian` (the old cast always reported `unknown`), `AbstractInputSuggest` popover for the save-folder field, `RecordingStatus` converted from the codebase's only `enum` to an `as const` union. The raw `addEventListener` calls in modals/banner are kept deliberately: Obsidian's `Modal` is not a `Component` (no `registerDomEvent`), and those listeners attach to DOM the modal empties on close.
- **TypeScript 6.0.3** (`ef6f9a3`) as its own final compatibility pass: migrates off deprecated `baseUrl`/`node10` resolution to `moduleResolution: bundler` + explicit `src/*` paths, explicit node types; verified with full `tsc`, suite, lint, and production build.

## Verification

- 1437 tests / 105 suites green (baseline was 1391/98), `tsc` clean, eslint clean, production build succeeds at every commit boundary and at the head.
- ⚠️ **Manual check still required per the task's own bar**: the player decomposition passes the full regression + new integration suites, but Reading view and Live Preview should be verified in real Obsidian (toggle waveform/markers on an open note in both modes, play a `#t=` embed alongside a plain embed of the same file, and confirm feature-off swaps back to the native embed via Obsidian's re-render) before the player task is considered done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnZZn2yq3xt59CqD8criRT

---
_Generated by [Claude Code](https://claude.ai/code/session_01XnZZn2yq3xt59CqD8criRT)_