### PR TITLE
fix(player): keep context menu and timecode clicks working in pop-out windows

### DIFF
--- a/docs/audio-player.md
+++ b/docs/audio-player.md
@@ -49,6 +49,8 @@ The player integrates with Obsidian's own embed rendering rather than bolting on
 
 A single audio element is shared per file across view modes, so the same playback is controlled whether you are in Reading view or Live Preview, and switching modes does not stop and restart playback.
 
+The player also keeps working in **pop-out windows**: moving a note that embeds a recording into its own window preserves the right-click menu and timecode-link playback there, because the plugin binds those handlers to each window's own document rather than only the main one.
+
 > **Desktop and mobile.** The enhanced player works in both the Obsidian desktop app and the mobile app (iOS and Android), taking over audio embeds wherever Obsidian renders them; waveform extraction relies on the Web Audio API available in both. See [Mobile support](mobile-support.md).
 
 ---

--- a/src/player/EnhancedPlayerRegistrar.ts
+++ b/src/player/EnhancedPlayerRegistrar.ts
@@ -23,9 +23,9 @@
  * (issue #39). Only the master toggle flip re-renders open views
  * (leaf.rebuildView), because it changes what every embed is in both
  * modes at once. When the internal registry API is unavailable, a
- * Markdown post-processor takes over embeds (Reading view only). A
- * document-level click handler routes timecode links to a live player.
- * All paths respect the feature toggle.
+ * Markdown post-processor takes over embeds (Reading view only). A click
+ * handler bound on every window's document (main and pop-out) routes timecode
+ * links to a live player. All paths respect the feature toggle.
  * @module player/EnhancedPlayerRegistrar
  */
 
@@ -56,6 +56,7 @@ import {
 	wikiLinkTargetAtCursor,
 } from './timecodeLinks';
 import { probeMediaKind, MEDIA_KIND, type MediaKind } from './mediaProbe';
+import { registerDomEventOnAllWindows } from '../utils/multiWindowDomEvents';
 import { MediaEmbedShell } from './MediaEmbedShell';
 import type { MediaKindStore } from './MediaKindStore';
 import { shouldEnhance } from './playerMode';
@@ -157,8 +158,14 @@ export class EnhancedPlayerRegistrar {
 			}
 		});
 
-		this.plugin.registerDomEvent(
-			activeDocument,
+		// Bind the timecode-link click handler on every window's document,
+		// including pop-out windows, so a transcript timestamp clicked in a
+		// popped-out note routes to a live player instead of being ignored
+		// (a pop-out has its own document that never shares events with the
+		// main window).
+		registerDomEventOnAllWindows(
+			this.plugin,
+			this.app,
 			'click',
 			(event) => {
 				this.handleTimecodeClick(event);

--- a/src/player/EnhancedPlayerRegistrar.ts
+++ b/src/player/EnhancedPlayerRegistrar.ts
@@ -57,6 +57,7 @@ import {
 } from './timecodeLinks';
 import { probeMediaKind, MEDIA_KIND, type MediaKind } from './mediaProbe';
 import { registerDomEventOnAllWindows } from '../utils/multiWindowDomEvents';
+import { markdownViewContaining } from '../utils/windowScopedViews';
 import { MediaEmbedShell } from './MediaEmbedShell';
 import type { MediaKindStore } from './MediaKindStore';
 import { shouldEnhance } from './playerMode';
@@ -621,7 +622,19 @@ export class EnhancedPlayerRegistrar {
 		if (startSeconds === null) {
 			return;
 		}
-		const sourcePath = this.app.workspace.getActiveFile()?.path ?? '';
+		// Resolve the link against the note that actually contains the clicked
+		// timecode link, located from the DOM rather than the globally active
+		// file, so a relative link stays correct when the note lives in a
+		// pop-out window or a background split whose note is not the active one.
+		// This mirrors the resolution the player context menu uses.
+		const target = event.target as Node | null;
+		const owningView = target
+			? markdownViewContaining(this.app, target)
+			: null;
+		const sourcePath =
+			owningView?.file?.path ??
+			this.app.workspace.getActiveFile()?.path ??
+			'';
 		const file = this.app.metadataCache.getFirstLinkpathDest(
 			linkPath,
 			sourcePath,
@@ -722,16 +735,22 @@ export class EnhancedPlayerRegistrar {
 	}
 
 	/**
-	 * Reads the wikilink target at a clicked node from the active editor's
-	 * source. Uses CodeMirror's DOM-to-offset mapping (the same internal API
-	 * the context menu uses) to find the line and column, then extracts the
-	 * link there. Returns null when the click is not on a wikilink or the
-	 * editor internals are unavailable.
+	 * Reads the wikilink target at a clicked node from the editor of the note
+	 * that actually contains the node, so a Live Preview timecode link clicked
+	 * in a pop-out window or a background split reads from that note's editor
+	 * rather than the globally active one, whose CodeMirror instance does not
+	 * own this node. Uses CodeMirror's DOM-to-offset mapping (the same internal
+	 * API the context menu uses) to find the line and column, then extracts the
+	 * link there. Falls back to the active view for a detached render, and
+	 * returns null when the click is not on a wikilink or the editor internals
+	 * are unavailable.
 	 * @param node - The clicked DOM node inside the editor
 	 * @returns The wikilink target, or null when none is under the click
 	 */
 	private resolveEditorLinkTarget(node: Node): string | null {
-		const view = this.app.workspace.getActiveViewOfType(MarkdownView);
+		const view =
+			markdownViewContaining(this.app, node) ??
+			this.app.workspace.getActiveViewOfType(MarkdownView);
 		if (!view) {
 			return null;
 		}

--- a/src/ui/ContextMenu.ts
+++ b/src/ui/ContextMenu.ts
@@ -17,6 +17,7 @@ import type { MarkdownFileInfo } from 'obsidian';
 import type { MenuItem } from 'obsidian';
 import { AAR_MENU_SECTION, PLUGIN_LOG_PREFIX } from '../constants';
 import { registerDomEventOnAllWindows } from '../utils/multiWindowDomEvents';
+import { markdownViewContaining } from '../utils/windowScopedViews';
 import { getPlayerEmbedActions } from '../player/playerEmbedActions';
 import { MARKER_KIND, type MarkerKind } from '../markers/markerModel';
 import { isAudioFile } from '../utils/audioFile';
@@ -204,7 +205,7 @@ export class ContextMenu {
 		sourcePath: string;
 		view: MarkdownView | null;
 	} {
-		const owningView = this.markdownViewContaining(embed);
+		const owningView = markdownViewContaining(this.app, embed);
 		if (owningView) {
 			return {
 				sourcePath: owningView.file?.path ?? '',
@@ -216,28 +217,6 @@ export class ContextMenu {
 			sourcePath: activeFile ? activeFile.path : '',
 			view: this.app.workspace.getActiveViewOfType(MarkdownView),
 		};
-	}
-
-	/**
-	 * Finds the open MarkdownView whose container holds the given embed.
-	 * `Node.contains` is scoped to the element's own document, so an embed
-	 * matches only the view in its own window, which is what makes the lookup
-	 * correct across pop-out windows.
-	 * @param embed - The embed element to locate
-	 * @returns The owning MarkdownView, or null when none holds it
-	 */
-	private markdownViewContaining(embed: HTMLElement): MarkdownView | null {
-		const owning: MarkdownView[] = [];
-		this.app.workspace.iterateAllLeaves((leaf) => {
-			const view = leaf.view;
-			if (
-				view instanceof MarkdownView &&
-				view.containerEl.contains(embed)
-			) {
-				owning.push(view);
-			}
-		});
-		return owning[0] ?? null;
 	}
 
 	/**

--- a/src/ui/ContextMenu.ts
+++ b/src/ui/ContextMenu.ts
@@ -16,6 +16,7 @@ import {
 import type { MarkdownFileInfo } from 'obsidian';
 import type { MenuItem } from 'obsidian';
 import { AAR_MENU_SECTION, PLUGIN_LOG_PREFIX } from '../constants';
+import { registerDomEventOnAllWindows } from '../utils/multiWindowDomEvents';
 import { getPlayerEmbedActions } from '../player/playerEmbedActions';
 import { MARKER_KIND, type MarkerKind } from '../markers/markerModel';
 import { isAudioFile } from '../utils/audioFile';
@@ -80,12 +81,16 @@ export class ContextMenu {
 	}
 
 	/**
-	 * Registers a global context menu event for audio players.
-	 * Detects right-clicks on standard Obsidian audio embeds and shows the file menu.
+	 * Registers a context menu event for audio players on every Obsidian
+	 * window. Detects right-clicks on standard Obsidian audio embeds and shows
+	 * the file menu. Binding per window (not once to activeDocument) is what
+	 * keeps the menu working after a note is moved into a pop-out window, whose
+	 * document does not share events with the main window.
 	 */
 	private registerPlayerMenu(): void {
-		this.plugin.registerDomEvent(
-			activeDocument,
+		registerDomEventOnAllWindows(
+			this.plugin,
+			this.app,
 			'contextmenu',
 			(event: MouseEvent) => {
 				const target = event.target as HTMLElement;

--- a/src/ui/ContextMenu.ts
+++ b/src/ui/ContextMenu.ts
@@ -108,10 +108,13 @@ export class ContextMenu {
 					return;
 				}
 
-				// Resolve the file from the link text.
-				// We use the active file as the source path to handle relative links correctly.
-				const activeFile = this.app.workspace.getActiveFile();
-				const sourcePath = activeFile ? activeFile.path : '';
+				// Resolve the file from the link text against the note that
+				// actually contains this embed, located from the DOM rather than
+				// the globally active file. This is what keeps a relative link
+				// correct when the embed lives in a pop-out window or a
+				// background split, whose note is not the active one.
+				const { sourcePath, view: owningView } =
+					this.resolveEmbedSource(embed as HTMLElement);
 				const file = this.app.metadataCache.getFirstLinkpathDest(
 					src,
 					sourcePath,
@@ -128,11 +131,11 @@ export class ContextMenu {
 
 					const menu = new Menu();
 
-					// Attempt to find the link in the editor to offer "Delete recording & link"
-					const activeView =
-						this.app.workspace.getActiveViewOfType(MarkdownView);
-					if (activeView) {
-						const editor = activeView.editor;
+					// Offer "Delete recording & link" from the same note the embed
+					// belongs to, so the editor lookup targets the pop-out or
+					// split that was right-clicked, not the active pane.
+					if (owningView) {
+						const editor = owningView.editor;
 						const editorView = (editor as EditorWithCM).cm;
 						if (editorView && editorView.posAtDOM) {
 							try {
@@ -184,6 +187,57 @@ export class ContextMenu {
 			},
 			{ capture: true },
 		);
+	}
+
+	/**
+	 * Resolves the note that contains an audio embed and its source path. The
+	 * embed is matched to the MarkdownView whose container holds it, so a
+	 * right-click resolves against the note the embed is actually in - a
+	 * pop-out window or a background split as well as the active pane - rather
+	 * than the globally active file. Falls back to the active file and view
+	 * when the embed cannot be tied to a view (e.g. a detached render).
+	 * @param embed - The right-clicked `.internal-embed` element
+	 * @returns The resolved source path and owning MarkdownView, or the active
+	 *   file and view as a fallback
+	 */
+	private resolveEmbedSource(embed: HTMLElement): {
+		sourcePath: string;
+		view: MarkdownView | null;
+	} {
+		const owningView = this.markdownViewContaining(embed);
+		if (owningView) {
+			return {
+				sourcePath: owningView.file?.path ?? '',
+				view: owningView,
+			};
+		}
+		const activeFile = this.app.workspace.getActiveFile();
+		return {
+			sourcePath: activeFile ? activeFile.path : '',
+			view: this.app.workspace.getActiveViewOfType(MarkdownView),
+		};
+	}
+
+	/**
+	 * Finds the open MarkdownView whose container holds the given embed.
+	 * `Node.contains` is scoped to the element's own document, so an embed
+	 * matches only the view in its own window, which is what makes the lookup
+	 * correct across pop-out windows.
+	 * @param embed - The embed element to locate
+	 * @returns The owning MarkdownView, or null when none holds it
+	 */
+	private markdownViewContaining(embed: HTMLElement): MarkdownView | null {
+		const owning: MarkdownView[] = [];
+		this.app.workspace.iterateAllLeaves((leaf) => {
+			const view = leaf.view;
+			if (
+				view instanceof MarkdownView &&
+				view.containerEl.contains(embed)
+			) {
+				owning.push(view);
+			}
+		});
+		return owning[0] ?? null;
 	}
 
 	/**

--- a/src/utils/multiWindowDomEvents.ts
+++ b/src/utils/multiWindowDomEvents.ts
@@ -1,0 +1,83 @@
+/**
+ * Document-level DOM event registration that spans every Obsidian window.
+ * @module utils/multiWindowDomEvents
+ */
+
+import { Component } from 'obsidian';
+import type { App, Plugin } from 'obsidian';
+
+/**
+ * Registers a document-level DOM event listener on the document of every
+ * Obsidian window - the main window, any pop-out window already open when
+ * this runs, and any pop-out opened later - and removes each listener when
+ * its window closes or the plugin unloads.
+ *
+ * Obsidian pop-out windows each own a separate `document`, and events raised
+ * inside one do not bubble into the main window. A single
+ * `registerDomEvent(activeDocument, ...)` therefore only ever covers the one
+ * window that was focused when it ran, so a note moved into a pop-out loses
+ * every delegated handler bound this way (its player context menu and its
+ * timecode-link clicks stop working). Binding per window is the direct fix.
+ *
+ * Each window's listener is owned by its own child {@link Component}: adding
+ * it as a plugin child makes plugin unload detach it, and `window-close`
+ * detaches it explicitly, so nothing outlives the window it belongs to.
+ *
+ * @param plugin - Owning plugin; its lifecycle bounds every listener
+ * @param app - Obsidian app, used to observe window open/close
+ * @param type - DOM event name to listen for on each window's document
+ * @param handler - Invoked with the event and the document it fired on
+ * @param options - Standard addEventListener options (e.g. capture)
+ */
+export function registerDomEventOnAllWindows<K extends keyof DocumentEventMap>(
+	plugin: Plugin,
+	app: App,
+	type: K,
+	handler: (event: DocumentEventMap[K], doc: Document) => void,
+	options?: boolean | AddEventListenerOptions,
+): void {
+	const { workspace } = app;
+	// One child Component per window document owns that window's listener. The
+	// map both prevents attaching the same document twice (the main window is
+	// reached by both the explicit attach and the leaf sweep) and lets
+	// window-close find the owner to unload.
+	const owners = new Map<Document, Component>();
+
+	const attach = (doc: Document): void => {
+		if (owners.has(doc)) {
+			return;
+		}
+		const owner = new Component();
+		owner.registerDomEvent(
+			doc,
+			type,
+			(event) => handler(event, doc),
+			options,
+		);
+		// addChild loads the owner at once (the plugin is already loaded), so
+		// the listener is live immediately and is removed on plugin unload.
+		plugin.addChild(owner);
+		owners.set(doc, owner);
+	};
+
+	const detach = (doc: Document): void => {
+		const owner = owners.get(doc);
+		if (!owner) {
+			return;
+		}
+		owners.delete(doc);
+		// removeChild unloads the owner, which removes its listener.
+		plugin.removeChild(owner);
+	};
+
+	// The currently focused window plus every window that already holds a leaf
+	// (the main window and any pop-out open when this runs); the map dedupes
+	// the overlap between the two.
+	attach(activeDocument);
+	workspace.iterateAllLeaves((leaf) => attach(leaf.getContainer().doc));
+
+	plugin.registerEvent(workspace.on('window-open', (win) => attach(win.doc)));
+	plugin.registerEvent(
+		workspace.on('window-close', (win) => detach(win.doc)),
+	);
+}

--- a/src/utils/windowScopedViews.ts
+++ b/src/utils/windowScopedViews.ts
@@ -1,0 +1,33 @@
+/**
+ * Window-scoped lookup of the MarkdownView that owns a DOM node. Used to
+ * resolve a right-clicked embed or a clicked timecode link against the note it
+ * actually lives in, so resolution stays correct in pop-out windows and
+ * background splits instead of assuming the globally active note.
+ * @module utils/windowScopedViews
+ */
+
+import { MarkdownView } from 'obsidian';
+import type { App } from 'obsidian';
+
+/**
+ * Finds the open MarkdownView whose container holds the given node.
+ * `Node.contains` is scoped to the node's own document, so a node matches only
+ * the view in its own window, which is what makes the lookup correct across
+ * pop-out windows and background splits rather than the globally active view.
+ * @param app - Obsidian app whose open leaves are searched
+ * @param node - The DOM node to locate (an embed element or a link node)
+ * @returns The owning MarkdownView, or null when none holds it
+ */
+export function markdownViewContaining(
+	app: App,
+	node: Node,
+): MarkdownView | null {
+	const owning: MarkdownView[] = [];
+	app.workspace.iterateAllLeaves((leaf) => {
+		const view = leaf.view;
+		if (view instanceof MarkdownView && view.containerEl.contains(node)) {
+			owning.push(view);
+		}
+	});
+	return owning[0] ?? null;
+}

--- a/tests/helpers/playbackHarness.ts
+++ b/tests/helpers/playbackHarness.ts
@@ -1,0 +1,115 @@
+/**
+ * Shared harness for the player integration suites: one controllable audio
+ * element installed as the global Audio factory, an in-memory sidecar store,
+ * and the small readers both suites use. Extracted so PlaybackSync and the
+ * pop-out suites drive the exact same real audio element instead of each
+ * hand-rolling (and drifting) their own copy.
+ * @module tests/helpers/playbackHarness
+ */
+
+import type { RecordingSidecarStore } from 'src/sidecar/RecordingSidecarStore';
+import type { PlayerMarker } from 'src/markers/markerModel';
+
+/** Controllable audio element whose setters emit the matching media events. */
+export interface ControllableAudio extends HTMLAudioElement {
+	/** Sets the reported readyState so metadata can be made available late. */
+	setReady(value: number): void;
+	/** Sets the duration and emits durationchange, as a real load would. */
+	setDuration(value: number): void;
+}
+
+/**
+ * Installs one deterministic audio element as the global Audio factory, so the
+ * registry's `new Audio()` and every player bind to the same element.
+ * @returns The shared element with test-only mutators and a restore function
+ */
+export function installSharedAudio(): {
+	audio: ControllableAudio;
+	restore(): void;
+} {
+	const el = document.createElement('audio') as ControllableAudio;
+	let paused = true;
+	let currentTime = 0;
+	let duration = NaN;
+	let ready = 0;
+	Object.defineProperties(el, {
+		paused: { configurable: true, get: () => paused },
+		currentTime: {
+			configurable: true,
+			get: () => currentTime,
+			set: (value: number) => {
+				currentTime = value;
+				el.dispatchEvent(new Event('timeupdate'));
+			},
+		},
+		duration: { configurable: true, get: () => duration },
+		readyState: { configurable: true, get: () => ready },
+	});
+	jest.spyOn(el, 'play').mockImplementation(() => {
+		paused = false;
+		el.dispatchEvent(new Event('play'));
+		return Promise.resolve();
+	});
+	jest.spyOn(el, 'pause').mockImplementation(() => {
+		paused = true;
+		el.dispatchEvent(new Event('pause'));
+	});
+	jest.spyOn(el, 'load').mockImplementation(() => undefined);
+	el.setReady = (value: number) => {
+		ready = value;
+	};
+	el.setDuration = (value: number) => {
+		duration = value;
+		el.dispatchEvent(new Event('durationchange'));
+	};
+	const factory = jest
+		.spyOn(globalThis, 'Audio')
+		.mockImplementation(() => el);
+	return {
+		audio: el,
+		restore: () => {
+			factory.mockRestore();
+		},
+	};
+}
+
+/**
+ * An in-memory sidecar store the players can read and write without
+ * persistence. `updateMarkers` mutates a backing map so a write is visible to
+ * a later `getMarkers`, and the no-op rename/delete/clear methods let the
+ * registrar's vault wiring and dispose run against it.
+ * @returns A RecordingSidecarStore double backed by an in-memory map
+ */
+export function makeMarkerStore(): RecordingSidecarStore {
+	const data = new Map<string, PlayerMarker[]>();
+	return {
+		getMarkers: jest.fn((path: string) =>
+			Promise.resolve([...(data.get(path) ?? [])]),
+		),
+		updateMarkers: jest.fn(
+			(
+				path: string,
+				change: (
+					existing: readonly PlayerMarker[],
+				) => readonly PlayerMarker[],
+			) => {
+				const merged = [...change(data.get(path) ?? [])];
+				data.set(path, merged);
+				return Promise.resolve(merged);
+			},
+		),
+		handleRename: jest.fn().mockResolvedValue(undefined),
+		handleOutputRename: jest.fn().mockResolvedValue(undefined),
+		handleDelete: jest.fn().mockResolvedValue(undefined),
+		clearCache: jest.fn(),
+	} as unknown as RecordingSidecarStore;
+}
+
+/** Reads the elapsed / total text the player renders. */
+export function timeText(container: HTMLElement): string {
+	return container.querySelector('.aar-player-time')?.textContent ?? '';
+}
+
+/** Resolves on the next macrotask, flushing pending player microtasks. */
+export const tick = (): Promise<void> =>
+	new Promise((resolve) => setTimeout(resolve, 0));

--- a/tests/helpers/popoutHarness.ts
+++ b/tests/helpers/popoutHarness.ts
@@ -1,0 +1,101 @@
+/**
+ * Shared doubles for the pop-out window integration suites: a Component-based
+ * plugin that records its post-processor and window callbacks, an app double
+ * the registrar and context menu read from, and a second-document factory.
+ * Extracted so the timecode and context-menu pop-out suites drive the same
+ * real primitive and registrar wiring instead of each rebuilding the fakes.
+ * @module tests/helpers/popoutHarness
+ */
+
+import { Component, TFile } from 'obsidian';
+import type { App, MarkdownPostProcessor, WorkspaceLeaf } from 'obsidian';
+
+/** A pop-out-like window handle, as workspace window events carry it. */
+export interface WindowLike {
+	doc: Document;
+}
+
+/**
+ * A plugin double built on the real Component (so addChild/removeChild and
+ * registerDomEvent attach and detach listeners for real), exposing the
+ * post-processor, the workspace window callbacks, and the open leaves the
+ * pop-out suites drive.
+ */
+export class FakePlugin extends Component {
+	readonly postProcessors: MarkdownPostProcessor[] = [];
+	readonly windowListeners: Record<string, (win: WindowLike) => void> = {};
+	/** Leaves the app double iterates; suites push to it to model open views. */
+	readonly leaves: WorkspaceLeaf[] = [];
+	app!: App;
+
+	registerMarkdownPostProcessor(
+		processor: MarkdownPostProcessor,
+	): MarkdownPostProcessor {
+		this.postProcessors.push(processor);
+		return processor;
+	}
+
+	/** Fires a recorded workspace window event, as Obsidian would. */
+	emit(name: 'window-open' | 'window-close', doc: Document): void {
+		this.windowListeners[name]?.({ doc });
+	}
+}
+
+/**
+ * The audio file every embed and link in these suites resolves to. Built on
+ * the TFile prototype so the registrar's and context menu's `instanceof TFile`
+ * guards pass.
+ */
+export function makeFile(): TFile {
+	return Object.assign(Object.create(TFile.prototype), {
+		path: 'rec.mp4',
+		basename: 'rec',
+		extension: 'mp4',
+		stat: { mtime: 1, size: 1000 },
+	}) as TFile;
+}
+
+/** A fresh, independent document standing in for a pop-out window. */
+export function makePopoutDoc(): Document {
+	return document.implementation.createHTMLDocument('popout');
+}
+
+/**
+ * Builds the app double the registrar, player, and context menu read from.
+ * `iterateAllLeaves` walks the plugin's `leaves`, so a suite can register an
+ * open view after setup, and `on` records the window callbacks onto the plugin
+ * so a suite can fire window-open/window-close.
+ * @param plugin - The plugin double whose leaves and window callbacks are used
+ * @param file - The audio file link resolution returns
+ */
+export function makeApp(plugin: FakePlugin, file: TFile): App {
+	return {
+		vault: {
+			getResourcePath: () => 'app://media',
+			readBinary: () => Promise.resolve(new ArrayBuffer(0)),
+			getFileByPath: () => file,
+			delete: jest.fn(),
+			on: () => ({}),
+		},
+		fileManager: {
+			trashFile: jest.fn(),
+			generateMarkdownLink: () => '[[rec.mp4]]',
+		},
+		metadataCache: {
+			getFirstLinkpathDest: (linkPath: string) =>
+				linkPath.startsWith('rec') ? file : null,
+		},
+		workspace: {
+			getActiveFile: () => ({ path: 'note.md' }),
+			getActiveViewOfType: () => null,
+			getLeavesOfType: () => [] as WorkspaceLeaf[],
+			iterateAllLeaves: (cb: (leaf: WorkspaceLeaf) => void) =>
+				plugin.leaves.forEach(cb),
+			trigger: jest.fn(),
+			on: (name: string, cb: (win: WindowLike) => void) => {
+				plugin.windowListeners[name] = cb;
+				return {};
+			},
+		},
+	} as unknown as App;
+}

--- a/tests/helpers/popoutHarness.ts
+++ b/tests/helpers/popoutHarness.ts
@@ -7,7 +7,12 @@
  * @module tests/helpers/popoutHarness
  */
 
-import { Component, TFile } from 'obsidian';
+import {
+	Component,
+	MarkdownView,
+	TFile,
+	addObsidianDomExtensions,
+} from 'obsidian';
 import type { App, MarkdownPostProcessor, WorkspaceLeaf } from 'obsidian';
 
 /** A pop-out-like window handle, as workspace window events carry it. */
@@ -98,4 +103,68 @@ export function makeApp(plugin: FakePlugin, file: TFile): App {
 			},
 		},
 	} as unknown as App;
+}
+
+/** A popped-out note in Live Preview, wired for a timecode-link click. */
+export interface PopoutLivePreview {
+	/** The CodeMirror internal-link token to dispatch the click on. */
+	linkToken: HTMLElement;
+	/** The element the registrar's post-processor enhances into a player. */
+	embedHost: HTMLElement;
+	/** The audio embed the player mounts into (its time display is asserted). */
+	embed: HTMLElement;
+}
+
+/**
+ * Builds a popped-out note in Live Preview: a real MarkdownView (so the
+ * owning-view lookup matches it via `instanceof`) whose container lives in the
+ * pop-out document and holds both a CodeMirror internal-link token and an audio
+ * embed, and whose editor resolves the wikilink from source. The view is
+ * registered as an open leaf so `markdownViewContaining` finds it. jsdom has no
+ * real CodeMirror, so the editor's `posAtDOM`/`offsetToPos`/`getLine` are
+ * stubbed to map the click onto the wikilink in the source line, exactly as the
+ * main-window Live Preview unit test does.
+ * @param plugin - The plugin whose leaves the app double iterates
+ * @param doc - The pop-out document the note is rendered in
+ * @param notePath - The popped-out note's path (its link source path)
+ * @param sourceLine - The editor line the timecode wikilink is read from
+ * @returns The link token to click and the embed the player mounts into
+ */
+export function makePopoutLivePreview(
+	plugin: FakePlugin,
+	doc: Document,
+	notePath: string,
+	sourceLine: string,
+): PopoutLivePreview {
+	const container = doc.createElement('div');
+	doc.body.appendChild(container);
+
+	const linkToken = doc.createElement('span');
+	linkToken.className = 'cm-hmd-internal-link';
+	linkToken.textContent = '1:30';
+	container.appendChild(linkToken);
+
+	const embedHost = addObsidianDomExtensions(doc.createElement('div'));
+	const embed = addObsidianDomExtensions(doc.createElement('div'));
+	embed.className = 'internal-embed is-loaded';
+	embed.setAttribute('src', 'rec.mp4');
+	embedHost.appendChild(embed);
+	container.appendChild(embedHost);
+
+	const editor = {
+		cm: { posAtDOM: () => 5 },
+		offsetToPos: () => ({ line: 0, ch: 5 }),
+		getLine: () => sourceLine,
+	};
+	const view = Object.assign(Object.create(MarkdownView.prototype), {
+		containerEl: container,
+		file: { path: notePath },
+		editor,
+	}) as MarkdownView;
+	plugin.leaves.push({
+		view,
+		getContainer: () => ({ doc }),
+	} as unknown as WorkspaceLeaf);
+
+	return { linkToken, embedHost, embed };
 }

--- a/tests/integration/PlaybackSync.test.ts
+++ b/tests/integration/PlaybackSync.test.ts
@@ -20,69 +20,12 @@ import type { PlayerMarker } from 'src/markers/markerModel';
 import type { ResolvedPlayerSettings } from 'src/player/playerSettings';
 import type { PlaybackControlsState } from 'src/player/playbackControls';
 import type { TFile } from 'obsidian';
-
-/** Controllable audio element whose setters emit the matching media events. */
-interface ControllableAudio extends HTMLAudioElement {
-	/** Sets the reported readyState so metadata can be made available late. */
-	setReady(value: number): void;
-	/** Sets the duration and emits durationchange, as a real load would. */
-	setDuration(value: number): void;
-}
-
-/**
- * Installs one deterministic audio element as the global Audio factory, so the
- * registry's `new Audio()` and every player bind to the same element.
- * @returns The shared element with test-only mutators
- */
-function installSharedAudio(): {
-	audio: ControllableAudio;
-	restore(): void;
-} {
-	const el = document.createElement('audio') as ControllableAudio;
-	let paused = true;
-	let currentTime = 0;
-	let duration = NaN;
-	let ready = 0;
-	Object.defineProperties(el, {
-		paused: { configurable: true, get: () => paused },
-		currentTime: {
-			configurable: true,
-			get: () => currentTime,
-			set: (value: number) => {
-				currentTime = value;
-				el.dispatchEvent(new Event('timeupdate'));
-			},
-		},
-		duration: { configurable: true, get: () => duration },
-		readyState: { configurable: true, get: () => ready },
-	});
-	jest.spyOn(el, 'play').mockImplementation(() => {
-		paused = false;
-		el.dispatchEvent(new Event('play'));
-		return Promise.resolve();
-	});
-	jest.spyOn(el, 'pause').mockImplementation(() => {
-		paused = true;
-		el.dispatchEvent(new Event('pause'));
-	});
-	jest.spyOn(el, 'load').mockImplementation(() => undefined);
-	el.setReady = (value: number) => {
-		ready = value;
-	};
-	el.setDuration = (value: number) => {
-		duration = value;
-		el.dispatchEvent(new Event('durationchange'));
-	};
-	const factory = jest
-		.spyOn(globalThis, 'Audio')
-		.mockImplementation(() => el);
-	return {
-		audio: el,
-		restore: () => {
-			factory.mockRestore();
-		},
-	};
-}
+import {
+	installSharedAudio,
+	makeMarkerStore,
+	timeText,
+	tick,
+} from '../helpers/playbackHarness';
 
 const app = {
 	vault: {
@@ -105,28 +48,6 @@ const WITH_MARKERS: ResolvedPlayerSettings = {
 	showWaveform: false,
 	enableMarkers: true,
 };
-
-/** In-memory marker store the players can read without persistence. */
-function makeMarkerStore(): RecordingSidecarStore {
-	const data = new Map<string, PlayerMarker[]>();
-	return {
-		getMarkers: jest.fn((path: string) =>
-			Promise.resolve([...(data.get(path) ?? [])]),
-		),
-		updateMarkers: jest.fn(
-			(
-				path: string,
-				change: (
-					existing: readonly PlayerMarker[],
-				) => readonly PlayerMarker[],
-			) => {
-				const merged = [...change(data.get(path) ?? [])];
-				data.set(path, merged);
-				return Promise.resolve(merged);
-			},
-		),
-	} as unknown as RecordingSidecarStore;
-}
 
 function makeFile(): TFile {
 	return {
@@ -184,14 +105,6 @@ function mountMarkerPlayer(
 		{ startSeconds: null, sourcePath: 'note.md', immediate: true },
 	).onload();
 }
-
-/** Reads the elapsed / total text the player renders. */
-function timeText(container: HTMLElement): string {
-	return container.querySelector('.aar-player-time')?.textContent ?? '';
-}
-
-const tick = (): Promise<void> =>
-	new Promise((resolve) => setTimeout(resolve, 0));
 
 afterEach(() => {
 	document.body.innerHTML = '';

--- a/tests/integration/PopoutContextMenu.test.ts
+++ b/tests/integration/PopoutContextMenu.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Pop-out window context-menu regression guard. The headline symptom of issue
+ * #12 is that the audio player's right-click menu ("Delete recording", "Audio
+ * file info") stops appearing once a note is moved into a pop-out window. This
+ * drives the REAL ContextMenu through the REAL registerDomEventOnAllWindows
+ * primitive against a second document and asserts that a contextmenu event
+ * there still resolves the recording and shows the plugin menu. It does NOT
+ * mock the primitive, because the point is that the real per-window binding
+ * reaches the pop-out's own document.
+ * @jest-environment jsdom
+ */
+
+import { Menu } from 'obsidian';
+import type { Plugin } from 'obsidian';
+import { ContextMenu } from 'src/ui/ContextMenu';
+import { FILE_ACTIONS } from 'src/actions/fileActions';
+import type { ActionServices } from 'src/actions/PluginAction';
+import {
+	FakePlugin,
+	makeApp,
+	makeFile,
+	makePopoutDoc,
+} from '../helpers/popoutHarness';
+
+afterEach(() => {
+	document.body.innerHTML = '';
+	jest.restoreAllMocks();
+});
+
+describe('context menu works inside a pop-out window', () => {
+	it('shows the player menu from a right-click in the pop-out document', () => {
+		const showAtPosition = jest.spyOn(Menu.prototype, 'showAtPosition');
+		const file = makeFile();
+		const plugin = new FakePlugin();
+		plugin.app = makeApp(plugin, file);
+		// registerPlayerMenu only reads services.app; the rest is unused because
+		// the file-menu is populated by other plugins, not this handler.
+		const services = { app: plugin.app } as unknown as ActionServices;
+
+		const contextMenu = new ContextMenu(
+			plugin as unknown as Plugin,
+			services,
+			FILE_ACTIONS,
+		);
+		// Load first so the primitive's per-window child components attach their
+		// listeners immediately.
+		plugin.load();
+		contextMenu.register();
+
+		// A pop-out window opens after load: the primitive must bind the
+		// contextmenu handler to its separate document.
+		const popoutDoc = makePopoutDoc();
+		plugin.emit('window-open', popoutDoc);
+
+		// The note's audio embed rendered inside the pop-out document.
+		const embed = popoutDoc.createElement('div');
+		embed.className = 'internal-embed';
+		embed.setAttribute('src', 'rec.mp4');
+		popoutDoc.body.appendChild(embed);
+
+		embed.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true }));
+
+		// The right-click reached the handler bound to the pop-out's own
+		// document, resolved the recording, and showed the menu.
+		expect(plugin.app.workspace.trigger).toHaveBeenCalledWith(
+			'file-menu',
+			expect.anything(),
+			file,
+			'audio-recorder-player-context-menu',
+		);
+		expect(showAtPosition).toHaveBeenCalled();
+	});
+});

--- a/tests/integration/PopoutPlayback.test.ts
+++ b/tests/integration/PopoutPlayback.test.ts
@@ -1,172 +1,35 @@
 /**
- * Pop-out window regression guard. A note moved into an Obsidian pop-out lives
- * in a separate `document` whose events never bubble into the main window, so a
- * handler bound once to activeDocument silently dies there - the exact cause of
- * the "context menu / timecode click stops working in a pop-out" bug. These
- * tests drive the REAL EnhancedPlayerRegistrar, its REAL AudioPlayerRegistry,
- * a REAL AudioPlayer, and the REAL registerDomEventOnAllWindows primitive, all
- * against a second jsdom document standing in for the pop-out, and prove a
- * timecode click there still seeks the popped-out embed. It deliberately does
- * NOT mock the primitive (unlike the registrar unit tests), because the whole
- * point is that the real per-window binding reaches the pop-out.
+ * Pop-out window playback regression guard. A note moved into an Obsidian
+ * pop-out lives in a separate `document` whose events never bubble into the
+ * main window, so a handler bound once to activeDocument silently dies there -
+ * the cause of the "timecode click stops working in a pop-out" half of the
+ * bug. This drives the REAL EnhancedPlayerRegistrar, its REAL
+ * AudioPlayerRegistry, a REAL AudioPlayer, and the REAL
+ * registerDomEventOnAllWindows primitive against a second document standing in
+ * for the pop-out, and proves a timecode click there seeks the popped-out
+ * embed. It deliberately does NOT mock the primitive (unlike the registrar
+ * unit tests), because the whole point is that the real per-window binding
+ * reaches the pop-out.
  * @jest-environment jsdom
  */
 
-import { Component, TFile, addObsidianDomExtensions } from 'obsidian';
-import type {
-	App,
-	MarkdownPostProcessor,
-	MarkdownPostProcessorContext,
-	Plugin,
-	WorkspaceLeaf,
-} from 'obsidian';
+import { Component, addObsidianDomExtensions } from 'obsidian';
+import type { MarkdownPostProcessorContext, Plugin } from 'obsidian';
 import { EnhancedPlayerRegistrar } from 'src/player/EnhancedPlayerRegistrar';
 import { DEFAULT_SETTINGS } from 'src/settings/settingsSchema';
 import type { AudioRecorderSettings } from 'src/settings/settingsSchema';
-import type { RecordingSidecarStore } from 'src/sidecar/RecordingSidecarStore';
-import type { PlayerMarker } from 'src/markers/markerModel';
-
-/** Controllable audio element whose setters emit the matching media events. */
-interface ControllableAudio extends HTMLAudioElement {
-	setReady(value: number): void;
-	setDuration(value: number): void;
-}
-
-/**
- * Installs one deterministic audio element as the global Audio factory, so the
- * registry's `new Audio()` and the player bind to the same element (mirrors the
- * PlaybackSync harness).
- */
-function installSharedAudio(): { audio: ControllableAudio; restore(): void } {
-	const el = document.createElement('audio') as ControllableAudio;
-	let paused = true;
-	let currentTime = 0;
-	let duration = NaN;
-	let ready = 0;
-	Object.defineProperties(el, {
-		paused: { configurable: true, get: () => paused },
-		currentTime: {
-			configurable: true,
-			get: () => currentTime,
-			set: (value: number) => {
-				currentTime = value;
-				el.dispatchEvent(new Event('timeupdate'));
-			},
-		},
-		duration: { configurable: true, get: () => duration },
-		readyState: { configurable: true, get: () => ready },
-	});
-	jest.spyOn(el, 'play').mockImplementation(() => {
-		paused = false;
-		el.dispatchEvent(new Event('play'));
-		return Promise.resolve();
-	});
-	jest.spyOn(el, 'pause').mockImplementation(() => {
-		paused = true;
-		el.dispatchEvent(new Event('pause'));
-	});
-	jest.spyOn(el, 'load').mockImplementation(() => undefined);
-	el.setReady = (value: number) => {
-		ready = value;
-	};
-	el.setDuration = (value: number) => {
-		duration = value;
-		el.dispatchEvent(new Event('durationchange'));
-	};
-	const factory = jest
-		.spyOn(globalThis, 'Audio')
-		.mockImplementation(() => el);
-	return { audio: el, restore: () => factory.mockRestore() };
-}
-
-/**
- * The audio file every embed and link in these tests resolves to. Built on
- * the TFile prototype so the registrar's `instanceof TFile` guards pass.
- */
-function makeFile(): TFile {
-	return Object.assign(Object.create(TFile.prototype), {
-		path: 'rec.mp4',
-		basename: 'rec',
-		extension: 'mp4',
-		stat: { mtime: 1, size: 1000 },
-	}) as TFile;
-}
-
-/** An in-memory sidecar store the player can read without persistence. */
-function makeMarkerStore(): RecordingSidecarStore {
-	return {
-		getMarkers: jest.fn(() => Promise.resolve([] as PlayerMarker[])),
-		updateMarkers: jest.fn((_path, change) =>
-			Promise.resolve([...change([])]),
-		),
-		handleRename: jest.fn().mockResolvedValue(undefined),
-		handleOutputRename: jest.fn().mockResolvedValue(undefined),
-		handleDelete: jest.fn().mockResolvedValue(undefined),
-		clearCache: jest.fn(),
-	} as unknown as RecordingSidecarStore;
-}
-
-/** A pop-out-like window handle, as workspace window events carry it. */
-interface WindowLike {
-	doc: Document;
-}
-
-/**
- * A plugin double built on the real Component (so addChild/removeChild and
- * registerDomEvent attach and detach listeners for real), exposing the
- * post-processor and the workspace window callbacks the test drives.
- */
-class FakePlugin extends Component {
-	readonly postProcessors: MarkdownPostProcessor[] = [];
-	readonly windowListeners: Record<string, (win: WindowLike) => void> = {};
-	app!: App;
-
-	registerMarkdownPostProcessor(
-		processor: MarkdownPostProcessor,
-	): MarkdownPostProcessor {
-		this.postProcessors.push(processor);
-		return processor;
-	}
-
-	/** Fires a recorded workspace window event, as Obsidian would. */
-	emit(name: 'window-open' | 'window-close', doc: Document): void {
-		this.windowListeners[name]?.({ doc });
-	}
-}
-
-/** Builds the app double the registrar and player read from. */
-function makeApp(plugin: FakePlugin, file: TFile): App {
-	return {
-		vault: {
-			getResourcePath: () => 'app://media',
-			readBinary: () => Promise.resolve(new ArrayBuffer(0)),
-			getFileByPath: () => file,
-			on: () => ({}),
-		},
-		metadataCache: {
-			getFirstLinkpathDest: (linkPath: string) =>
-				linkPath.startsWith('rec') ? file : null,
-		},
-		workspace: {
-			getActiveFile: () => ({ path: 'note.md' }),
-			getActiveViewOfType: () => null,
-			getLeavesOfType: () => [] as WorkspaceLeaf[],
-			iterateAllLeaves: () => undefined,
-			on: (name: string, cb: (win: WindowLike) => void) => {
-				plugin.windowListeners[name] = cb;
-				return {};
-			},
-		},
-	} as unknown as App;
-}
-
-/** Reads the elapsed / total text the player renders. */
-function timeText(container: HTMLElement): string {
-	return container.querySelector('.aar-player-time')?.textContent ?? '';
-}
-
-const tick = (): Promise<void> =>
-	new Promise((resolve) => setTimeout(resolve, 0));
+import {
+	installSharedAudio,
+	makeMarkerStore,
+	timeText,
+	tick,
+} from '../helpers/playbackHarness';
+import {
+	FakePlugin,
+	makeApp,
+	makeFile,
+	makePopoutDoc,
+} from '../helpers/popoutHarness';
 
 afterEach(() => {
 	document.body.innerHTML = '';
@@ -201,8 +64,7 @@ describe('timecode clicks work inside a pop-out window', () => {
 
 			// A pop-out window opens after load: the primitive must bind the
 			// timecode click handler to its separate document.
-			const popoutDoc =
-				document.implementation.createHTMLDocument('popout');
+			const popoutDoc = makePopoutDoc();
 			plugin.emit('window-open', popoutDoc);
 
 			// Obsidian renders the note's embed inside the pop-out document.

--- a/tests/integration/PopoutPlayback.test.ts
+++ b/tests/integration/PopoutPlayback.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Pop-out window regression guard. A note moved into an Obsidian pop-out lives
+ * in a separate `document` whose events never bubble into the main window, so a
+ * handler bound once to activeDocument silently dies there - the exact cause of
+ * the "context menu / timecode click stops working in a pop-out" bug. These
+ * tests drive the REAL EnhancedPlayerRegistrar, its REAL AudioPlayerRegistry,
+ * a REAL AudioPlayer, and the REAL registerDomEventOnAllWindows primitive, all
+ * against a second jsdom document standing in for the pop-out, and prove a
+ * timecode click there still seeks the popped-out embed. It deliberately does
+ * NOT mock the primitive (unlike the registrar unit tests), because the whole
+ * point is that the real per-window binding reaches the pop-out.
+ * @jest-environment jsdom
+ */
+
+import { Component, TFile, addObsidianDomExtensions } from 'obsidian';
+import type {
+	App,
+	MarkdownPostProcessor,
+	MarkdownPostProcessorContext,
+	Plugin,
+	WorkspaceLeaf,
+} from 'obsidian';
+import { EnhancedPlayerRegistrar } from 'src/player/EnhancedPlayerRegistrar';
+import { DEFAULT_SETTINGS } from 'src/settings/settingsSchema';
+import type { AudioRecorderSettings } from 'src/settings/settingsSchema';
+import type { RecordingSidecarStore } from 'src/sidecar/RecordingSidecarStore';
+import type { PlayerMarker } from 'src/markers/markerModel';
+
+/** Controllable audio element whose setters emit the matching media events. */
+interface ControllableAudio extends HTMLAudioElement {
+	setReady(value: number): void;
+	setDuration(value: number): void;
+}
+
+/**
+ * Installs one deterministic audio element as the global Audio factory, so the
+ * registry's `new Audio()` and the player bind to the same element (mirrors the
+ * PlaybackSync harness).
+ */
+function installSharedAudio(): { audio: ControllableAudio; restore(): void } {
+	const el = document.createElement('audio') as ControllableAudio;
+	let paused = true;
+	let currentTime = 0;
+	let duration = NaN;
+	let ready = 0;
+	Object.defineProperties(el, {
+		paused: { configurable: true, get: () => paused },
+		currentTime: {
+			configurable: true,
+			get: () => currentTime,
+			set: (value: number) => {
+				currentTime = value;
+				el.dispatchEvent(new Event('timeupdate'));
+			},
+		},
+		duration: { configurable: true, get: () => duration },
+		readyState: { configurable: true, get: () => ready },
+	});
+	jest.spyOn(el, 'play').mockImplementation(() => {
+		paused = false;
+		el.dispatchEvent(new Event('play'));
+		return Promise.resolve();
+	});
+	jest.spyOn(el, 'pause').mockImplementation(() => {
+		paused = true;
+		el.dispatchEvent(new Event('pause'));
+	});
+	jest.spyOn(el, 'load').mockImplementation(() => undefined);
+	el.setReady = (value: number) => {
+		ready = value;
+	};
+	el.setDuration = (value: number) => {
+		duration = value;
+		el.dispatchEvent(new Event('durationchange'));
+	};
+	const factory = jest
+		.spyOn(globalThis, 'Audio')
+		.mockImplementation(() => el);
+	return { audio: el, restore: () => factory.mockRestore() };
+}
+
+/**
+ * The audio file every embed and link in these tests resolves to. Built on
+ * the TFile prototype so the registrar's `instanceof TFile` guards pass.
+ */
+function makeFile(): TFile {
+	return Object.assign(Object.create(TFile.prototype), {
+		path: 'rec.mp4',
+		basename: 'rec',
+		extension: 'mp4',
+		stat: { mtime: 1, size: 1000 },
+	}) as TFile;
+}
+
+/** An in-memory sidecar store the player can read without persistence. */
+function makeMarkerStore(): RecordingSidecarStore {
+	return {
+		getMarkers: jest.fn(() => Promise.resolve([] as PlayerMarker[])),
+		updateMarkers: jest.fn((_path, change) =>
+			Promise.resolve([...change([])]),
+		),
+		handleRename: jest.fn().mockResolvedValue(undefined),
+		handleOutputRename: jest.fn().mockResolvedValue(undefined),
+		handleDelete: jest.fn().mockResolvedValue(undefined),
+		clearCache: jest.fn(),
+	} as unknown as RecordingSidecarStore;
+}
+
+/** A pop-out-like window handle, as workspace window events carry it. */
+interface WindowLike {
+	doc: Document;
+}
+
+/**
+ * A plugin double built on the real Component (so addChild/removeChild and
+ * registerDomEvent attach and detach listeners for real), exposing the
+ * post-processor and the workspace window callbacks the test drives.
+ */
+class FakePlugin extends Component {
+	readonly postProcessors: MarkdownPostProcessor[] = [];
+	readonly windowListeners: Record<string, (win: WindowLike) => void> = {};
+	app!: App;
+
+	registerMarkdownPostProcessor(
+		processor: MarkdownPostProcessor,
+	): MarkdownPostProcessor {
+		this.postProcessors.push(processor);
+		return processor;
+	}
+
+	/** Fires a recorded workspace window event, as Obsidian would. */
+	emit(name: 'window-open' | 'window-close', doc: Document): void {
+		this.windowListeners[name]?.({ doc });
+	}
+}
+
+/** Builds the app double the registrar and player read from. */
+function makeApp(plugin: FakePlugin, file: TFile): App {
+	return {
+		vault: {
+			getResourcePath: () => 'app://media',
+			readBinary: () => Promise.resolve(new ArrayBuffer(0)),
+			getFileByPath: () => file,
+			on: () => ({}),
+		},
+		metadataCache: {
+			getFirstLinkpathDest: (linkPath: string) =>
+				linkPath.startsWith('rec') ? file : null,
+		},
+		workspace: {
+			getActiveFile: () => ({ path: 'note.md' }),
+			getActiveViewOfType: () => null,
+			getLeavesOfType: () => [] as WorkspaceLeaf[],
+			iterateAllLeaves: () => undefined,
+			on: (name: string, cb: (win: WindowLike) => void) => {
+				plugin.windowListeners[name] = cb;
+				return {};
+			},
+		},
+	} as unknown as App;
+}
+
+/** Reads the elapsed / total text the player renders. */
+function timeText(container: HTMLElement): string {
+	return container.querySelector('.aar-player-time')?.textContent ?? '';
+}
+
+const tick = (): Promise<void> =>
+	new Promise((resolve) => setTimeout(resolve, 0));
+
+afterEach(() => {
+	document.body.innerHTML = '';
+	jest.restoreAllMocks();
+});
+
+describe('timecode clicks work inside a pop-out window', () => {
+	it('seeks the popped-out embed from a timecode link in its own document', async () => {
+		const shared = installSharedAudio();
+		try {
+			const file = makeFile();
+			const plugin = new FakePlugin();
+			plugin.app = makeApp(plugin, file);
+			const settings: AudioRecorderSettings = {
+				...DEFAULT_SETTINGS,
+				enhancedPlayerEnabled: true,
+				playerShowWaveform: false,
+				playerEnableMarkers: false,
+			};
+
+			const registrar = new EnhancedPlayerRegistrar(
+				plugin as unknown as Plugin,
+				plugin.app,
+				() => settings,
+				makeMarkerStore(),
+				null,
+			);
+			// The plugin must be loaded so the primitive's per-window child
+			// components load (and thus attach their listeners) at once.
+			plugin.load();
+			registrar.register();
+
+			// A pop-out window opens after load: the primitive must bind the
+			// timecode click handler to its separate document.
+			const popoutDoc =
+				document.implementation.createHTMLDocument('popout');
+			plugin.emit('window-open', popoutDoc);
+
+			// Obsidian renders the note's embed inside the pop-out document.
+			const section = addObsidianDomExtensions(
+				popoutDoc.createElement('div'),
+			);
+			popoutDoc.body.appendChild(section);
+			const embed = addObsidianDomExtensions(
+				popoutDoc.createElement('div'),
+			);
+			embed.className = 'internal-embed is-loaded';
+			embed.setAttribute('src', 'rec.mp4');
+			section.appendChild(embed);
+
+			// Drive the registrar's real post-processor to mount a real player
+			// into the pop-out embed, joined to the registrar's own registry.
+			const ctx = {
+				sourcePath: 'note.md',
+				addChild: (child: Component) => child.load(),
+			} as unknown as MarkdownPostProcessorContext;
+			void plugin.postProcessors[0](section, ctx);
+			await tick();
+			shared.audio.setReady(1);
+			shared.audio.setDuration(600);
+
+			// A transcript timestamp clicked in the pop-out document.
+			const link = popoutDoc.createElement('a');
+			link.className = 'internal-link';
+			link.setAttribute('data-href', 'rec.mp4#t=90');
+			popoutDoc.body.appendChild(link);
+			link.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+			// The click reached the handler bound to the pop-out's own document
+			// and seeked the embed there - it shows 1:30, not a dead 0:00.
+			expect(timeText(embed)).toBe('1:30 / 10:00');
+			expect(shared.audio.paused).toBe(false);
+		} finally {
+			shared.restore();
+		}
+	});
+});

--- a/tests/integration/PopoutPlayback.test.ts
+++ b/tests/integration/PopoutPlayback.test.ts
@@ -29,6 +29,7 @@ import {
 	makeApp,
 	makeFile,
 	makePopoutDoc,
+	makePopoutLivePreview,
 } from '../helpers/popoutHarness';
 
 afterEach(() => {
@@ -99,6 +100,78 @@ describe('timecode clicks work inside a pop-out window', () => {
 
 			// The click reached the handler bound to the pop-out's own document
 			// and seeked the embed there - it shows 1:30, not a dead 0:00.
+			expect(timeText(embed)).toBe('1:30 / 10:00');
+			expect(shared.audio.paused).toBe(false);
+		} finally {
+			shared.restore();
+		}
+	});
+
+	it('seeks the popped-out embed from a Live Preview timecode link resolved against its own note', async () => {
+		const shared = installSharedAudio();
+		try {
+			const file = makeFile();
+			const plugin = new FakePlugin();
+			plugin.app = makeApp(plugin, file);
+			// The recording resolves only against the popped-out note. Resolving
+			// against the active note (a different file) would return null, so a
+			// passing seek proves the click used the owning view, not the active
+			// one. Without the window-scoped fix, both the editor lookup (active
+			// view is null) and the source-path lookup (active file is note.md)
+			// miss and the embed stays dead at 0:00.
+			plugin.app.metadataCache.getFirstLinkpathDest = (
+				linkPath: string,
+				sourcePath: string,
+			) =>
+				linkPath.startsWith('rec') && sourcePath === 'popout-note.md'
+					? file
+					: null;
+
+			const settings: AudioRecorderSettings = {
+				...DEFAULT_SETTINGS,
+				enhancedPlayerEnabled: true,
+				playerShowWaveform: false,
+				playerEnableMarkers: false,
+			};
+
+			const registrar = new EnhancedPlayerRegistrar(
+				plugin as unknown as Plugin,
+				plugin.app,
+				() => settings,
+				makeMarkerStore(),
+				null,
+			);
+			plugin.load();
+			registrar.register();
+
+			const popoutDoc = makePopoutDoc();
+			plugin.emit('window-open', popoutDoc);
+
+			// The popped-out note in Live Preview: a MarkdownView whose editor
+			// resolves the wikilink from source, registered as an open leaf.
+			const { linkToken, embedHost, embed } = makePopoutLivePreview(
+				plugin,
+				popoutDoc,
+				'popout-note.md',
+				'[[rec.mp4#t=90|1:30]] Speaker 1',
+			);
+
+			// Mount a real player into the pop-out embed so a seek has a display.
+			const ctx = {
+				sourcePath: 'popout-note.md',
+				addChild: (child: Component) => child.load(),
+			} as unknown as MarkdownPostProcessorContext;
+			void plugin.postProcessors[0](embedHost, ctx);
+			await tick();
+			shared.audio.setReady(1);
+			shared.audio.setDuration(600);
+
+			// The Live Preview wikilink clicked in the pop-out, while the active
+			// view is null and the active file is a different, main-window note.
+			linkToken.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+			// The editor target and the source path both resolved against the
+			// popped-out note, so the click seeked the embed there to 1:30.
 			expect(timeText(embed)).toBe('1:30 / 10:00');
 			expect(shared.audio.paused).toBe(false);
 		} finally {

--- a/tests/unit/ContextMenu.test.ts
+++ b/tests/unit/ContextMenu.test.ts
@@ -24,6 +24,7 @@ import {
 	MetadataCache,
 	Vault,
 	FileManager,
+	MarkdownView,
 } from 'obsidian';
 
 /** The shape of a recorded menu item (see the Menu fake below). */
@@ -163,6 +164,7 @@ describe('ContextMenu', () => {
 			trigger: jest.fn(),
 			getActiveFile: jest.fn(),
 			getActiveViewOfType: jest.fn(),
+			iterateAllLeaves: jest.fn(),
 		} as unknown as Workspace;
 
 		mockMetadataCache = {
@@ -724,6 +726,51 @@ describe('ContextMenu', () => {
 				'',
 			);
 			expect(mockWorkspace.trigger).toHaveBeenCalled();
+		});
+
+		it('resolves the embed against the note that contains it, not the active file', () => {
+			// The embed lives inside a specific view's container (a pop-out or a
+			// background split), whose note differs from the globally active file.
+			const containerEl = document.createElement('div');
+			const embed = document.createElement('div');
+			embed.className = 'internal-embed';
+			embed.setAttribute('src', 'audio.mp3');
+			const target = document.createElement('span');
+			embed.appendChild(target);
+			containerEl.appendChild(embed);
+
+			const owningView = Object.assign(
+				Object.create(
+					(MarkdownView as unknown as { prototype: object })
+						.prototype,
+				),
+				{ containerEl, file: { path: 'owner.md' }, editor: {} },
+			);
+			(mockWorkspace.iterateAllLeaves as jest.Mock).mockImplementation(
+				(cb: (leaf: { view: unknown }) => void) =>
+					cb({ view: owningView }),
+			);
+			// A DIFFERENT note is active; it must not be used for resolution.
+			(mockWorkspace.getActiveFile as jest.Mock).mockReturnValue({
+				path: 'active.md',
+			});
+			(
+				mockMetadataCache.getFirstLinkpathDest as jest.Mock
+			).mockReturnValue(makeAudioFile());
+
+			playerMenuCallback({
+				target,
+				pageX: 10,
+				pageY: 20,
+				preventDefault: jest.fn(),
+				stopPropagation: jest.fn(),
+			} as unknown as MouseEvent);
+
+			expect(mockMetadataCache.getFirstLinkpathDest).toHaveBeenCalledWith(
+				'audio.mp3',
+				'owner.md',
+			);
+			expect(mockWorkspace.getActiveFile).not.toHaveBeenCalled();
 		});
 
 		it('offers "Delete recording & link to file" when the embed maps to an editor link', () => {

--- a/tests/unit/ContextMenu.test.ts
+++ b/tests/unit/ContextMenu.test.ts
@@ -86,6 +86,14 @@ jest.mock('obsidian', () => {
 	};
 });
 
+// The player menu binds through registerDomEventOnAllWindows (one listener
+// per Obsidian window). These unit tests exercise the handler itself, so the
+// primitive is mocked to capture the registered handler; its own cross-window
+// behavior is covered in tests/unit/multiWindowDomEvents.test.ts.
+jest.mock('src/utils/multiWindowDomEvents', () => ({
+	registerDomEventOnAllWindows: jest.fn(),
+}));
+
 jest.mock('src/ui/AudioFileInfoModal', () => ({
 	AudioFileInfoModal: jest.fn().mockImplementation(() => ({
 		open: jest.fn(),
@@ -221,8 +229,12 @@ describe('ContextMenu', () => {
 				'editor-menu',
 				expect.any(Function),
 			);
-			expect(mockPlugin.registerDomEvent).toHaveBeenCalledWith(
-				document,
+			const { registerDomEventOnAllWindows } = jest.requireMock(
+				'src/utils/multiWindowDomEvents',
+			);
+			expect(registerDomEventOnAllWindows).toHaveBeenCalledWith(
+				mockPlugin,
+				mockApp,
 				'contextmenu',
 				expect.any(Function),
 				{ capture: true },
@@ -580,10 +592,13 @@ describe('ContextMenu', () => {
 
 		beforeEach(() => {
 			contextMenu.register();
+			const { registerDomEventOnAllWindows } = jest.requireMock(
+				'src/utils/multiWindowDomEvents',
+			);
 			const call = (
-				mockPlugin.registerDomEvent as jest.Mock
-			).mock.calls.find((c) => c[1] === 'contextmenu');
-			playerMenuCallback = call[2];
+				registerDomEventOnAllWindows as jest.Mock
+			).mock.calls.find((c) => c[2] === 'contextmenu');
+			playerMenuCallback = call[3];
 		});
 
 		function makeEmbedEvent(src = 'audio.mp3'): MouseEvent {

--- a/tests/unit/EnhancedPlayerRegistrar.test.ts
+++ b/tests/unit/EnhancedPlayerRegistrar.test.ts
@@ -42,6 +42,15 @@ jest.mock('src/player/AudioPlayer', () => ({
 	})),
 }));
 
+// The timecode click handler binds through registerDomEventOnAllWindows (one
+// listener per Obsidian window). These tests exercise the handler itself, so
+// the primitive is mocked to capture the registered handler; its cross-window
+// behavior is covered in tests/unit/multiWindowDomEvents.test.ts and the
+// pop-out integration test.
+jest.mock('src/utils/multiWindowDomEvents', () => ({
+	registerDomEventOnAllWindows: jest.fn(),
+}));
+
 jest.mock('src/player/mediaProbe', () => ({
 	...jest.requireActual('src/player/mediaProbe'),
 	probeMediaKind: jest.fn(),
@@ -675,14 +684,17 @@ describe('EnhancedPlayerRegistrar vault rename/delete wiring', () => {
 
 describe('EnhancedPlayerRegistrar timecode links', () => {
 	/** Returns the document click handler the registrar installed on register. */
-	function clickHandler(plugin: Plugin): (event: MouseEvent) => void {
-		const call = (plugin.registerDomEvent as jest.Mock).mock.calls.find(
-			(args) => args[1] === 'click',
+	function clickHandler(_plugin: Plugin): (event: MouseEvent) => void {
+		const { registerDomEventOnAllWindows } = jest.requireMock(
+			'src/utils/multiWindowDomEvents',
 		);
+		const call = (
+			registerDomEventOnAllWindows as jest.Mock
+		).mock.calls.find((args: unknown[]) => args[2] === 'click');
 		if (!call) {
 			throw new Error('Expected a click handler registration');
 		}
-		return call[2] as (event: MouseEvent) => void;
+		return call[3] as (event: MouseEvent) => void;
 	}
 
 	/** Builds a click event whose target is a timecode internal link. */

--- a/tests/unit/EnhancedPlayerRegistrar.test.ts
+++ b/tests/unit/EnhancedPlayerRegistrar.test.ts
@@ -200,6 +200,10 @@ function setup(
 			getActiveFile: () => ({ path: 'note.md' }),
 			getLeavesOfType: getLeaves,
 			getActiveViewOfType: jest.fn(() => null),
+			// The timecode resolver locates the note owning the clicked node
+			// across windows; no leaf owns the detached test nodes, so the
+			// lookup finds nothing and falls back to the active view/file.
+			iterateAllLeaves: jest.fn(),
 		},
 	} as unknown as App;
 

--- a/tests/unit/multiWindowDomEvents.test.ts
+++ b/tests/unit/multiWindowDomEvents.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Unit tests for registerDomEventOnAllWindows. The primitive exists because
+ * Obsidian pop-out windows each own a separate `document` whose events never
+ * reach the main window, so a listener bound once to activeDocument silently
+ * misses every pop-out. These tests drive the REAL primitive against several
+ * jsdom documents and assert that a listener reaches the main window, any
+ * pop-out already open at registration, and pop-outs opened later, and that it
+ * is removed on window-close and on plugin unload.
+ * @module tests/unit/multiWindowDomEvents.test
+ */
+
+import { Component } from 'obsidian';
+import type { App, Plugin, WorkspaceLeaf } from 'obsidian';
+import { registerDomEventOnAllWindows } from 'src/utils/multiWindowDomEvents';
+
+/** A pop-out-like window handle, as workspace window events carry it. */
+interface WindowLike {
+	doc: Document;
+}
+
+/**
+ * A faithful plugin/app double: a real Component (so addChild/removeChild and
+ * registerDomEvent behave like Obsidian's, attaching and detaching listeners
+ * for real) plus a workspace that records its window-open/close callbacks and
+ * iterates a configurable set of already-open leaves.
+ */
+class FakePlugin extends Component {
+	readonly windowListeners: Record<string, (win: WindowLike) => void> = {};
+	readonly app: App;
+
+	constructor(preOpenDocs: Document[]) {
+		super();
+		const leaves: WorkspaceLeaf[] = preOpenDocs.map(
+			(doc) =>
+				({
+					getContainer: () => ({ doc }),
+				}) as unknown as WorkspaceLeaf,
+		);
+		this.app = {
+			workspace: {
+				iterateAllLeaves: (cb: (leaf: WorkspaceLeaf) => void): void => {
+					leaves.forEach(cb);
+				},
+				on: (name: string, cb: (win: WindowLike) => void): object => {
+					this.windowListeners[name] = cb;
+					return {};
+				},
+			},
+		} as unknown as App;
+	}
+
+	/** Fires a recorded workspace window event, as Obsidian would. */
+	emit(name: 'window-open' | 'window-close', doc: Document): void {
+		this.windowListeners[name]?.({ doc });
+	}
+}
+
+/** A fresh, independent document, standing in for a pop-out window. */
+function makeDoc(): Document {
+	return document.implementation.createHTMLDocument('popout');
+}
+
+/** Dispatches a bubbling click on a document, returning nothing. */
+function click(doc: Document): void {
+	doc.dispatchEvent(new Event('click', { bubbles: true }));
+}
+
+describe('registerDomEventOnAllWindows', () => {
+	it('reaches the main window and a pop-out open at registration time', () => {
+		const preOpen = makeDoc();
+		const plugin = new FakePlugin([preOpen]);
+		plugin.load();
+		const seen: Document[] = [];
+
+		registerDomEventOnAllWindows(
+			plugin as unknown as Plugin,
+			plugin.app,
+			'click',
+			(_event, doc) => seen.push(doc),
+		);
+
+		click(document);
+		click(preOpen);
+
+		expect(seen).toContain(document);
+		expect(seen).toContain(preOpen);
+	});
+
+	it('reaches a pop-out opened after registration', () => {
+		const plugin = new FakePlugin([]);
+		plugin.load();
+		const seen: Document[] = [];
+		registerDomEventOnAllWindows(
+			plugin as unknown as Plugin,
+			plugin.app,
+			'click',
+			(_event, doc) => seen.push(doc),
+		);
+		const popout = makeDoc();
+
+		// Before the window opens, its document has no listener
+		click(popout);
+		expect(seen).not.toContain(popout);
+
+		plugin.emit('window-open', popout);
+		click(popout);
+
+		expect(seen).toContain(popout);
+	});
+
+	it('stops reaching a pop-out once its window closes', () => {
+		const plugin = new FakePlugin([]);
+		plugin.load();
+		const seen: Document[] = [];
+		registerDomEventOnAllWindows(
+			plugin as unknown as Plugin,
+			plugin.app,
+			'click',
+			(_event, doc) => seen.push(doc),
+		);
+		const popout = makeDoc();
+		plugin.emit('window-open', popout);
+
+		plugin.emit('window-close', popout);
+		click(popout);
+
+		expect(seen).not.toContain(popout);
+	});
+
+	it('attaches a document only once even if it opens twice', () => {
+		const plugin = new FakePlugin([]);
+		plugin.load();
+		const seen: Document[] = [];
+		registerDomEventOnAllWindows(
+			plugin as unknown as Plugin,
+			plugin.app,
+			'click',
+			(_event, doc) => seen.push(doc),
+		);
+		const popout = makeDoc();
+
+		plugin.emit('window-open', popout);
+		plugin.emit('window-open', popout);
+		click(popout);
+
+		expect(seen.filter((doc) => doc === popout)).toHaveLength(1);
+	});
+
+	it('removes every window listener when the plugin unloads', () => {
+		const preOpen = makeDoc();
+		const plugin = new FakePlugin([preOpen]);
+		plugin.load();
+		const seen: Document[] = [];
+		registerDomEventOnAllWindows(
+			plugin as unknown as Plugin,
+			plugin.app,
+			'click',
+			(_event, doc) => seen.push(doc),
+		);
+		const popout = makeDoc();
+		plugin.emit('window-open', popout);
+
+		plugin.unload();
+		click(document);
+		click(preOpen);
+		click(popout);
+
+		expect(seen).toHaveLength(0);
+	});
+
+	it('forwards addEventListener options (capture) to each window', () => {
+		const attach = jest.spyOn(Component.prototype, 'registerDomEvent');
+		try {
+			const plugin = new FakePlugin([]);
+			plugin.load();
+
+			registerDomEventOnAllWindows(
+				plugin as unknown as Plugin,
+				plugin.app,
+				'click',
+				() => {},
+				{ capture: true },
+			);
+
+			expect(attach).toHaveBeenCalledWith(
+				document,
+				'click',
+				expect.any(Function),
+				{ capture: true },
+			);
+		} finally {
+			attach.mockRestore();
+		}
+	});
+});


### PR DESCRIPTION
Fixes #12.

Obsidian pop-out windows each own a separate `document`, and events raised inside one never bubble into the main window. The audio player context menu and the enhanced player's timecode-link click handler were each bound once through `registerDomEvent(activeDocument, ...)` at plugin load, so they only ever covered the window that was focused at that moment. Once a note is moved into a pop-out window, the right-click menu ("Delete recording", "Audio file info") no longer appears and a timecode click no longer seeks, because those clicks land in the pop-out's own document where nothing is listening.

The fix introduces `registerDomEventOnAllWindows`, a small primitive that binds a document-level listener on every window and keeps that set current:

- it attaches to the currently focused window and to every window that already holds a leaf (the main window plus any pop-out open at load);
- it attaches to each pop-out opened later through the workspace `window-open` event;
- it detaches on `window-close` and on plugin unload, because each window's listener is owned by its own child `Component`.

Both the context menu registration (`ContextMenu`) and the timecode click registration (`EnhancedPlayerRegistrar`) now go through it, so no window is left without a listener and nothing is bound twice.

## Tests

- A unit test drives the real primitive across several jsdom documents and asserts it reaches the main window, a pop-out already open at registration, and a pop-out opened later, and that it stops firing on `window-close` and on plugin unload.
- A new integration test drives the real `EnhancedPlayerRegistrar`, its real `AudioPlayerRegistry`, and a real `AudioPlayer` in a second document, and proves a timecode click there seeks the popped-out embed (it shows `1:30`, not a dead `0:00`).

`npm run lint`, `npm run test:coverage` (138 suites, 2119 tests, coverage thresholds enforced), and `npm run build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)