### PR TITLE
Mono in cleanup, silent-channel prompt, conversion channel preset

### DIFF
--- a/docs/audio-cleanup.md
+++ b/docs/audio-cleanup.md
@@ -36,10 +36,24 @@ _Figure: the Clean up audio dialog with per-stage toggles and parameters._
     - an **embedded audio player**.
 2. Choose **Clean up audio**.
 3. In the dialog, toggle the stages you want and adjust their parameters. The toggles and values start from your settings defaults but can be changed per run.
-4. (Optional) Enable **Delete source after processing** to move the original to the system trash once the cleaned copy is written.
-5. Click **Process**. A notice reports the path of the written file.
+4. (Optional) Set **Channels** to downmix the cleaned copy to mono - see [Channels](#channels) below.
+5. (Optional) Enable **Delete source after processing** to move the original to the system trash once the cleaned copy is written.
+6. Click **Process**. A notice reports the path of the written file.
 
-At least one stage must be enabled, or the dialog asks you to enable one.
+At least one stage must be enabled, or a mono **Channels** option chosen, or the dialog asks you to pick one.
+
+### Channels
+
+The **Channels** dropdown downmixes the cleaned copy to mono during processing, in addition to (or instead of) the DSP stages:
+
+| Option                      | What it writes                                            |
+| --------------------------- | -------------------------------------------------------- |
+| **Same as source**          | The source channel layout (default).                     |
+| **Mono (mix all channels)** | The average of every channel - the standard downmix.     |
+| **Mono (left channel)**     | Only the left channel, at full level.                    |
+| **Mono (right channel)**    | Only the right channel, at full level.                   |
+
+The left/right options rescue a stereo recording where only one channel carries audio - the typical result of a single microphone on a dual-input audio interface. Because the downmix happens before the DSP stages, choosing a mono option is enough on its own: you can clean up **and** collapse to mono in one pass, or run a pure mono downmix with every stage off. See [Recording in mono](recording.md#recording-in-mono) for the capture-time equivalent and the automatic [silent-channel prompt](recording.md#recording-in-mono).
 
 ## Processing stages
 
@@ -79,7 +93,7 @@ The compressor itself uses fixed, speech-friendly settings (threshold -24 dB, ra
 
 ## Output
 
-- The cleaned file is always written as **16-bit PCM WAV**, regardless of the source format, because the cleanup re-encodes the decoded audio. The source's channel layout (mono/stereo) is preserved; the sample rate is the one the Obsidian audio engine decodes to, which may differ from the source.
+- The cleaned file is always written as **16-bit PCM WAV**, regardless of the source format, because the cleanup re-encodes the decoded audio. The source's channel layout (mono/stereo) is preserved unless you pick a mono **Channels** option; the sample rate is the one the Obsidian audio engine decodes to, which may differ from the source.
 - The file is saved **next to the source**, named `<source-name>-processed.wav`. If that name is taken, a numeric suffix is appended (`…-processed_1.wav`).
 - The original file is left untouched unless you enable **Delete source after processing**. If processing succeeds but deleting the source fails, the cleaned copy is still kept and a notice explains what happened.
 - **Linking into your note.** When you start the cleanup from an embed or player **inside a note**, the cleaned copy is linked into that note automatically: with **Delete source after processing** on, the source's embed is _replaced_ with the cleaned file (so no broken link is left behind); with it off, the cleaned file's embed is _inserted on the line right after_ the source, keeping both. The new links follow your link-format preferences, and the [enhanced player](audio-player.md) picks up the cleaned file straight away. Running cleanup from the **File Explorer** (where the active note does not embed the file) writes the copy but adds no link.

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -70,9 +70,9 @@ Notes:
 
 ### Automatic silent-channel prompt
 
-If you forget to set the channel mode, the plugin can catch a lopsided recording after the fact. With **Detect silent channel after recording** on (**Settings > Audio processing & feedback**, default on), each saved recording is checked for the stereo-with-one-silent-channel pattern. When it is found, a notice appears - "Recording's right channel is silent" - with a **Convert to mono** action that opens the [conversion dialog](file-operations.md#convert-audio-format) already preset to keep the channel that carries audio. You still confirm the format and link handling before it runs.
+If you forget to set the channel mode, the plugin can catch a lopsided recording after the fact. With **Detect silent channel after recording** on (**Settings > Audio processing & feedback**, default on), one file from every output track is checked for the stereo-with-one-silent-channel pattern (for auto-split sessions, the first part of each track). When it is found, a notice identifies the affected file and offers a **Convert to mono** action that opens the [conversion dialog](file-operations.md#convert-audio-format) already preset to keep the channel that carries audio. You still confirm the format and link handling before it runs.
 
-The check decodes the file, so it is skipped for long recordings (over 20 minutes) to keep saving fast, and it only fires for genuine stereo files where one channel is essentially silent - a normal stereo mix never triggers it. Turn the setting off to silence the prompt entirely.
+The active recording duration is checked before the file is read, so long sessions (over 20 minutes) are skipped without a decode. Shorter files are metadata-probed before decoding, and the signal check uses short RMS windows instead of one whole-file average: a brief but real sound on a channel is preserved instead of being diluted by a long quiet stretch. Turn the setting off to silence the prompt entirely.
 
 ---
 

--- a/docs/recording.md
+++ b/docs/recording.md
@@ -66,7 +66,13 @@ Notes:
 - The setting applies to **single-track** recordings and to the **Test recording** button in settings. Each track of a [multi-track session](multi-track-recording.md) has its own **Channels for track N** selector instead, so a hard-panned microphone track can go mono while a genuine stereo track stays untouched.
 - The selector is **disabled (greyed out)** when the selected device reports a mono-only input or is no longer connected - every mono option would be pointless until a multichannel device is available. The saved channel choice is preserved, so reconnecting the device restores it. Devices whose capabilities the platform does not report keep the selection available.
 - If a mono option is active while the device actually delivers mono, the recording still works - the picked-channel options fall back to the only channel available.
-- Existing stereo files can be fixed after the fact with the **Channels** option in the [Convert audio format dialog](file-operations.md#convert-audio-format).
+- Existing stereo files can be fixed after the fact with the **Channels** option in the [Convert audio format dialog](file-operations.md#convert-audio-format) or the [Clean up audio dialog](audio-cleanup.md#channels).
+
+### Automatic silent-channel prompt
+
+If you forget to set the channel mode, the plugin can catch a lopsided recording after the fact. With **Detect silent channel after recording** on (**Settings > Audio processing & feedback**, default on), each saved recording is checked for the stereo-with-one-silent-channel pattern. When it is found, a notice appears - "Recording's right channel is silent" - with a **Convert to mono** action that opens the [conversion dialog](file-operations.md#convert-audio-format) already preset to keep the channel that carries audio. You still confirm the format and link handling before it runs.
+
+The check decodes the file, so it is skipped for long recordings (over 20 minutes) to keep saving fast, and it only fires for genuine stereo files where one channel is essentially silent - a normal stereo mix never triggers it. Turn the setting off to silence the prompt entirely.
 
 ---
 

--- a/docs/settings-reference.md
+++ b/docs/settings-reference.md
@@ -250,7 +250,7 @@ Control the browser's input processing applied while recording, plus the live re
 | **Automatic gain control**  | Let the browser normalize the input level automatically.                              | On / Off        | On      |
 | **Input level meter**       | Show a live input-level (VU) meter in the status bar while recording.                 | On / Off        | On      |
 | **Recording stats**         | Show the live elapsed time and total recorded size in the status bar while recording. | On / Off        | On      |
-| **Detect silent channel after recording** | After a recording is saved, check whether it is a stereo file with one silent channel (a single mic on a dual-input interface) and show a notice offering a one-click mono conversion. Skipped for recordings longer than 20 minutes. See [Automatic silent-channel prompt](recording.md#automatic-silent-channel-prompt). | On / Off        | On      |
+| **Detect silent channel after recording** | After a recording is saved, check one file per output track for a silent channel (a single mic on a dual-input interface) and show a notice that opens mono conversion with the correct channel preset. Sessions longer than 20 minutes are skipped before their files are read. See [Automatic silent-channel prompt](recording.md#automatic-silent-channel-prompt). | On / Off        | On      |
 | **Mobile recording banner** | Show a prominent recording banner on mobile, where there is no ribbon indicator.      | On / Off        | On      |
 
 ---

--- a/docs/settings-reference.md
+++ b/docs/settings-reference.md
@@ -250,6 +250,7 @@ Control the browser's input processing applied while recording, plus the live re
 | **Automatic gain control**  | Let the browser normalize the input level automatically.                              | On / Off        | On      |
 | **Input level meter**       | Show a live input-level (VU) meter in the status bar while recording.                 | On / Off        | On      |
 | **Recording stats**         | Show the live elapsed time and total recorded size in the status bar while recording. | On / Off        | On      |
+| **Detect silent channel after recording** | After a recording is saved, check whether it is a stereo file with one silent channel (a single mic on a dual-input interface) and show a notice offering a one-click mono conversion. Skipped for recordings longer than 20 minutes. See [Automatic silent-channel prompt](recording.md#automatic-silent-channel-prompt). | On / Off        | On      |
 | **Mobile recording banner** | Show a prominent recording banner on mobile, where there is no ribbon indicator.      | On / Off        | On      |
 
 ---

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -113,8 +113,9 @@ See also: [Recording](recording.md), [Settings reference](settings-reference.md#
 
 The recording plays back entirely in one ear. This is the normal result of recording a single microphone through an audio interface with two mono inputs: the operating system exposes the interface as one stereo device, so the mic on input 1 lands in the left channel and input 2 (silent) becomes the right channel.
 
-- For **new recordings**, set **Settings > Audio input > Recording channels** to **Mono (left channel)** (or right, depending on which input the microphone uses). The recording keeps the full level of that channel and saves a mono file. **Mono (mix all channels)** also produces mono but folds in the silent channel, which lowers the voice by 6 dB. See [Recording in mono](recording.md#recording-in-mono).
-- For **existing files**, right-click the file, choose **Convert audio format**, and set **Channels** to **Mono (left channel)** / **Mono (right channel)**. Converting to the same format writes a `<name>-mono` copy. See [Convert audio format](file-operations.md#convert-audio-format).
+- The plugin usually **catches this for you**: with **Detect silent channel after recording** on (the default), a notice appears right after saving with a **Convert to mono** action preset to the channel that has audio. See [Automatic silent-channel prompt](recording.md#automatic-silent-channel-prompt).
+- For **new recordings**, set **Settings > Audio input > Recording channels** to **Mono (left channel)** (or right, depending on which input the microphone uses). The recording keeps the full level of that channel and saves a mono file. In a [multi-track session](multi-track-recording.md) use the per-track **Channels for track N** selector instead. **Mono (mix all channels)** also produces mono but folds in the silent channel, which lowers the voice by 6 dB. See [Recording in mono](recording.md#recording-in-mono).
+- For **existing files**, right-click the file, choose **Convert audio format** (or **Clean up audio**), and set **Channels** to **Mono (left channel)** / **Mono (right channel)**. Converting to the same format writes a `<name>-mono` copy. See [Convert audio format](file-operations.md#convert-audio-format) and [Audio cleanup](audio-cleanup.md#channels).
 
 ### A recording format is not available
 

--- a/src/actions/fileActions.ts
+++ b/src/actions/fileActions.ts
@@ -47,18 +47,15 @@ export const FILE_ACTIONS: readonly FileAction[] = [
 		showInEditorMenu: true,
 		isAvailable: always,
 		run: (file: TFile, services: ActionServices): void => {
-			new ConversionModal(
-				services.app,
-				file,
-				services.getSettings(),
-				(convertedPath) => {
+			new ConversionModal(services.app, file, services.getSettings(), {
+				onConverted: (convertedPath) => {
 					// The note link is already rewritten by the conversion's
 					// linkAction; prime the converted file so its embed
 					// becomes the enhanced player at once.
 					services.primeForEnhancement([convertedPath]);
 				},
-				services.getWorkerClient,
-			).open();
+				getWorkerClient: services.getWorkerClient,
+			}).open();
 		},
 	},
 	{

--- a/src/cleanup/AudioProcessingModal.ts
+++ b/src/cleanup/AudioProcessingModal.ts
@@ -29,10 +29,15 @@ import {
 } from '../constants';
 import { AudioProcessingService } from './AudioProcessingService';
 import {
-	hasActiveStage,
+	hasActiveChange,
 	resolveAudioDspConfig,
 	type AudioDspConfig,
 } from './audioDsp';
+import {
+	CHANNEL_MODES,
+	normalizeChannelMode,
+	type ChannelMode,
+} from '../audio/downmix';
 import type { AudioRecorderSettings } from '../settings/settingsSchema';
 
 /**
@@ -118,6 +123,27 @@ export class AudioProcessingModal extends Modal {
 		);
 
 		new Setting(contentEl)
+			.setName('Channels')
+			.setDesc(
+				'Keep the source channel layout, or downmix the cleaned copy to mono. The left/right options keep one channel at full level - useful when only one channel carries audio.',
+			)
+			.addDropdown((dropdown) => {
+				const labels: Record<ChannelMode, string> = {
+					source: 'Same as source',
+					'mono-mix': 'Mono (mix all channels)',
+					'mono-left': 'Mono (left channel)',
+					'mono-right': 'Mono (right channel)',
+				};
+				CHANNEL_MODES.forEach((mode) => {
+					dropdown.addOption(mode, labels[mode]);
+				});
+				dropdown.setValue(this.config.channelMode);
+				dropdown.onChange((value) => {
+					this.config.channelMode = normalizeChannelMode(value);
+				});
+			});
+
+		new Setting(contentEl)
 			.setName('Delete source after processing')
 			.addToggle((toggle) =>
 				toggle.setValue(this.deleteSource).onChange((v) => {
@@ -189,8 +215,10 @@ export class AudioProcessingModal extends Modal {
 		if (this.processing) {
 			return;
 		}
-		if (!hasActiveStage(this.config)) {
-			new Notice('Enable at least one processing stage.');
+		if (!hasActiveChange(this.config)) {
+			new Notice(
+				'Enable at least one processing stage, or choose a mono channel option.',
+			);
 			return;
 		}
 		this.processing = true;

--- a/src/cleanup/AudioProcessingService.ts
+++ b/src/cleanup/AudioProcessingService.ts
@@ -16,6 +16,7 @@ import {
 } from '../constants';
 import { createWavFileBuffer, WAV_HEADER_SIZE } from '../audio/WavEncoder';
 import { floatToInt16 } from '../audio/pcm';
+import { downmixChannelData, isMonoChannelMode } from '../audio/downmix';
 import { directoryOf } from '../utils/paths';
 import { resolveUniquePathInDirectory } from '../audio/RecordingFileManager';
 import { delay } from '../utils/TimeUtils';
@@ -95,7 +96,16 @@ export class AudioProcessingService {
 			);
 		}
 		const data = await this.app.vault.readBinary(file);
-		const { sampleRate, data: channels } = await this.decodeChannels(data);
+		const { sampleRate, data: decoded } = await this.decodeChannels(data);
+		// Downmix to mono up front, before the DSP stages: the rest of the
+		// pipeline is channel-count agnostic, so a mono mode simply leaves
+		// one channel to filter/gate/level (and to write), halving that
+		// work for a stereo source. Multichannel input only; an already
+		// mono file is left as-is.
+		const channels =
+			isMonoChannelMode(config.channelMode) && decoded.length > 1
+				? [downmixChannelData(decoded, config.channelMode)]
+				: decoded;
 		const numChannels = channels.length;
 		// decodeChannels rejects empty audio, so the first channel exists
 		const numFrames = channels[0]?.length ?? 0;

--- a/src/cleanup/audioDsp.ts
+++ b/src/cleanup/audioDsp.ts
@@ -18,12 +18,19 @@ import {
 	MIN_CLEANUP_LEVELING_MAKEUP_DB,
 } from '../constants';
 import type { AudioRecorderSettings } from '../settings/settingsSchema';
+import { CHANNEL_MODE_SOURCE, type ChannelMode } from '../audio/downmix';
 
 /** Resolved, clamped audio-cleanup configuration. */
 export interface AudioDspConfig {
 	highPass: { enabled: boolean; hz: number };
 	gate: { enabled: boolean; thresholdDb: number };
 	leveling: { enabled: boolean; makeupDb: number };
+	/**
+	 * Channel layout for the cleaned copy: keep the source layout or
+	 * downmix to mono (mix or one picked channel). A per-run choice,
+	 * not seeded from settings.
+	 */
+	channelMode: ChannelMode;
 }
 
 /** Clamps a value into a range, falling back when non-finite. */
@@ -76,12 +83,15 @@ export function resolveAudioDspConfig(
 				DEFAULT_CLEANUP_LEVELING_MAKEUP_DB,
 			),
 		},
+		channelMode: CHANNEL_MODE_SOURCE,
 	};
 }
 
 /**
- * True when at least one stage is enabled (processing would change the
- * audio).
+ * True when at least one DSP stage is enabled (a filter, gate, or
+ * leveling pass would change the audio). A mono downmix is a change too
+ * but is tracked separately, since it depends on the source channel
+ * count the config does not carry - see {@link hasActiveChange}.
  * @param config - Resolved config
  */
 export function hasActiveStage(config: AudioDspConfig): boolean {
@@ -90,6 +100,17 @@ export function hasActiveStage(config: AudioDspConfig): boolean {
 		config.gate.enabled ||
 		config.leveling.enabled
 	);
+}
+
+/**
+ * True when processing would change the audio at all: any DSP stage, or
+ * a mono channel mode (a downmix, or a channel pick, that alters the
+ * output). Used by the dialog to allow a pure mono downmix with no DSP
+ * stage enabled.
+ * @param config - Resolved config
+ */
+export function hasActiveChange(config: AudioDspConfig): boolean {
+	return hasActiveStage(config) || config.channelMode !== CHANNEL_MODE_SOURCE;
 }
 
 /**

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -89,6 +89,20 @@ export const SILENT_CHANNEL_FLOOR_DB = -60;
 export const SILENT_CHANNEL_MIN_GAP_DB = 40;
 
 /**
+ * Minimum peak-window level that counts as real audio on the channel we
+ * propose to keep. This prevents a nearly empty recording with tiny device
+ * noise just above the silence floor from producing a conversion prompt.
+ */
+export const SILENT_CHANNEL_MIN_AUDIO_DB = -45;
+
+/**
+ * Window length used by silent-channel analysis. Peak window RMS is used
+ * instead of whole-file RMS so a short but real sound on one channel is not
+ * diluted by minutes of silence and incorrectly discarded.
+ */
+export const SILENT_CHANNEL_ANALYSIS_WINDOW_SECONDS = 0.25;
+
+/**
  * Maximum recording duration, in seconds, that the post-save
  * silent-channel check will decode. A full decode is the only way to
  * read per-channel levels; capping it keeps a long session from paying

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -74,6 +74,28 @@ export const MIME_TYPE_AUDIO_PREFIX = 'audio/';
 /** Default audio sample rate in Hz. */
 export const DEFAULT_SAMPLE_RATE = 44100;
 
+/**
+ * A channel whose RMS is at or below this level (dBFS) is treated as
+ * silent by the post-recording lopsided-stereo check. -60 dBFS is deep
+ * below usable speech, so a channel this quiet carries no real content.
+ */
+export const SILENT_CHANNEL_FLOOR_DB = -60;
+
+/**
+ * Minimum gap, in dB, between the loud and quiet channels of a stereo
+ * recording before the quiet one is reported as silent. Keeps a merely
+ * off-center mix (both channels present) from triggering the prompt.
+ */
+export const SILENT_CHANNEL_MIN_GAP_DB = 40;
+
+/**
+ * Maximum recording duration, in seconds, that the post-save
+ * silent-channel check will decode. A full decode is the only way to
+ * read per-channel levels; capping it keeps a long session from paying
+ * that cost on every save. Longer files are skipped silently.
+ */
+export const SILENT_CHANNEL_MAX_DECODE_SECONDS = 20 * 60;
+
 /** Default encoder bitrate in bits per second. */
 export const DEFAULT_BITRATE = 128000;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -105,6 +105,12 @@ interface BackgroundTranscriptionProgress {
 	restore: () => void;
 }
 
+interface SilentChannelSuggestion {
+	file: TFile;
+	keepMode: ChannelMode;
+	silentSide: 'left' | 'right';
+}
+
 /**
  * Advanced Audio Recorder plugin for Obsidian.
  */
@@ -131,6 +137,10 @@ export default class AudioRecorderPlugin extends Plugin {
 		BackgroundTranscriptionProgress
 	>();
 	private nextBackgroundTranscriptionId = 0;
+	/** Current actionable silent-channel notice, replaced per save. */
+	private silentChannelNotice: Notice | null = null;
+	/** Invalidates an older asynchronous analysis when a newer save starts. */
+	private silentChannelSuggestionGeneration = 0;
 	/**
 	 * True when data.json exists on disk but could not be read at load
 	 * time. While set, saveSettings refuses to write so the possibly
@@ -288,6 +298,9 @@ export default class AudioRecorderPlugin extends Plugin {
 	 * Called when the plugin is unloaded.
 	 */
 	override onunload(): void {
+		this.silentChannelSuggestionGeneration++;
+		this.silentChannelNotice?.hide();
+		this.silentChannelNotice = null;
 		this.recordingManager.cleanup();
 		this.recordingBanner.hide();
 		this.playerRegistrar.dispose();
@@ -677,8 +690,13 @@ export default class AudioRecorderPlugin extends Plugin {
 		);
 
 		// Fire-and-forget lopsided-stereo check; failures never touch the
-		// stop sequence (the detector itself already swallows its errors)
-		void this.maybeSuggestMonoConversion(result);
+		// stop sequence and are contained at this orchestration boundary.
+		void this.maybeSuggestMonoConversion(result).catch((error: unknown) => {
+			console.warn(
+				`${PLUGIN_LOG_PREFIX} Silent-channel suggestion failed:`,
+				error,
+			);
+		});
 
 		if (
 			!this.settings.transcriptionEnabled ||
@@ -711,62 +729,107 @@ export default class AudioRecorderPlugin extends Plugin {
 	 * Checks a freshly saved recording for the lopsided-stereo pattern
 	 * (one silent channel, a single mic through a dual-input interface)
 	 * and, when found, shows a Notice offering a one-click conversion to
-	 * mono that keeps the channel with audio. Only the first saved file
-	 * is inspected: a multi-track or auto-split session produces several
-	 * files, and one prompt is enough to alert the user. Gated by the
-	 * setting; a no-op when disabled or when nothing lopsided is found.
+	 * mono that keeps the channel with audio. One file per output track is
+	 * inspected (the first part for auto-split), sequentially to bound peak
+	 * decode memory. Gated by the setting; a no-op when disabled or when
+	 * nothing lopsided is found.
 	 * @param result - The saved audio paths
 	 */
 	private async maybeSuggestMonoConversion(
 		result: RecordingSaveResult,
 	): Promise<void> {
+		const generation = ++this.silentChannelSuggestionGeneration;
+		this.silentChannelNotice?.hide();
+		this.silentChannelNotice = null;
 		if (
 			!this.settings.detectSilentChannelOnSave ||
 			result.audioPaths.length === 0
 		) {
 			return;
 		}
-		const [firstAudioPath] = result.audioPaths;
-		if (!firstAudioPath) {
+		const perTrackPaths = result.trackFiles
+			?.map((group) => group.files[0])
+			.filter((path): path is string => Boolean(path));
+		const candidates = Array.from(
+			new Set(
+				perTrackPaths && perTrackPaths.length > 0
+					? perTrackPaths
+					: result.audioPaths.slice(0, 1),
+			),
+		);
+		const suggestions: SilentChannelSuggestion[] = [];
+		for (const path of candidates) {
+			if (generation !== this.silentChannelSuggestionGeneration) {
+				return;
+			}
+			const file = this.app.vault.getFileByPath(path);
+			if (!file) {
+				continue;
+			}
+			const detection = await detectSilentChannel(this.app, file, {
+				knownDurationSeconds: result.durationSeconds,
+			});
+			if (detection) {
+				suggestions.push({
+					file,
+					keepMode: detection.keepMode,
+					silentSide:
+						detection.silentChannel === 1 ? 'right' : 'left',
+				});
+			}
+		}
+		if (
+			generation !== this.silentChannelSuggestionGeneration ||
+			!this.settings.detectSilentChannelOnSave ||
+			suggestions.length === 0
+		) {
 			return;
 		}
-		const file = this.app.vault.getFileByPath(firstAudioPath);
-		if (!file) {
-			return;
-		}
-		const detection = await detectSilentChannel(this.app, file);
-		if (!detection) {
-			return;
-		}
-		const silentSide = detection.silentChannel === 1 ? 'right' : 'left';
-		this.showSilentChannelNotice(file, detection.keepMode, silentSide);
+		this.showSilentChannelNotice(suggestions);
 	}
 
 	/**
 	 * Shows the actionable lopsided-stereo Notice. Clicking "Convert to
 	 * mono" opens the conversion dialog preset to the channel that
 	 * carries audio, so the user confirms format/links and runs it.
-	 * @param file - The recorded file
-	 * @param keepMode - Channel mode that keeps the audio channel
-	 * @param silentSide - Human-readable label of the silent side
+	 * @param suggestions - Lopsided files and the channel each should keep
 	 */
 	private showSilentChannelNotice(
-		file: TFile,
-		keepMode: ChannelMode,
-		silentSide: string,
+		suggestions: SilentChannelSuggestion[],
 	): void {
+		this.silentChannelNotice?.hide();
 		const fragment = activeDocument.createDocumentFragment();
-		fragment.append(`Recording's ${silentSide} channel is silent. `);
-		const link = activeDocument.createElement('a');
-		link.textContent = 'Convert to mono';
-		link.className = 'aar-silent-channel-convert';
-		link.setAttribute('role', 'button');
-		fragment.append(link);
-		const notice = new Notice(fragment, 0);
-		link.addEventListener('click', () => {
-			notice.hide();
-			this.openMonoConversion(file, keepMode);
-		});
+		if (suggestions.length > 1) {
+			fragment.append(
+				`${String(suggestions.length)} recordings have a silent channel: `,
+			);
+		}
+		for (const [index, suggestion] of suggestions.entries()) {
+			if (index > 0) {
+				fragment.append(' ');
+			}
+			if (suggestions.length === 1) {
+				fragment.append(
+					`Recording's ${suggestion.silentSide} channel is silent. `,
+				);
+			}
+			const button = activeDocument.createElement('button');
+			button.type = 'button';
+			button.textContent =
+				suggestions.length === 1
+					? 'Convert to mono'
+					: `Convert ${suggestion.file.name}`;
+			button.className = 'aar-silent-channel-convert';
+			button.addEventListener('click', () => {
+				if (suggestions.length === 1) {
+					this.silentChannelNotice?.hide();
+					this.silentChannelNotice = null;
+				}
+				this.openMonoConversion(suggestion.file, suggestion.keepMode);
+			});
+			fragment.append(button);
+		}
+		this.silentChannelNotice = new Notice(fragment, 0);
 	}
 
 	/**
@@ -777,18 +840,15 @@ export default class AudioRecorderPlugin extends Plugin {
 	 * @param keepMode - Channel mode to preselect in the dialog
 	 */
 	private openMonoConversion(file: TFile, keepMode: ChannelMode): void {
-		new ConversionModal(
-			this.app,
-			file,
-			this.settings,
-			(convertedPath) => {
+		new ConversionModal(this.app, file, this.settings, {
+			onConverted: (convertedPath) => {
 				this.playerRegistrar.primeSavedRecordingsForEnhancement([
 					convertedPath,
 				]);
 			},
-			() => this.encodingWorker,
-			keepMode,
-		).open();
+			getWorkerClient: () => this.encodingWorker,
+			initialChannelMode: keepMode,
+		}).open();
 	}
 
 	/**

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@
  */
 
 import { Notice, Platform, Plugin } from 'obsidian';
+import type { TFile } from 'obsidian';
 import { RecordingStatus } from './types';
 import type {
 	SaveProgress,
@@ -18,6 +19,9 @@ import {
 } from './settings/settingsSerialization';
 import { AudioRecorderSettingTab } from './settings/SettingsTab';
 import { RecordingManager } from './recording/RecordingManager';
+import { detectSilentChannel } from './recording/silentChannelDetector';
+import type { ChannelMode } from './audio/downmix';
+import { ConversionModal } from './ui/ConversionModal';
 import { SessionJournal, JOURNAL_FILE_NAME } from './recording/SessionJournal';
 import {
 	collectRecoverableSessions,
@@ -672,6 +676,10 @@ export default class AudioRecorderPlugin extends Plugin {
 			result.audioPaths,
 		);
 
+		// Fire-and-forget lopsided-stereo check; failures never touch the
+		// stop sequence (the detector itself already swallows its errors)
+		void this.maybeSuggestMonoConversion(result);
+
 		if (
 			!this.settings.transcriptionEnabled ||
 			!this.settings.transcribeOnSave ||
@@ -697,6 +705,90 @@ export default class AudioRecorderPlugin extends Plugin {
 			autoStart: true,
 			notePath: result.notePath ?? undefined,
 		}).open();
+	}
+
+	/**
+	 * Checks a freshly saved recording for the lopsided-stereo pattern
+	 * (one silent channel, a single mic through a dual-input interface)
+	 * and, when found, shows a Notice offering a one-click conversion to
+	 * mono that keeps the channel with audio. Only the first saved file
+	 * is inspected: a multi-track or auto-split session produces several
+	 * files, and one prompt is enough to alert the user. Gated by the
+	 * setting; a no-op when disabled or when nothing lopsided is found.
+	 * @param result - The saved audio paths
+	 */
+	private async maybeSuggestMonoConversion(
+		result: RecordingSaveResult,
+	): Promise<void> {
+		if (
+			!this.settings.detectSilentChannelOnSave ||
+			result.audioPaths.length === 0
+		) {
+			return;
+		}
+		const [firstAudioPath] = result.audioPaths;
+		if (!firstAudioPath) {
+			return;
+		}
+		const file = this.app.vault.getFileByPath(firstAudioPath);
+		if (!file) {
+			return;
+		}
+		const detection = await detectSilentChannel(this.app, file);
+		if (!detection) {
+			return;
+		}
+		const silentSide = detection.silentChannel === 1 ? 'right' : 'left';
+		this.showSilentChannelNotice(file, detection.keepMode, silentSide);
+	}
+
+	/**
+	 * Shows the actionable lopsided-stereo Notice. Clicking "Convert to
+	 * mono" opens the conversion dialog preset to the channel that
+	 * carries audio, so the user confirms format/links and runs it.
+	 * @param file - The recorded file
+	 * @param keepMode - Channel mode that keeps the audio channel
+	 * @param silentSide - Human-readable label of the silent side
+	 */
+	private showSilentChannelNotice(
+		file: TFile,
+		keepMode: ChannelMode,
+		silentSide: string,
+	): void {
+		const fragment = activeDocument.createDocumentFragment();
+		fragment.append(`Recording's ${silentSide} channel is silent. `);
+		const link = activeDocument.createElement('a');
+		link.textContent = 'Convert to mono';
+		link.className = 'aar-silent-channel-convert';
+		link.setAttribute('role', 'button');
+		fragment.append(link);
+		const notice = new Notice(fragment, 0);
+		link.addEventListener('click', () => {
+			notice.hide();
+			this.openMonoConversion(file, keepMode);
+		});
+	}
+
+	/**
+	 * Opens the conversion dialog preset to the given channel mode and
+	 * primes the converted file for the enhanced player. Extracted so
+	 * the silent-channel prompt's action is testable without the Notice.
+	 * @param file - The file to convert
+	 * @param keepMode - Channel mode to preselect in the dialog
+	 */
+	private openMonoConversion(file: TFile, keepMode: ChannelMode): void {
+		new ConversionModal(
+			this.app,
+			file,
+			this.settings,
+			(convertedPath) => {
+				this.playerRegistrar.primeSavedRecordingsForEnhancement([
+					convertedPath,
+				]);
+			},
+			() => this.encodingWorker,
+			keepMode,
+		).open();
 	}
 
 	/**

--- a/src/recording/RecordingManager.ts
+++ b/src/recording/RecordingManager.ts
@@ -695,6 +695,11 @@ export class RecordingManager {
 		if (!this.rotation.requestStop()) {
 			return;
 		}
+		// Snapshot active audio time before recorder shutdown and saving add
+		// wall-clock latency. The post-save detector uses this to reject long
+		// sessions before reading or decoding their files.
+		const activeDurationSeconds =
+			this.rotation.getSessionActiveMs(this.status) / 1000;
 
 		try {
 			// Let an in-flight part rotation finish before tearing down:
@@ -721,11 +726,15 @@ export class RecordingManager {
 			const durationMs = Date.now() - this.recordingStartTime;
 			this.debugLogger.logRecordingStats(durationMs, this.totalChunks);
 
-			const saveResult = await this.finalizer.saveRecording(
+			const finalized = await this.finalizer.saveRecording(
 				this.chunkTargets,
 				this.recordingTimestamp,
 				this.insertionContext,
 			);
+			const saveResult: RecordingSaveResult = {
+				...finalized,
+				durationSeconds: activeDurationSeconds,
+			};
 			// Persist live markers before the hook so they are on disk when a
 			// post-save action (e.g. opening the player) reads the sidecar
 			await this.markers.persistMarkers(saveResult);

--- a/src/recording/silentChannelDetector.ts
+++ b/src/recording/silentChannelDetector.ts
@@ -3,9 +3,9 @@
  * recording where one channel carries audio and the other is silent -
  * the signature of a single microphone captured through an audio
  * interface that the OS exposes as one stereo device. The pure
- * analysis (per-channel RMS, the loud/quiet decision) lives here so it
- * is unit tested without Web Audio; the decode wrapper is a thin
- * adapter around it.
+ * analysis (per-channel peak-window RMS and the loud/quiet decision) lives
+ * here so it is unit tested without Web Audio; the decode wrapper first uses
+ * known/container metadata to avoid unnecessary full decodes.
  * @module recording/silentChannelDetector
  */
 
@@ -14,9 +14,11 @@ import {
 	PLUGIN_LOG_PREFIX,
 	SILENT_CHANNEL_FLOOR_DB,
 	SILENT_CHANNEL_MIN_GAP_DB,
+	SILENT_CHANNEL_MIN_AUDIO_DB,
+	SILENT_CHANNEL_ANALYSIS_WINDOW_SECONDS,
 	SILENT_CHANNEL_MAX_DECODE_SECONDS,
 } from '../constants';
-import { computeRms } from './InputLevelMonitor';
+import { probeAudioMetadata } from '../utils/AudioFileAnalyzer';
 import {
 	CHANNEL_MODE_MONO_LEFT,
 	CHANNEL_MODE_MONO_RIGHT,
@@ -37,26 +39,61 @@ export interface SilentChannelResult {
 	keepMode: ChannelMode;
 }
 
+/** Tunable thresholds for the pure channel-balance analysis. */
+export interface ChannelBalanceOptions {
+	floorDb?: number;
+	minGapDb?: number;
+	minAudioDb?: number;
+	windowFrames?: number;
+}
+
+/** Early-bound recording metadata used to avoid opening large files. */
+export interface SilentChannelDetectionOptions {
+	knownDurationSeconds?: number;
+	maxDecodeSeconds?: number;
+}
+
 /** Converts an RMS amplitude (0..1) to dBFS, with a floor for silence. */
 function rmsToDb(rms: number): number {
 	return rms > 0 ? 20 * Math.log10(rms) : -Infinity;
 }
 
 /**
+ * Highest RMS among fixed-size windows. A real but brief sound therefore
+ * remains visible instead of being diluted by the duration of the whole
+ * recording. The final partial window is included.
+ */
+function peakWindowRmsDb(samples: Float32Array, windowFrames: number): number {
+	if (samples.length === 0) {
+		return -Infinity;
+	}
+	const size = Math.max(1, Math.floor(windowFrames));
+	let peakRms = 0;
+	for (let start = 0; start < samples.length; start += size) {
+		const end = Math.min(samples.length, start + size);
+		let sumSquares = 0;
+		for (let i = start; i < end; i++) {
+			const sample = samples[i] ?? 0;
+			sumSquares += sample * sample;
+		}
+		peakRms = Math.max(peakRms, Math.sqrt(sumSquares / (end - start)));
+	}
+	return rmsToDb(peakRms);
+}
+
+/**
  * Analyzes decoded stereo channels for the lopsided pattern. Returns a
- * result only when exactly one of two channels is at or below the
- * silence floor while the other sits clearly above it by at least the
- * minimum gap - so a centered or merely off-balance stereo mix, where
- * both channels carry audio, never qualifies.
+ * result only when exactly one of two channels never rises above the silence
+ * floor while the other reaches a useful level with at least the minimum
+ * gap. Peak windows preserve a short real event instead of diluting it over
+ * the entire file.
  * @param channels - Per-channel decoded samples
- * @param floorDb - Silence floor in dBFS
- * @param minGapDb - Minimum loud-to-quiet gap in dB
+ * @param options - Window size and level thresholds
  * @returns The lopsided result, or null when it does not apply
  */
 export function analyzeChannelBalance(
 	channels: Float32Array[],
-	floorDb: number = SILENT_CHANNEL_FLOOR_DB,
-	minGapDb: number = SILENT_CHANNEL_MIN_GAP_DB,
+	options: ChannelBalanceOptions = {},
 ): SilentChannelResult | null {
 	if (channels.length !== 2) {
 		return null;
@@ -66,8 +103,12 @@ export function analyzeChannelBalance(
 	if (!left || !right) {
 		return null;
 	}
-	const leftDb = rmsToDb(computeRms(left));
-	const rightDb = rmsToDb(computeRms(right));
+	const floorDb = options.floorDb ?? SILENT_CHANNEL_FLOOR_DB;
+	const minGapDb = options.minGapDb ?? SILENT_CHANNEL_MIN_GAP_DB;
+	const minAudioDb = options.minAudioDb ?? SILENT_CHANNEL_MIN_AUDIO_DB;
+	const windowFrames = options.windowFrames ?? Math.max(left.length, 1);
+	const leftDb = peakWindowRmsDb(left, windowFrames);
+	const rightDb = peakWindowRmsDb(right, windowFrames);
 
 	const leftSilent = leftDb <= floorDb;
 	const rightSilent = rightDb <= floorDb;
@@ -75,14 +116,14 @@ export function analyzeChannelBalance(
 	if (leftSilent === rightSilent) {
 		return null;
 	}
-	if (rightSilent && leftDb - rightDb >= minGapDb) {
+	if (rightSilent && leftDb >= minAudioDb && leftDb - rightDb >= minGapDb) {
 		return {
 			silentChannel: 1,
 			audioChannel: 0,
 			keepMode: CHANNEL_MODE_MONO_LEFT,
 		};
 	}
-	if (leftSilent && rightDb - leftDb >= minGapDb) {
+	if (leftSilent && rightDb >= minAudioDb && rightDb - leftDb >= minGapDb) {
 		return {
 			silentChannel: 0,
 			audioChannel: 1,
@@ -100,17 +141,33 @@ export function analyzeChannelBalance(
  * throws: any failure resolves to null so the post-save flow continues.
  * @param app - Obsidian app handle
  * @param file - Saved audio file to inspect
- * @param maxDecodeSeconds - Duration cap; longer files are skipped
+ * @param options - Known duration and decode cap
  * @returns The lopsided result, or null
  */
 export async function detectSilentChannel(
 	app: App,
 	file: TFile,
-	maxDecodeSeconds: number = SILENT_CHANNEL_MAX_DECODE_SECONDS,
+	options: SilentChannelDetectionOptions = {},
 ): Promise<SilentChannelResult | null> {
 	let audioContext: AudioContext | null = null;
 	try {
+		const maxDecodeSeconds =
+			options.maxDecodeSeconds ?? SILENT_CHANNEL_MAX_DECODE_SECONDS;
+		if (
+			Number.isFinite(options.knownDurationSeconds) &&
+			(options.knownDurationSeconds ?? 0) > maxDecodeSeconds
+		) {
+			return null;
+		}
 		const data = await app.vault.readBinary(file);
+		const metadata = await probeAudioMetadata(data, file.path);
+		if (
+			metadata &&
+			(metadata.channels !== 2 ||
+				metadata.durationSeconds > maxDecodeSeconds)
+		) {
+			return null;
+		}
 		audioContext = new AudioContext();
 		const buffer = await audioContext.decodeAudioData(data);
 		if (
@@ -119,10 +176,18 @@ export async function detectSilentChannel(
 		) {
 			return null;
 		}
-		return analyzeChannelBalance([
-			buffer.getChannelData(0),
-			buffer.getChannelData(1),
-		]);
+		return analyzeChannelBalance(
+			[buffer.getChannelData(0), buffer.getChannelData(1)],
+			{
+				windowFrames: Math.max(
+					1,
+					Math.round(
+						buffer.sampleRate *
+							SILENT_CHANNEL_ANALYSIS_WINDOW_SECONDS,
+					),
+				),
+			},
+		);
 	} catch (error) {
 		console.warn(
 			`${PLUGIN_LOG_PREFIX} Silent-channel check skipped:`,

--- a/src/recording/silentChannelDetector.ts
+++ b/src/recording/silentChannelDetector.ts
@@ -1,0 +1,139 @@
+/**
+ * Post-recording detection of a lopsided stereo file: a two-channel
+ * recording where one channel carries audio and the other is silent -
+ * the signature of a single microphone captured through an audio
+ * interface that the OS exposes as one stereo device. The pure
+ * analysis (per-channel RMS, the loud/quiet decision) lives here so it
+ * is unit tested without Web Audio; the decode wrapper is a thin
+ * adapter around it.
+ * @module recording/silentChannelDetector
+ */
+
+import type { App, TFile } from 'obsidian';
+import {
+	PLUGIN_LOG_PREFIX,
+	SILENT_CHANNEL_FLOOR_DB,
+	SILENT_CHANNEL_MIN_GAP_DB,
+	SILENT_CHANNEL_MAX_DECODE_SECONDS,
+} from '../constants';
+import { computeRms } from './InputLevelMonitor';
+import {
+	CHANNEL_MODE_MONO_LEFT,
+	CHANNEL_MODE_MONO_RIGHT,
+	type ChannelMode,
+} from '../audio/downmix';
+
+/**
+ * Outcome of the lopsided-stereo analysis: which channel is silent (so
+ * the caller keeps the other), or null when the file is balanced, mono,
+ * or both channels are effectively silent.
+ */
+export interface SilentChannelResult {
+	/** Zero-based index of the silent channel (0 = left, 1 = right). */
+	silentChannel: 0 | 1;
+	/** Zero-based index of the channel that carries audio. */
+	audioChannel: 0 | 1;
+	/** Channel mode that keeps only the audio channel. */
+	keepMode: ChannelMode;
+}
+
+/** Converts an RMS amplitude (0..1) to dBFS, with a floor for silence. */
+function rmsToDb(rms: number): number {
+	return rms > 0 ? 20 * Math.log10(rms) : -Infinity;
+}
+
+/**
+ * Analyzes decoded stereo channels for the lopsided pattern. Returns a
+ * result only when exactly one of two channels is at or below the
+ * silence floor while the other sits clearly above it by at least the
+ * minimum gap - so a centered or merely off-balance stereo mix, where
+ * both channels carry audio, never qualifies.
+ * @param channels - Per-channel decoded samples
+ * @param floorDb - Silence floor in dBFS
+ * @param minGapDb - Minimum loud-to-quiet gap in dB
+ * @returns The lopsided result, or null when it does not apply
+ */
+export function analyzeChannelBalance(
+	channels: Float32Array[],
+	floorDb: number = SILENT_CHANNEL_FLOOR_DB,
+	minGapDb: number = SILENT_CHANNEL_MIN_GAP_DB,
+): SilentChannelResult | null {
+	if (channels.length !== 2) {
+		return null;
+	}
+	const left = channels[0];
+	const right = channels[1];
+	if (!left || !right) {
+		return null;
+	}
+	const leftDb = rmsToDb(computeRms(left));
+	const rightDb = rmsToDb(computeRms(right));
+
+	const leftSilent = leftDb <= floorDb;
+	const rightSilent = rightDb <= floorDb;
+	// Exactly one side silent, and the other clearly present
+	if (leftSilent === rightSilent) {
+		return null;
+	}
+	if (rightSilent && leftDb - rightDb >= minGapDb) {
+		return {
+			silentChannel: 1,
+			audioChannel: 0,
+			keepMode: CHANNEL_MODE_MONO_LEFT,
+		};
+	}
+	if (leftSilent && rightDb - leftDb >= minGapDb) {
+		return {
+			silentChannel: 0,
+			audioChannel: 1,
+			keepMode: CHANNEL_MODE_MONO_RIGHT,
+		};
+	}
+	return null;
+}
+
+/**
+ * Decodes an audio file and reports whether it is a lopsided stereo
+ * recording. Skips files that are not decodable, not stereo, or longer
+ * than the decode cap (a full decode is the only way to read per-channel
+ * levels, so long sessions are not paid for on every save). Never
+ * throws: any failure resolves to null so the post-save flow continues.
+ * @param app - Obsidian app handle
+ * @param file - Saved audio file to inspect
+ * @param maxDecodeSeconds - Duration cap; longer files are skipped
+ * @returns The lopsided result, or null
+ */
+export async function detectSilentChannel(
+	app: App,
+	file: TFile,
+	maxDecodeSeconds: number = SILENT_CHANNEL_MAX_DECODE_SECONDS,
+): Promise<SilentChannelResult | null> {
+	let audioContext: AudioContext | null = null;
+	try {
+		const data = await app.vault.readBinary(file);
+		audioContext = new AudioContext();
+		const buffer = await audioContext.decodeAudioData(data);
+		if (
+			buffer.numberOfChannels !== 2 ||
+			buffer.duration > maxDecodeSeconds
+		) {
+			return null;
+		}
+		return analyzeChannelBalance([
+			buffer.getChannelData(0),
+			buffer.getChannelData(1),
+		]);
+	} catch (error) {
+		console.warn(
+			`${PLUGIN_LOG_PREFIX} Silent-channel check skipped:`,
+			error,
+		);
+		return null;
+	} finally {
+		if (audioContext) {
+			void audioContext.close().catch(() => {
+				// Closing a context that already failed is non-fatal
+			});
+		}
+	}
+}

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -871,6 +871,20 @@ export class AudioRecorderSettingTab extends PluginSettingTab {
 			);
 
 		new Setting(containerEl)
+			.setName('Detect silent channel after recording')
+			.setDesc(
+				'After saving a recording, check whether it is a stereo file with one silent channel - the typical result of a single microphone on a dual-input audio interface - and offer to convert it to mono. Long recordings are skipped.',
+			)
+			.addToggle((toggle) =>
+				toggle
+					.setValue(s.detectSilentChannelOnSave)
+					.onChange(async (v) => {
+						s.detectSilentChannelOnSave = v;
+						await this.plugin.saveSettings();
+					}),
+			);
+
+		new Setting(containerEl)
 			.setName('Mobile recording banner')
 			.setDesc(
 				'Show a prominent recording banner on mobile, where there is no ribbon indicator.',

--- a/src/settings/settingsSchema.ts
+++ b/src/settings/settingsSchema.ts
@@ -263,6 +263,12 @@ export interface AudioRecorderSettings {
 	inputAutoGainControl: boolean;
 	/** Show a live input-level meter while recording */
 	showInputLevelMeter: boolean;
+	/**
+	 * After saving a recording, check whether it is a stereo file with
+	 * one silent channel (a single mic through a dual-input interface)
+	 * and offer to convert it to mono.
+	 */
+	detectSilentChannelOnSave: boolean;
 	/** Show live elapsed time and file size while recording */
 	showRecordingStats: boolean;
 	/** Show a prominent recording banner on mobile */
@@ -402,6 +408,7 @@ export const DEFAULT_SETTINGS: AudioRecorderSettings = {
 	inputEchoCancellation: true,
 	inputAutoGainControl: true,
 	showInputLevelMeter: true,
+	detectSilentChannelOnSave: true,
 	showRecordingStats: true,
 	mobileRecordingBanner: true,
 	cleanupHighPassEnabled: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,6 +70,10 @@ export interface RecordingSaveResult {
 	 * markers can be resolved to the right file. Absent only when a caller
 	 * (e.g. a test mock) does not provide it. */
 	trackFiles?: TrackFileGroup[];
+	/** Active recording duration in seconds, excluding paused intervals.
+	 * Runtime recording results always include it; optional for compatibility
+	 * with recovery paths and external/test callers. */
+	durationSeconds?: number;
 }
 
 /**

--- a/src/ui/ConversionModal.ts
+++ b/src/ui/ConversionModal.ts
@@ -52,6 +52,10 @@ export class ConversionModal extends Modal {
 	 * @param settings - Plugin settings (seed format/bitrate/link defaults)
 	 * @param onConverted - Called with the converted file's path after a
 	 *   successful run, so a caller can prime it for the enhanced player.
+	 * @param getWorkerClient - Supplies the encoding worker, if any
+	 * @param initialChannelMode - Preselects the Channels option, so a
+	 *   caller (e.g. the silent-channel prompt) can open the dialog
+	 *   already set to the recommended mono downmix
 	 */
 	constructor(
 		app: App,
@@ -59,11 +63,13 @@ export class ConversionModal extends Modal {
 		settings: AudioRecorderSettings,
 		private readonly onConverted?: (convertedPath: string) => void,
 		getWorkerClient: () => EncodingWorkerClient | null = () => null,
+		initialChannelMode: ChannelMode = CHANNEL_MODE_SOURCE,
 	) {
 		super(app);
 		this.sourceFile = sourceFile;
 		this.deleteSource = settings.deleteSourceAfterConversion;
 		this.linkAction = settings.conversionLinkAction;
+		this.channelMode = normalizeChannelMode(initialChannelMode);
 		this.conversionService = new ConversionService(app, getWorkerClient);
 	}
 

--- a/src/ui/ConversionModal.ts
+++ b/src/ui/ConversionModal.ts
@@ -27,6 +27,13 @@ import type {
 	ConversionLinkAction,
 } from '../settings/settingsSchema';
 
+/** Optional collaborators and initial form state for ConversionModal. */
+export interface ConversionModalOptions {
+	onConverted?: (convertedPath: string) => void;
+	getWorkerClient?: () => EncodingWorkerClient | null;
+	initialChannelMode?: ChannelMode;
+}
+
 /**
  * Modal for converting an audio file to a different format.
  */
@@ -45,32 +52,32 @@ export class ConversionModal extends Modal {
 	private progressNotice: Notice | null = null;
 	/** Conversion pipeline behind the form. */
 	private readonly conversionService: ConversionService;
+	private readonly onConverted?: (convertedPath: string) => void;
 
 	/**
 	 * @param app - Obsidian app handle
 	 * @param sourceFile - Audio file to convert
 	 * @param settings - Plugin settings (seed format/bitrate/link defaults)
-	 * @param onConverted - Called with the converted file's path after a
-	 *   successful run, so a caller can prime it for the enhanced player.
-	 * @param getWorkerClient - Supplies the encoding worker, if any
-	 * @param initialChannelMode - Preselects the Channels option, so a
-	 *   caller (e.g. the silent-channel prompt) can open the dialog
-	 *   already set to the recommended mono downmix
+	 * @param options - Optional callback, worker supplier, and initial channel
+	 * mode. A named object keeps future callers from depending on positional
+	 * argument order.
 	 */
 	constructor(
 		app: App,
 		sourceFile: TFile,
 		settings: AudioRecorderSettings,
-		private readonly onConverted?: (convertedPath: string) => void,
-		getWorkerClient: () => EncodingWorkerClient | null = () => null,
-		initialChannelMode: ChannelMode = CHANNEL_MODE_SOURCE,
+		options: ConversionModalOptions = {},
 	) {
 		super(app);
 		this.sourceFile = sourceFile;
 		this.deleteSource = settings.deleteSourceAfterConversion;
 		this.linkAction = settings.conversionLinkAction;
-		this.channelMode = normalizeChannelMode(initialChannelMode);
-		this.conversionService = new ConversionService(app, getWorkerClient);
+		this.channelMode = normalizeChannelMode(options.initialChannelMode);
+		this.onConverted = options.onConverted;
+		this.conversionService = new ConversionService(
+			app,
+			options.getWorkerClient ?? (() => null),
+		);
 	}
 
 	override onOpen(): void {

--- a/src/utils/AudioFileAnalyzer.ts
+++ b/src/utils/AudioFileAnalyzer.ts
@@ -32,7 +32,7 @@ export interface AudioFileInfo {
 }
 
 /** The raw numbers the info dialog is built from. */
-interface ProbedAudioMetadata {
+export interface ProbedAudioMetadata {
 	durationSeconds: number;
 	sampleRate: number;
 	channels: number;
@@ -52,7 +52,7 @@ export async function getAudioFileInfo(
 		const arrayBuffer = await app.vault.readBinary(file);
 
 		const metadata =
-			(await probeMetadata(arrayBuffer, file.path)) ??
+			(await probeAudioMetadata(arrayBuffer, file.path)) ??
 			(await decodeMetadata(arrayBuffer));
 		if (!metadata) {
 			return null;
@@ -104,7 +104,7 @@ export async function getAudioFileInfo(
  * @param data - The file's bytes
  * @param path - Vault path, for the warning log only
  */
-async function probeMetadata(
+export async function probeAudioMetadata(
 	data: ArrayBuffer,
 	path: string,
 ): Promise<ProbedAudioMetadata | null> {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -725,3 +725,21 @@ input.aar-input-invalid {
 .aar-doc-callout-link {
     font-weight: var(--font-semibold);
 }
+
+/* Native button semantics make the persistent post-recording action keyboard
+   accessible; link styling keeps it compact inside an Obsidian Notice. */
+.aar-silent-channel-convert {
+    appearance: none;
+    border: 0;
+    padding: 0;
+    background: none;
+    color: var(--text-accent);
+    font: inherit;
+    text-decoration: underline;
+    cursor: pointer;
+}
+
+.aar-silent-channel-convert:focus-visible {
+    outline: 2px solid var(--background-modifier-border-focus);
+    outline-offset: 2px;
+}

--- a/tests/mocks/obsidian.ts
+++ b/tests/mocks/obsidian.ts
@@ -89,6 +89,10 @@ export class Vault {
 		// Mock implementation
 	}
 
+	getFileByPath(_path: string): TFile | null {
+		return null;
+	}
+
 	getRoot(): TFolder {
 		return new TFolder('');
 	}
@@ -121,11 +125,12 @@ export class Workspace {
  * The global clearMocks option resets the calls between tests.
  */
 export const Notice = jest.fn(function (
-	this: { message: string },
-	message: string,
+	this: { message: string | DocumentFragment; hide: jest.Mock },
+	message: string | DocumentFragment,
 	_timeout?: number,
 ) {
 	this.message = message;
+	this.hide = jest.fn();
 });
 
 /**

--- a/tests/unit/AudioProcessingModal.test.ts
+++ b/tests/unit/AudioProcessingModal.test.ts
@@ -131,7 +131,35 @@ describe('AudioProcessingModal', () => {
 
 		expect(processMock).not.toHaveBeenCalled();
 		expect(Notice).toHaveBeenCalledWith(
-			'Enable at least one processing stage.',
+			'Enable at least one processing stage, or choose a mono channel option.',
+		);
+	});
+
+	it('runs a pure mono downmix with no DSP stage enabled', async () => {
+		processMock.mockResolvedValue('recordings/take-processed.wav');
+		const { modal, processButton } = openModal(
+			makeApp(),
+			settingsWithStages(false),
+		);
+		jest.spyOn(modal, 'close').mockImplementation();
+
+		// Pick a mono mode via the Channels dropdown
+		const channelsSelect = settingRowByName(
+			modal.contentEl,
+			'Channels',
+		).querySelector<HTMLSelectElement>('select');
+		if (!channelsSelect) {
+			throw new Error('channels dropdown not rendered');
+		}
+		channelsSelect.value = 'mono-left';
+		channelsSelect.dispatchEvent(new Event('change'));
+
+		processButton.click();
+		await settle();
+
+		expect(processMock).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({ channelMode: 'mono-left' }),
 		);
 	});
 

--- a/tests/unit/AudioProcessingService.test.ts
+++ b/tests/unit/AudioProcessingService.test.ts
@@ -123,6 +123,7 @@ const ALL_STAGES: AudioDspConfig = {
 	highPass: { enabled: true, hz: 80 },
 	gate: { enabled: true, thresholdDb: -50 },
 	leveling: { enabled: true, makeupDb: 6 },
+	channelMode: 'source',
 };
 
 /** Parses the channel count / sample rate / frame count from a WAV blob. */
@@ -167,6 +168,32 @@ describe('AudioProcessingService.process (e2e pipeline)', () => {
 		expect(header.dataBytes).toBe(sampleRate * 2 * 2); // frames * ch * 2 bytes
 	});
 
+	it('downmixes a stereo source to mono when a mono mode is chosen', async () => {
+		const sampleRate = 8000;
+		const left = new Float32Array(sampleRate).fill(0.6);
+		const right = new Float32Array(sampleRate).fill(0);
+		decodeAudioData.mockResolvedValue(
+			fakeBuffer([left, right], sampleRate),
+		);
+		const { app, written } = makeApp();
+		const service = new AudioProcessingService(app);
+
+		const path = await service.process(fakeFile('voice/rec.wav'), {
+			highPass: { enabled: false, hz: 80 },
+			gate: { enabled: false, thresholdDb: -50 },
+			leveling: { enabled: false, makeupDb: 0 },
+			channelMode: 'mono-left',
+		});
+
+		const buffer = written.get(path) as ArrayBuffer;
+		const header = readWavHeader(buffer);
+		// One channel out, and it carries the loud left channel untouched
+		expect(header.channels).toBe(1);
+		expect(header.dataBytes).toBe(sampleRate * 2);
+		const pcm = new DataView(buffer, 44);
+		expect(pcm.getInt16(0, true)).toBeGreaterThan(0);
+	});
+
 	it('processes a gate-only run without invoking the offline graph', async () => {
 		const sampleRate = 16000;
 		decodeAudioData.mockResolvedValue(
@@ -178,6 +205,7 @@ describe('AudioProcessingService.process (e2e pipeline)', () => {
 			highPass: { enabled: false, hz: 80 },
 			gate: { enabled: true, thresholdDb: -50 },
 			leveling: { enabled: false, makeupDb: 0 },
+			channelMode: 'source',
 		});
 		expect(path).toBe('voice/rec-processed.wav');
 		expect(readWavHeader(written.get(path) as ArrayBuffer).channels).toBe(
@@ -198,6 +226,7 @@ describe('AudioProcessingService.process (e2e pipeline)', () => {
 			highPass: { enabled: false, hz: 80 },
 			gate: { enabled: true, thresholdDb: -50 },
 			leveling: { enabled: false, makeupDb: 0 },
+			channelMode: 'source',
 		});
 		const buffer = written.get(path) as ArrayBuffer;
 		expect(readWavHeader(buffer).dataBytes).toBe(numFrames * 2);

--- a/tests/unit/ConversionModal.test.ts
+++ b/tests/unit/ConversionModal.test.ts
@@ -170,6 +170,16 @@ describe('ConversionModal', () => {
 		expect(modal).toBeDefined();
 	});
 
+	it('initializes the channel preset through named options', () => {
+		const modal = new ConversionModal(mockApp, mockFile, mockSettings, {
+			initialChannelMode: 'mono-right',
+		});
+
+		expect((modal as unknown as { channelMode: string }).channelMode).toBe(
+			'mono-right',
+		);
+	});
+
 	it('should set up content on open', () => {
 		const modal = new ConversionModal(mockApp, mockFile, mockSettings);
 		modal.onOpen();

--- a/tests/unit/RecordingManager.output.test.ts
+++ b/tests/unit/RecordingManager.output.test.ts
@@ -1083,9 +1083,11 @@ describe('RecordingManager', () => {
 			const result = onRecordingSaved.mock.calls[0][0] as {
 				audioPaths: string[];
 				notePath: string | null;
+				durationSeconds?: number;
 			};
 			expect(result.audioPaths.length).toBeGreaterThan(0);
 			expect(result.notePath).toBe('Notes/active.md');
+			expect(result.durationSeconds).toEqual(expect.any(Number));
 		});
 
 		it('should use replaceRange at stored position when insertAtOriginalPosition is enabled', async () => {

--- a/tests/unit/Settings.test.ts
+++ b/tests/unit/Settings.test.ts
@@ -342,6 +342,7 @@ describe('Settings', () => {
 				inputEchoCancellation: false,
 				inputAutoGainControl: false,
 				showInputLevelMeter: false,
+				detectSilentChannelOnSave: false,
 				showRecordingStats: false,
 				mobileRecordingBanner: false,
 				cleanupHighPassEnabled: false,

--- a/tests/unit/audioDsp.test.ts
+++ b/tests/unit/audioDsp.test.ts
@@ -7,6 +7,7 @@ import {
 	applyNoiseGateToChannel,
 	dbToGain,
 	gateShouldOpen,
+	hasActiveChange,
 	hasActiveStage,
 	resolveAudioDspConfig,
 } from 'src/cleanup/audioDsp';
@@ -42,17 +43,55 @@ describe('dbToGain', () => {
 });
 
 describe('hasActiveStage', () => {
+	const off = {
+		highPass: { enabled: false, hz: 80 },
+		gate: { enabled: false, thresholdDb: -50 },
+		leveling: { enabled: false, makeupDb: 6 },
+		channelMode: 'source' as const,
+	};
+
 	it('is false only when every stage is disabled', () => {
-		const off = {
-			highPass: { enabled: false, hz: 80 },
-			gate: { enabled: false, thresholdDb: -50 },
-			leveling: { enabled: false, makeupDb: 6 },
-		};
 		expect(hasActiveStage(off)).toBe(false);
 		expect(
 			hasActiveStage({
 				...off,
 				gate: { enabled: true, thresholdDb: -50 },
+			}),
+		).toBe(true);
+	});
+
+	it('ignores the channel mode', () => {
+		// A mono downmix is a change, but not a DSP stage
+		expect(hasActiveStage({ ...off, channelMode: 'mono-left' })).toBe(
+			false,
+		);
+	});
+});
+
+describe('hasActiveChange', () => {
+	const off = {
+		highPass: { enabled: false, hz: 80 },
+		gate: { enabled: false, thresholdDb: -50 },
+		leveling: { enabled: false, makeupDb: 6 },
+		channelMode: 'source' as const,
+	};
+
+	it('is false when nothing changes the audio', () => {
+		expect(hasActiveChange(off)).toBe(false);
+	});
+
+	it('is true for a mono downmix with no DSP stage', () => {
+		expect(hasActiveChange({ ...off, channelMode: 'mono-mix' })).toBe(true);
+		expect(hasActiveChange({ ...off, channelMode: 'mono-right' })).toBe(
+			true,
+		);
+	});
+
+	it('is true when a DSP stage is enabled', () => {
+		expect(
+			hasActiveChange({
+				...off,
+				highPass: { enabled: true, hz: 80 },
 			}),
 		).toBe(true);
 	});

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -3,7 +3,7 @@
  * @module tests/unit/main
  */
 
-import { App } from 'obsidian';
+import { App, Notice } from 'obsidian';
 import AudioRecorderPlugin from 'src/main';
 import { DEFAULT_SETTINGS } from 'src/settings/settingsSchema';
 import type { SaveProgress } from 'src/types';
@@ -82,11 +82,15 @@ interface SilentChannelHooks {
 	maybeSuggestMonoConversion(result: {
 		audioPaths: string[];
 		notePath: null;
+		trackFiles?: { trackIndex: number; files: string[] }[];
+		durationSeconds?: number;
 	}): Promise<void>;
 	showSilentChannelNotice(
-		file: unknown,
-		keepMode: string,
-		silentSide: string,
+		suggestions: {
+			file: { path: string; name: string };
+			keepMode: string;
+			silentSide: string;
+		}[],
 	): void;
 	openMonoConversion(file: unknown, keepMode: string): void;
 }
@@ -697,7 +701,7 @@ describe('AudioRecorderPlugin silent-channel suggestion', () => {
 		file: unknown;
 	} {
 		const { plugin } = createPlugin([{}]);
-		const file = { path: 'rec.wav' };
+		const file = { path: 'rec.wav', name: 'rec.wav' };
 		plugin.app.vault.getFileByPath = jest.fn().mockReturnValue(file);
 		const hooks = plugin as unknown as SilentChannelHooks;
 		hooks.settings = {
@@ -739,8 +743,11 @@ describe('AudioRecorderPlugin silent-channel suggestion', () => {
 		expect(detectSilentChannel).toHaveBeenCalledWith(
 			expect.anything(),
 			file,
+			{ knownDurationSeconds: undefined },
 		);
-		expect(noticeSpy).toHaveBeenCalledWith(file, 'mono-left', 'right');
+		expect(noticeSpy).toHaveBeenCalledWith([
+			{ file, keepMode: 'mono-left', silentSide: 'right' },
+		]);
 	});
 
 	it('labels a silent left channel and keeps the right', async () => {
@@ -759,7 +766,54 @@ describe('AudioRecorderPlugin silent-channel suggestion', () => {
 			notePath: null,
 		});
 
-		expect(noticeSpy).toHaveBeenCalledWith(file, 'mono-right', 'left');
+		expect(noticeSpy).toHaveBeenCalledWith([
+			{ file, keepMode: 'mono-right', silentSide: 'left' },
+		]);
+	});
+
+	it('checks the first saved file of every track sequentially', async () => {
+		const { plugin, hooks } = primedPlugin();
+		const first = { path: 'loopback.webm', name: 'loopback.webm' };
+		const second = { path: 'mic.webm', name: 'mic.webm' };
+		plugin.app.vault.getFileByPath = jest.fn((path: string) =>
+			path === first.path ? first : second,
+		);
+		(detectSilentChannel as jest.Mock)
+			.mockResolvedValueOnce(null)
+			.mockResolvedValueOnce({
+				silentChannel: 1,
+				audioChannel: 0,
+				keepMode: 'mono-left',
+			});
+		const noticeSpy = jest
+			.spyOn(hooks, 'showSilentChannelNotice')
+			.mockImplementation(() => undefined);
+
+		await hooks.maybeSuggestMonoConversion({
+			audioPaths: [first.path, second.path],
+			notePath: null,
+			durationSeconds: 30,
+			trackFiles: [
+				{ trackIndex: 0, files: [first.path, 'loopback-part2.webm'] },
+				{ trackIndex: 1, files: [second.path, 'mic-part2.webm'] },
+			],
+		});
+
+		expect(detectSilentChannel).toHaveBeenNthCalledWith(
+			1,
+			expect.anything(),
+			first,
+			{ knownDurationSeconds: 30 },
+		);
+		expect(detectSilentChannel).toHaveBeenNthCalledWith(
+			2,
+			expect.anything(),
+			second,
+			{ knownDurationSeconds: 30 },
+		);
+		expect(noticeSpy).toHaveBeenCalledWith([
+			{ file: second, keepMode: 'mono-left', silentSide: 'right' },
+		]);
 	});
 
 	it('does nothing when the setting is disabled', async () => {
@@ -803,10 +857,75 @@ describe('AudioRecorderPlugin silent-channel suggestion', () => {
 		hooks.openMonoConversion(file, 'mono-left');
 
 		expect(ConversionModal).toHaveBeenCalledTimes(1);
-		// The channel mode is the 6th constructor argument
-		expect((ConversionModal as jest.Mock).mock.calls[0][5]).toBe(
-			'mono-left',
+		expect((ConversionModal as jest.Mock).mock.calls[0][3]).toEqual(
+			expect.objectContaining({ initialChannelMode: 'mono-left' }),
 		);
 		expect(mockConversionModalOpen).toHaveBeenCalled();
+	});
+
+	it('renders a native keyboard-accessible action and hides a single notice on click', () => {
+		const { hooks, file } = primedPlugin();
+		const openSpy = jest
+			.spyOn(hooks, 'openMonoConversion')
+			.mockImplementation(() => undefined);
+
+		hooks.showSilentChannelNotice([
+			{ file, keepMode: 'mono-left', silentSide: 'right' },
+		]);
+
+		const notice = (Notice as jest.Mock).mock.instances.at(-1) as {
+			message: DocumentFragment;
+			hide: jest.Mock;
+		};
+		const button = notice.message.querySelector<HTMLButtonElement>(
+			'.aar-silent-channel-convert',
+		);
+		expect(button?.tagName).toBe('BUTTON');
+		expect(button?.type).toBe('button');
+		button?.click();
+		expect(notice.hide).toHaveBeenCalled();
+		expect(openSpy).toHaveBeenCalledWith(file, 'mono-left');
+	});
+
+	it('replaces a previous persistent silent-channel notice', () => {
+		const { hooks, file } = primedPlugin();
+		hooks.showSilentChannelNotice([
+			{ file, keepMode: 'mono-left', silentSide: 'right' },
+		]);
+		const first = (Notice as jest.Mock).mock.instances.at(-1) as {
+			hide: jest.Mock;
+		};
+
+		hooks.showSilentChannelNotice([
+			{ file, keepMode: 'mono-left', silentSide: 'right' },
+		]);
+
+		expect(first.hide).toHaveBeenCalled();
+	});
+
+	it('renders one conversion action per affected track', () => {
+		const { hooks, file } = primedPlugin();
+		const second = { path: 'mic-2.wav', name: 'mic-2.wav' };
+		const openSpy = jest
+			.spyOn(hooks, 'openMonoConversion')
+			.mockImplementation(() => undefined);
+
+		hooks.showSilentChannelNotice([
+			{ file, keepMode: 'mono-left', silentSide: 'right' },
+			{ file: second, keepMode: 'mono-right', silentSide: 'left' },
+		]);
+
+		const notice = (Notice as jest.Mock).mock.instances.at(-1) as {
+			message: DocumentFragment;
+			hide: jest.Mock;
+		};
+		const buttons = notice.message.querySelectorAll<HTMLButtonElement>(
+			'.aar-silent-channel-convert',
+		);
+		expect(buttons).toHaveLength(2);
+		buttons[1]?.click();
+		expect(openSpy).toHaveBeenCalledWith(second, 'mono-right');
+		// Keep the aggregate notice available so the other file can be fixed.
+		expect(notice.hide).not.toHaveBeenCalled();
 	});
 });

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -64,6 +64,33 @@ jest.mock('src/ui/RecoveryModal', () => ({
 	})),
 }));
 
+jest.mock('src/recording/silentChannelDetector', () => ({
+	detectSilentChannel: jest.fn(),
+}));
+
+const mockConversionModalOpen = jest.fn();
+jest.mock('src/ui/ConversionModal', () => ({
+	ConversionModal: jest.fn().mockImplementation(() => ({
+		open: mockConversionModalOpen,
+	})),
+}));
+
+interface SilentChannelHooks {
+	settings: typeof DEFAULT_SETTINGS;
+	playerRegistrar: { primeSavedRecordingsForEnhancement: jest.Mock };
+	encodingWorker: unknown;
+	maybeSuggestMonoConversion(result: {
+		audioPaths: string[];
+		notePath: null;
+	}): Promise<void>;
+	showSilentChannelNotice(
+		file: unknown,
+		keepMode: string,
+		silentSide: string,
+	): void;
+	openMonoConversion(file: unknown, keepMode: string): void;
+}
+
 // Fixture path: in production the directory comes from manifest.dir
 const PLUGIN_DIR = 'config-dir/plugins/advanced-audio-recorder';
 const DATA_PATH = `${PLUGIN_DIR}/data.json`;
@@ -655,5 +682,131 @@ describe('AudioRecorderPlugin background transcription status bar', () => {
 			progress(60, 'Second job'),
 			expect.objectContaining({ onActivate: restoreSecond }),
 		);
+	});
+});
+
+describe('AudioRecorderPlugin silent-channel suggestion', () => {
+	const { detectSilentChannel } = jest.requireMock(
+		'src/recording/silentChannelDetector',
+	);
+	const { ConversionModal } = jest.requireMock('src/ui/ConversionModal');
+
+	function primedPlugin(overrides?: Partial<typeof DEFAULT_SETTINGS>): {
+		plugin: AudioRecorderPlugin;
+		hooks: SilentChannelHooks;
+		file: unknown;
+	} {
+		const { plugin } = createPlugin([{}]);
+		const file = { path: 'rec.wav' };
+		plugin.app.vault.getFileByPath = jest.fn().mockReturnValue(file);
+		const hooks = plugin as unknown as SilentChannelHooks;
+		hooks.settings = {
+			...DEFAULT_SETTINGS,
+			detectSilentChannelOnSave: true,
+			...overrides,
+		};
+		hooks.playerRegistrar = {
+			primeSavedRecordingsForEnhancement: jest.fn(),
+		};
+		hooks.encodingWorker = null;
+		return { plugin, hooks, file };
+	}
+
+	beforeEach(() => {
+		(detectSilentChannel as jest.Mock).mockReset();
+		mockConversionModalOpen.mockClear();
+		(ConversionModal as jest.Mock).mockClear();
+	});
+
+	it('prompts a mono conversion for a lopsided stereo recording', async () => {
+		const { hooks, file } = primedPlugin();
+		(detectSilentChannel as jest.Mock).mockResolvedValue({
+			silentChannel: 1,
+			audioChannel: 0,
+			keepMode: 'mono-left',
+		});
+		// The Notice/DOM path is exercised through showSilentChannelNotice;
+		// here we assert the detection-to-prompt wiring without the Notice
+		const noticeSpy = jest
+			.spyOn(hooks, 'showSilentChannelNotice')
+			.mockImplementation(() => undefined);
+
+		await hooks.maybeSuggestMonoConversion({
+			audioPaths: ['rec.wav'],
+			notePath: null,
+		});
+
+		expect(detectSilentChannel).toHaveBeenCalledWith(
+			expect.anything(),
+			file,
+		);
+		expect(noticeSpy).toHaveBeenCalledWith(file, 'mono-left', 'right');
+	});
+
+	it('labels a silent left channel and keeps the right', async () => {
+		const { hooks, file } = primedPlugin();
+		(detectSilentChannel as jest.Mock).mockResolvedValue({
+			silentChannel: 0,
+			audioChannel: 1,
+			keepMode: 'mono-right',
+		});
+		const noticeSpy = jest
+			.spyOn(hooks, 'showSilentChannelNotice')
+			.mockImplementation(() => undefined);
+
+		await hooks.maybeSuggestMonoConversion({
+			audioPaths: ['rec.wav'],
+			notePath: null,
+		});
+
+		expect(noticeSpy).toHaveBeenCalledWith(file, 'mono-right', 'left');
+	});
+
+	it('does nothing when the setting is disabled', async () => {
+		const { hooks } = primedPlugin({ detectSilentChannelOnSave: false });
+
+		await hooks.maybeSuggestMonoConversion({
+			audioPaths: ['rec.wav'],
+			notePath: null,
+		});
+
+		expect(detectSilentChannel).not.toHaveBeenCalled();
+	});
+
+	it('does nothing when no lopsided channel is detected', async () => {
+		const { hooks } = primedPlugin();
+		(detectSilentChannel as jest.Mock).mockResolvedValue(null);
+		const noticeSpy = jest.spyOn(hooks, 'showSilentChannelNotice');
+
+		await hooks.maybeSuggestMonoConversion({
+			audioPaths: ['rec.wav'],
+			notePath: null,
+		});
+
+		expect(noticeSpy).not.toHaveBeenCalled();
+	});
+
+	it('does nothing when there are no saved files', async () => {
+		const { hooks } = primedPlugin();
+
+		await hooks.maybeSuggestMonoConversion({
+			audioPaths: [],
+			notePath: null,
+		});
+
+		expect(detectSilentChannel).not.toHaveBeenCalled();
+	});
+
+	it('opens the conversion dialog preset to the kept channel', () => {
+		const { hooks, file } = primedPlugin();
+
+		hooks.openMonoConversion(file, 'mono-left');
+
+		expect(ConversionModal).toHaveBeenCalledTimes(1);
+		// The channel mode is the 6th constructor argument
+		expect((ConversionModal as jest.Mock).mock.calls[0][5]).toBe(
+			'mono-left',
+		);
+		expect(mockConversionModalOpen).toHaveBeenCalled();
 	});
 });

--- a/tests/unit/silentChannelDetector.test.ts
+++ b/tests/unit/silentChannelDetector.test.ts
@@ -10,6 +10,12 @@ import {
 } from 'src/recording/silentChannelDetector';
 import type { App, TFile } from 'obsidian';
 
+jest.mock('src/utils/AudioFileAnalyzer', () => ({
+	probeAudioMetadata: jest.fn(),
+}));
+
+const { probeAudioMetadata } = jest.requireMock('src/utils/AudioFileAnalyzer');
+
 /** Full-scale-ish tone; RMS ~0.35 (about -9 dBFS). */
 function loud(length = 2048): Float32Array {
 	const data = new Float32Array(length);
@@ -79,8 +85,29 @@ describe('analyzeChannelBalance', () => {
 	it('honors custom floor and gap thresholds', () => {
 		const quiet = new Float32Array(2048).fill(0.02);
 		// Raise the floor above the quiet channel and shrink the gap
-		const result = analyzeChannelBalance([loud(), quiet], -30, 10);
+		const result = analyzeChannelBalance([loud(), quiet], {
+			floorDb: -30,
+			minGapDb: 10,
+		});
 		expect(result?.silentChannel).toBe(1);
+	});
+
+	it('preserves a channel containing a short real signal', () => {
+		const continuous = new Float32Array(4096).fill(0.3);
+		const sparse = new Float32Array(4096);
+		sparse.set(new Float32Array(256).fill(0.2), 2048);
+
+		expect(
+			analyzeChannelBalance([continuous, sparse], { windowFrames: 256 }),
+		).toBeNull();
+	});
+
+	it('does not treat tiny device noise as the audio channel', () => {
+		const almostSilent = new Float32Array(2048).fill(
+			Math.pow(10, -59 / 20),
+		);
+
+		expect(analyzeChannelBalance([almostSilent, silent()])).toBeNull();
 	});
 });
 
@@ -90,6 +117,7 @@ describe('detectSilentChannel', () => {
 			public numberOfChannels: number,
 			public duration: number,
 			private readonly channels: Float32Array[],
+			public sampleRate = 44100,
 		) {}
 		getChannelData(index: number): Float32Array {
 			return this.channels[index] ?? new Float32Array();
@@ -108,6 +136,11 @@ describe('detectSilentChannel', () => {
 	const file = { path: 'rec.wav' } as unknown as TFile;
 
 	beforeEach(() => {
+		(probeAudioMetadata as jest.Mock).mockReset().mockResolvedValue({
+			durationSeconds: 5,
+			sampleRate: 44100,
+			channels: 2,
+		});
 		decodeAudioData = jest.fn();
 		close = jest.fn().mockResolvedValue(undefined);
 		(global as Record<string, unknown>).AudioContext = jest
@@ -127,22 +160,64 @@ describe('detectSilentChannel', () => {
 	});
 
 	it('returns null and closes the context for a mono file', async () => {
-		decodeAudioData.mockResolvedValue(new FakeAudioBuffer(1, 5, [loud()]));
+		(probeAudioMetadata as jest.Mock).mockResolvedValue({
+			durationSeconds: 5,
+			sampleRate: 44100,
+			channels: 1,
+		});
+		const app = makeApp();
 
-		expect(await detectSilentChannel(makeApp(), file)).toBeNull();
-		expect(close).toHaveBeenCalled();
+		expect(await detectSilentChannel(app, file)).toBeNull();
+		expect(decodeAudioData).not.toHaveBeenCalled();
+		expect(close).not.toHaveBeenCalled();
 	});
 
-	it('skips files longer than the decode cap', async () => {
+	it('skips a known long recording before reading or decoding it', async () => {
+		const app = makeApp();
+
+		expect(
+			await detectSilentChannel(app, file, {
+				knownDurationSeconds: 3600,
+				maxDecodeSeconds: 60,
+			}),
+		).toBeNull();
+		expect(app.vault.readBinary).not.toHaveBeenCalled();
+		expect(probeAudioMetadata).not.toHaveBeenCalled();
+		expect(decodeAudioData).not.toHaveBeenCalled();
+	});
+
+	it('skips a long file from metadata before full decode', async () => {
+		(probeAudioMetadata as jest.Mock).mockResolvedValue({
+			durationSeconds: 3600,
+			sampleRate: 44100,
+			channels: 2,
+		});
+
+		expect(
+			await detectSilentChannel(makeApp(), file, {
+				maxDecodeSeconds: 60,
+			}),
+		).toBeNull();
+		expect(decodeAudioData).not.toHaveBeenCalled();
+	});
+
+	it('keeps the decoded-duration guard when metadata is unavailable', async () => {
+		(probeAudioMetadata as jest.Mock).mockResolvedValue(null);
 		decodeAudioData.mockResolvedValue(
 			new FakeAudioBuffer(2, 3600, [loud(), silent()]),
 		);
 
-		expect(await detectSilentChannel(makeApp(), file, 60)).toBeNull();
+		expect(
+			await detectSilentChannel(makeApp(), file, {
+				maxDecodeSeconds: 60,
+			}),
+		).toBeNull();
+		expect(close).toHaveBeenCalled();
 	});
 
 	it('returns null and closes the context when decoding fails', async () => {
 		const warn = jest.spyOn(console, 'warn').mockImplementation();
+		(probeAudioMetadata as jest.Mock).mockResolvedValue(null);
 		decodeAudioData.mockRejectedValue(new Error('bad data'));
 
 		expect(await detectSilentChannel(makeApp(), file)).toBeNull();

--- a/tests/unit/silentChannelDetector.test.ts
+++ b/tests/unit/silentChannelDetector.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Unit tests for the post-recording lopsided-stereo detector: the pure
+ * channel-balance analysis and the decode wrapper around it.
+ * @module tests/unit/silentChannelDetector.test
+ */
+
+import {
+	analyzeChannelBalance,
+	detectSilentChannel,
+} from 'src/recording/silentChannelDetector';
+import type { App, TFile } from 'obsidian';
+
+/** Full-scale-ish tone; RMS ~0.35 (about -9 dBFS). */
+function loud(length = 2048): Float32Array {
+	const data = new Float32Array(length);
+	for (let i = 0; i < length; i++) {
+		data[i] = Math.sin((2 * Math.PI * 440 * i) / 44100) * 0.5;
+	}
+	return data;
+}
+
+/** Effectively silent channel (well below the -60 dBFS floor). */
+function silent(length = 2048): Float32Array {
+	return new Float32Array(length);
+}
+
+/** Faint noise around -70 dBFS, still below the silence floor. */
+function faint(length = 2048): Float32Array {
+	return new Float32Array(length).fill(0.0002);
+}
+
+describe('analyzeChannelBalance', () => {
+	it('flags a silent right channel and keeps the left', () => {
+		const result = analyzeChannelBalance([loud(), silent()]);
+
+		expect(result).toEqual({
+			silentChannel: 1,
+			audioChannel: 0,
+			keepMode: 'mono-left',
+		});
+	});
+
+	it('flags a silent left channel and keeps the right', () => {
+		const result = analyzeChannelBalance([silent(), loud()]);
+
+		expect(result).toEqual({
+			silentChannel: 0,
+			audioChannel: 1,
+			keepMode: 'mono-right',
+		});
+	});
+
+	it('treats a near-silent (noise-floor) channel as silent', () => {
+		const result = analyzeChannelBalance([loud(), faint()]);
+
+		expect(result?.silentChannel).toBe(1);
+	});
+
+	it('returns null for a balanced stereo signal', () => {
+		expect(analyzeChannelBalance([loud(), loud()])).toBeNull();
+	});
+
+	it('returns null when both channels are silent', () => {
+		expect(analyzeChannelBalance([silent(), silent()])).toBeNull();
+	});
+
+	it('returns null for mono and multichannel inputs', () => {
+		expect(analyzeChannelBalance([loud()])).toBeNull();
+		expect(analyzeChannelBalance([loud(), silent(), loud()])).toBeNull();
+	});
+
+	it('requires the gap to exceed the minimum before flagging', () => {
+		// Quiet-but-present channel: below the loud one, but not by the
+		// 40 dB gap and not under the silence floor
+		const quiet = new Float32Array(2048).fill(0.02); // ~-34 dBFS
+		expect(analyzeChannelBalance([loud(), quiet])).toBeNull();
+	});
+
+	it('honors custom floor and gap thresholds', () => {
+		const quiet = new Float32Array(2048).fill(0.02);
+		// Raise the floor above the quiet channel and shrink the gap
+		const result = analyzeChannelBalance([loud(), quiet], -30, 10);
+		expect(result?.silentChannel).toBe(1);
+	});
+});
+
+describe('detectSilentChannel', () => {
+	class FakeAudioBuffer {
+		constructor(
+			public numberOfChannels: number,
+			public duration: number,
+			private readonly channels: Float32Array[],
+		) {}
+		getChannelData(index: number): Float32Array {
+			return this.channels[index] ?? new Float32Array();
+		}
+	}
+
+	let decodeAudioData: jest.Mock;
+	let close: jest.Mock;
+
+	function makeApp(bytes = new ArrayBuffer(64)): App {
+		return {
+			vault: { readBinary: jest.fn().mockResolvedValue(bytes) },
+		} as unknown as App;
+	}
+
+	const file = { path: 'rec.wav' } as unknown as TFile;
+
+	beforeEach(() => {
+		decodeAudioData = jest.fn();
+		close = jest.fn().mockResolvedValue(undefined);
+		(global as Record<string, unknown>).AudioContext = jest
+			.fn()
+			.mockImplementation(() => ({ decodeAudioData, close }));
+	});
+
+	it('detects a lopsided stereo recording', async () => {
+		decodeAudioData.mockResolvedValue(
+			new FakeAudioBuffer(2, 5, [loud(), silent()]),
+		);
+
+		const result = await detectSilentChannel(makeApp(), file);
+
+		expect(result?.keepMode).toBe('mono-left');
+		expect(close).toHaveBeenCalled();
+	});
+
+	it('returns null and closes the context for a mono file', async () => {
+		decodeAudioData.mockResolvedValue(new FakeAudioBuffer(1, 5, [loud()]));
+
+		expect(await detectSilentChannel(makeApp(), file)).toBeNull();
+		expect(close).toHaveBeenCalled();
+	});
+
+	it('skips files longer than the decode cap', async () => {
+		decodeAudioData.mockResolvedValue(
+			new FakeAudioBuffer(2, 3600, [loud(), silent()]),
+		);
+
+		expect(await detectSilentChannel(makeApp(), file, 60)).toBeNull();
+	});
+
+	it('returns null and closes the context when decoding fails', async () => {
+		const warn = jest.spyOn(console, 'warn').mockImplementation();
+		decodeAudioData.mockRejectedValue(new Error('bad data'));
+
+		expect(await detectSilentChannel(makeApp(), file)).toBeNull();
+		expect(close).toHaveBeenCalled();
+		warn.mockRestore();
+	});
+
+	it('returns null when the file cannot be read', async () => {
+		const warn = jest.spyOn(console, 'warn').mockImplementation();
+		const app = {
+			vault: {
+				readBinary: jest.fn().mockRejectedValue(new Error('missing')),
+			},
+		} as unknown as App;
+
+		expect(await detectSilentChannel(app, file)).toBeNull();
+		warn.mockRestore();
+	});
+});


### PR DESCRIPTION
Follow-up to #57 and #58 (both merged). Rounds out the mono-audio work with cleanup downmixing, post-save silent-channel detection, and conversion presets.

## What changed

**Mono downmix in Audio cleanup.** The Clean up audio dialog gains a **Channels** dropdown (`Same as source` / `Mono (mix all channels)` / `Mono (left channel)` / `Mono (right channel)`). Downmix runs before the DSP stages, so cleanup and mono conversion happen in one pass, and a pure downmix works with every DSP stage disabled.

**Automatic silent-channel prompt.** The opt-out **Detect silent channel after recording** setting (default on) checks one file from every output track for the stereo-with-one-silent-channel pattern. Auto-split sessions inspect the first part of each track. A single accessible notice identifies every affected file and opens conversion preset to keep the channel carrying audio.

The detector is bounded and conservative:

- RecordingManager carries pause-aware active duration into the save result; sessions over 20 minutes are rejected before file I/O.
- Container metadata is probed before Web Audio decoding, so mono, non-stereo, and unexpectedly long files do not pay for a full decode.
- Accepted tracks are decoded sequentially to bound peak memory.
- Peak RMS over short windows replaces whole-file RMS, preserving brief real content that would otherwise be diluted by long silence.
- The proposed audio channel must also reach a useful minimum level, preventing nearly empty recordings with tiny device noise from triggering.
- Generation guards discard stale asynchronous results; persistent notices are deduplicated and released on plugin unload.

**Conversion channel preset.** `ConversionModal` accepts named options including `initialChannelMode`, so the prompt opens with the recommended channel selected. The named options object replaces the previous brittle positional collaborator arguments.

**Accessible notice action.** Conversion actions are native buttons (keyboard-operable by default), styled as compact links. Multiple affected tracks receive separate actions in one notice.

The channel-count display in the file-info modal was already implemented, so no additional change was needed there.

## Tests

Review follow-up added coverage for:

- rejecting a known long recording before `readBinary`, metadata probing, or decode;
- metadata-based mono/long-file early exits and decoded-duration fallback;
- sparse real channel content and nearly silent device noise;
- balanced-first / lopsided-second multi-track output;
- one candidate per track and first-part selection for auto-split;
- accessible native notice actions, multi-file actions, and notice replacement;
- pause-aware duration propagation;
- named ConversionModal channel preset initialization.

Full local validation:

- 108 test suites / 1599 tests passing
- Coverage: 85.59% statements, 76.75% branches, 77.06% functions, 85.58% lines
- Production build and lint passing

## Docs

Updated `audio-cleanup.md`, `recording.md`, `settings-reference.md`, and `troubleshooting.md` for cleanup channels, per-track detection, early duration skipping, and conversion behavior.

## Manual verification

Worth confirming on a real Windows dual-input interface:

- left-only and right-only microphone recordings trigger the correct preset;
- a short real event on the quieter channel prevents a false prompt;
- multi-track output reports a lopsided microphone track even when the first track is balanced stereo;
- recordings over 20 minutes do not produce a post-save decode spike;
- keyboard focus and Enter/Space activate the notice action.

The cleanup and Audio input screenshots still lag the new controls and should be re-shot before release.