### PR TITLE
fix(settings): answer the plugin review instead of silencing it

### DIFF
--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -23,9 +23,10 @@ import {
 	TFolder,
 	Vault,
 	debounce,
+	requireApiVersion,
 	setIcon,
 } from 'obsidian';
-import type { Plugin, SettingTab } from 'obsidian';
+import type { Plugin } from 'obsidian';
 import type { SettingDefinitionItem } from 'obsidian';
 import {
 	createSettingsRenderMode,
@@ -231,19 +232,17 @@ export class AudioRecorderSettingTab extends PluginSettingTab {
 		// The container belongs to this tab on both Obsidians and survives every
 		// render, so it is where the stylesheet is told which settings are ours.
 		this.containerEl.addClass(SETTINGS_TAB_CLASS);
-		// SettingTab.update() is the 1.13 API this probe is looking for: the
-		// typings declare it unconditionally, so only the runtime tells the two
-		// versions apart. Its absence selects the imperative mode, which is
-		// what keeps the tab working down to minAppVersion. The call itself
-		// stays on the instance, so the framework - or a test double standing
-		// in for it - always drives its own re-render.
-		const hasFrameworkUpdate =
-			// eslint-disable-next-line obsidianmd/no-unsupported-api -- probing for the 1.13 API is how the pre-1.13 fallback is chosen; the call below is guarded by this result
-			typeof (this as Partial<SettingTab>).update === 'function';
+		// Obsidian 1.13 is where the declarative settings API begins, and with
+		// it SettingTab.update(), the framework's own re-render of the
+		// definitions. The typings declare that method unconditionally, so the
+		// running app is what has to be asked; below 1.13 the answer selects
+		// the imperative mode, which is what keeps the tab working down to
+		// minAppVersion. The re-render itself stays a call on the instance, so
+		// the framework - or a test double standing in for it - always drives
+		// its own pass.
 		this.renderMode = createSettingsRenderMode({
-			frameworkUpdate: hasFrameworkUpdate
+			frameworkUpdate: requireApiVersion('1.13.0')
 				? (): void => {
-						// eslint-disable-next-line obsidianmd/no-unsupported-api -- reached only when the probe above found update(), i.e. on Obsidian 1.13+
 						this.update();
 					}
 				: undefined,

--- a/src/settings/settingsDefinitions.ts
+++ b/src/settings/settingsDefinitions.ts
@@ -165,9 +165,15 @@ export const SETTINGS_ROOT_CLASS = 'aar-settings-root';
 export const SETTINGS_BLOCK_ROW_CLASS = 'aar-setting-block-row';
 
 /**
- * Marks a group whose text areas are laid out under their name across the whole
- * row. A glossary or a guidance prompt is edited in paragraphs, and the control
- * column a row gives a text area by default is a few characters wide.
+ * Marks a block whose rows are all multi-line editors, laid out with the field
+ * under its name across the whole row. A glossary or a guidance prompt is
+ * edited in paragraphs, and the control column a row gives a text area by
+ * default is a few characters wide.
+ *
+ * Only a group takes a class - a row cannot - so a text area is put in a block
+ * of its own rather than beside the switches and pickers it belongs with. That
+ * is what lets the stylesheet find it without asking which rows hold a text
+ * area, a question CSS can only answer by testing every element on the page.
  */
 export const STACKED_TEXT_CLASS = 'aar-stacked-text';
 
@@ -178,8 +184,13 @@ export const STACKED_TEXT_CLASS = 'aar-stacked-text';
  * between blocks and switches off the one Obsidian draws between the rows
  * inside them. It needs a handle for that, and a group is the only shape in the
  * tree that takes a class, so every group declared here carries this one - the
- * class also tells the stylesheet which containers are this plugin's, so
- * nothing outside its own settings is restyled.
+ * class is also the whole scope of those rules, so nothing outside this tab's
+ * own blocks is restyled.
+ *
+ * That scope only holds while the tree leaves no row loose: Obsidian collects
+ * every run of rows that sits outside a group into a block of its own, and such
+ * a block carries no class to find it by. Every level of this tree therefore
+ * declares its blocks itself, {@link sectionItems} being the shorthand for it.
  */
 export const SETTINGS_SECTION_CLASS = 'aar-settings-section';
 
@@ -604,9 +615,7 @@ function audioInputGroup(
  * already says whether recordings are split and how often.
  * @param settings - Live settings, read by the entry's value
  */
-function audioSplittingPage(
-	settings: AudioRecorderSettings,
-): SettingDefinitionItem {
+function audioSplittingPage(settings: AudioRecorderSettings): SettingGroupItem {
 	const available = isAutoSplitSupported();
 	return {
 		type: 'page',
@@ -675,7 +684,7 @@ function audioSplittingPage(
 function multiTrackPage(
 	settings: AudioRecorderSettings,
 	devices: DeviceOptions,
-): SettingDefinitionItem {
+): SettingGroupItem {
 	const available = isMultiTrackCaptureSupported();
 	const active = (): boolean => settings.enableMultiTrack && available;
 	const trackRows = (): SettingGroupItem[] => {
@@ -776,9 +785,7 @@ function multiTrackPage(
  * section.
  * @param settings - Live settings, read by the predicates
  */
-function audioPlayerPage(
-	settings: AudioRecorderSettings,
-): SettingDefinitionItem {
+function audioPlayerPage(settings: AudioRecorderSettings): SettingGroupItem {
 	const enhanced = (): boolean => settings.enhancedPlayerEnabled;
 	return {
 		type: 'page',
@@ -813,9 +820,15 @@ function audioPlayerPage(
  * prompt that steer it. Nothing here is shared with the other two LLM jobs any
  * more - each names its own engine beside its own switch - so the rows follow
  * this feature alone.
+ *
+ * Two blocks rather than one, because the prompt of the chosen task is a
+ * multi-line editor: it is laid out under its name across the row, and that
+ * layout is declared per block (see {@link STACKED_TEXT_CLASS}). The task
+ * decides which of the three prompts is shown, so the second block always holds
+ * exactly the one being edited, and disappears with the feature.
  * @param settings - Live settings, read by the predicates
  */
-function llmGroup(settings: AudioRecorderSettings): SettingDefinitionItem {
+function llmGroup(settings: AudioRecorderSettings): SettingDefinitionItem[] {
 	const postProcessing = (): boolean =>
 		settings.transcriptionEnabled && settings.llmPostProcessEnabled;
 	const promptRow = (
@@ -835,55 +848,64 @@ function llmGroup(settings: AudioRecorderSettings): SettingDefinitionItem {
 			...(rows === undefined ? {} : { rows }),
 		},
 	});
-	return {
-		type: 'group',
-		cls: SETTINGS_SECTION_CLASS,
-		heading: 'LLM post-processing',
-		visible: (): boolean => settings.transcriptionEnabled,
-		items: [
-			{
-				name: 'Enable LLM post-processing',
-				aliases: ['ai', 'summary', 'cleanup', 'gpt'],
-				desc: 'Clean up punctuation and formatting, or summarize the transcript with an LLM.',
-				control: { type: 'toggle', key: 'llmPostProcessEnabled' },
-			},
-			engineChoiceRow(
-				'Post-processing engine',
-				'Which engine writes the post-processed transcript. Set it up under Engines.',
-				LLM_JOBS.postProcess.key,
-				postProcessing,
-			),
-			{
-				name: 'Task',
-				desc: 'Clean up, summarize into key points, or apply a custom instruction.',
-				visible: postProcessing,
-				control: {
-					type: 'dropdown',
-					key: 'llmPostProcessTask',
-					options: LLM_TASK_LABELS,
+	return [
+		{
+			type: 'group',
+			cls: SETTINGS_SECTION_CLASS,
+			heading: 'LLM post-processing',
+			visible: (): boolean => settings.transcriptionEnabled,
+			items: [
+				{
+					name: 'Enable LLM post-processing',
+					aliases: ['ai', 'summary', 'cleanup', 'gpt'],
+					desc: 'Clean up punctuation and formatting, or summarize the transcript with an LLM.',
+					control: { type: 'toggle', key: 'llmPostProcessEnabled' },
 				},
-			},
-			promptRow(
-				'cleanup',
-				'Cleanup prompt',
-				'System instruction for the cleanup pass. The transcript language is appended automatically; empty uses the built-in default.',
-				'llmCleanupPrompt',
-			),
-			promptRow(
-				'summary',
-				'Summary prompt',
-				'System instruction for the summary pass. The transcript language is appended automatically; empty uses the built-in default.',
-				'llmSummaryPrompt',
-			),
-			promptRow(
-				'custom',
-				'Custom instruction',
-				'System instruction applied to the transcript text, sent verbatim.',
-				'llmCustomInstruction',
-				8,
-			),
-		],
-	};
+				engineChoiceRow(
+					'Post-processing engine',
+					'Which engine writes the post-processed transcript. Set it up under Engines.',
+					LLM_JOBS.postProcess.key,
+					postProcessing,
+				),
+				{
+					name: 'Task',
+					desc: 'Clean up, summarize into key points, or apply a custom instruction.',
+					visible: postProcessing,
+					control: {
+						type: 'dropdown',
+						key: 'llmPostProcessTask',
+						options: LLM_TASK_LABELS,
+					},
+				},
+			],
+		},
+		{
+			type: 'group',
+			cls: `${SETTINGS_SECTION_CLASS} ${STACKED_TEXT_CLASS}`,
+			visible: (): boolean => settings.transcriptionEnabled,
+			items: [
+				promptRow(
+					'cleanup',
+					'Cleanup prompt',
+					'System instruction for the cleanup pass. The transcript language is appended automatically; empty uses the built-in default.',
+					'llmCleanupPrompt',
+				),
+				promptRow(
+					'summary',
+					'Summary prompt',
+					'System instruction for the summary pass. The transcript language is appended automatically; empty uses the built-in default.',
+					'llmSummaryPrompt',
+				),
+				promptRow(
+					'custom',
+					'Custom instruction',
+					'System instruction applied to the transcript text, sent verbatim.',
+					'llmCustomInstruction',
+					8,
+				),
+			],
+		},
+	];
 }
 
 /** One stored profile, as its entry in the catalogue presents it. */
@@ -992,7 +1014,7 @@ function profilePage(
 		items: [
 			{
 				type: 'group',
-				cls: `${SETTINGS_SECTION_CLASS} ${STACKED_TEXT_CLASS}`,
+				cls: SETTINGS_SECTION_CLASS,
 				items: [
 					{
 						name: catalogue.selectionName,
@@ -1005,6 +1027,14 @@ function profilePage(
 							),
 						},
 					},
+				],
+			},
+			{
+				// The body is a multi-line editor, which is laid out across the
+				// whole row and therefore in a block of its own.
+				type: 'group',
+				cls: `${SETTINGS_SECTION_CLASS} ${STACKED_TEXT_CLASS}`,
+				items: [
 					{
 						name: catalogue.bodyName,
 						desc: catalogue.bodyDesc,
@@ -1873,7 +1903,7 @@ function autoChaptersGroup(
  */
 function audioProcessingPage(
 	settings: AudioRecorderSettings,
-): SettingDefinitionItem {
+): SettingGroupItem {
 	const rows: SettingDefinition[] = [
 		{
 			name: 'Noise suppression',
@@ -1927,9 +1957,7 @@ function audioProcessingPage(
  * the number follows the switch that decides whether it is used at all.
  * @param settings - Live settings, read by the disabled predicates
  */
-function audioCleanupPage(
-	settings: AudioRecorderSettings,
-): SettingDefinitionItem {
+function audioCleanupPage(settings: AudioRecorderSettings): SettingGroupItem {
 	return {
 		type: 'page',
 		name: 'Audio cleanup defaults',
@@ -2005,7 +2033,7 @@ function audioCleanupPage(
 function diagnosticsPage(
 	diagnostics: DiagnosticsActions,
 	settings: AudioRecorderSettings,
-): SettingDefinitionItem {
+): SettingGroupItem {
 	return {
 		type: 'page',
 		name: 'Diagnostics',
@@ -2054,6 +2082,11 @@ function diagnosticsPage(
 
 /**
  * Builds the tab's definition tree.
+ *
+ * The callout and the entries below the blocks are rows rather than blocks, so
+ * each run of them is declared as a block here: Obsidian would otherwise wrap
+ * them in one of its own, which carries no class and would be left ruled
+ * between every row (see {@link SETTINGS_SECTION_CLASS}).
  * @param ctx - The tab's remainder body and action handlers
  * @returns The definitions, in the order the tab renders them
  */
@@ -2061,43 +2094,47 @@ export function buildSettingsDefinitions(
 	ctx: SettingsDefinitionContext,
 ): SettingDefinitionItem[] {
 	return [
-		{
-			name: 'Documentation',
-			searchable: false,
-			render: (setting: Setting): void => {
-				const host = setting.settingEl;
-				host.empty();
-				host.addClass(SETTINGS_ROOT_CLASS);
-				ctx.renderDocumentationLink(host);
+		...sectionItems([
+			{
+				name: 'Documentation',
+				searchable: false,
+				render: (setting: Setting): void => {
+					const host = setting.settingEl;
+					host.empty();
+					host.addClass(SETTINGS_ROOT_CLASS);
+					ctx.renderDocumentationLink(host);
+				},
 			},
-		},
+		]),
 		audioInputGroup(ctx.settings, ctx.devices, ctx.sampleRates),
 		outputFormatGroup(ctx.outputFormat),
 		fileStorageGroup(ctx.settings),
-		audioSplittingPage(ctx.settings),
-		multiTrackPage(ctx.settings, ctx.devices),
-		audioPlayerPage(ctx.settings),
-		{
-			// Forty-odd settings with a scope of their own: the style guide's
-			// case for a sub-page, and it keeps the main tab scannable.
-			type: 'page',
-			name: 'Transcription',
-			desc: 'Speech-to-text, transcript output, chapters, and LLM post-processing.',
-			displayValue: (): string =>
-				ctx.settings.transcriptionEnabled ? 'On' : 'Off',
-			items: [
-				// Each block holds what belongs to it, catalogues included:
-				// nothing floats on the page beside the section it configures.
-				transcriptionGroup(ctx, enginesPage(ctx)),
-				transcriptOutputGroup(ctx.settings),
-				autoChaptersGroup(ctx, 'chapters'),
-				llmGroup(ctx.settings),
-				transcriptionAdvancedGroup(ctx, 'advanced'),
-			],
-		},
-		audioProcessingPage(ctx.settings),
-		audioCleanupPage(ctx.settings),
-		diagnosticsPage(ctx.diagnostics, ctx.settings),
+		...sectionItems([
+			audioSplittingPage(ctx.settings),
+			multiTrackPage(ctx.settings, ctx.devices),
+			audioPlayerPage(ctx.settings),
+			{
+				// Forty-odd settings with a scope of their own: the style guide's
+				// case for a sub-page, and it keeps the main tab scannable.
+				type: 'page',
+				name: 'Transcription',
+				desc: 'Speech-to-text, transcript output, chapters, and LLM post-processing.',
+				displayValue: (): string =>
+					ctx.settings.transcriptionEnabled ? 'On' : 'Off',
+				items: [
+					// Each block holds what belongs to it, catalogues included:
+					// nothing floats on the page beside the section it configures.
+					transcriptionGroup(ctx, enginesPage(ctx)),
+					transcriptOutputGroup(ctx.settings),
+					autoChaptersGroup(ctx, 'chapters'),
+					...llmGroup(ctx.settings),
+					transcriptionAdvancedGroup(ctx, 'advanced'),
+				],
+			},
+			audioProcessingPage(ctx.settings),
+			audioCleanupPage(ctx.settings),
+			diagnosticsPage(ctx.diagnostics, ctx.settings),
+		]),
 	];
 }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -852,25 +852,22 @@ input.aar-input-invalid {
    text area is written in paragraphs, so the control moves under the label and
    fills the row instead. The two selectors are the two ways such a row is
    found: the legacy renderer marks the row itself, while from 1.13 the row
-   belongs to the framework and the tree can only mark the group around it, so
-   the rule reaches the row through the text area it holds. */
+   belongs to the framework and only a group takes a class, so the tree keeps
+   its text areas in a block of their own and this rule dresses that block. */
 .aar-setting-stacked,
-:has(> .aar-settings-section)
-	.setting-item:has(> .setting-item-control > textarea) {
+.aar-stacked-text .setting-item {
     display: block;
 }
 
 .aar-setting-stacked .setting-item-control,
-:has(> .aar-settings-section)
-	.setting-item:has(> .setting-item-control > textarea)
-	> .setting-item-control {
+.aar-stacked-text .setting-item-control {
     width: 100%;
     padding-top: var(--size-4-2);
     justify-content: flex-start;
 }
 
 .aar-setting-stacked .setting-item-control textarea,
-:has(> .aar-settings-section) .setting-item-control > textarea {
+.aar-stacked-text .setting-item-control > textarea {
     width: 100%;
     min-height: 6em;
     resize: vertical;
@@ -879,19 +876,19 @@ input.aar-input-invalid {
 
 /* Where the lines of this tab go: between the blocks, not between the rows
    inside them. A block is one group of the definition tree, and every group the
-   tree declares carries .aar-settings-section, which is also how these rules
-   find the containers that are this plugin's - a container holding one of those
-   groups holds only this tab's blocks, so the groups the framework builds
-   around loose rows are dressed with them and nothing outside is touched.
+   tree declares carries .aar-settings-section, which is also the scope of these
+   rules: they reach nothing but this tab's own blocks and what those blocks
+   hold. The tree leaves no row loose beside them, so a block the framework
+   builds around loose rows - which would carry no class - never arises.
 
    The row divider is switched off through Obsidian's own variable rather than
    by overriding the rule that reads it, so a theme changing that rule keeps
    working. */
-:has(> .aar-settings-section) > .setting-group {
+.aar-settings-section {
     --setting-items-divider-width: 0;
 }
 
-:has(> .aar-settings-section) > .setting-group + .setting-group {
+.aar-settings-section + .aar-settings-section {
     border-top: var(--divider-width) solid var(--background-modifier-border);
     padding-top: var(--size-4-4);
 }
@@ -903,7 +900,7 @@ input.aar-input-invalid {
    action rows, written the way the app writes it, hover-capable devices only:
    on a touch device the framework has its own tap state. */
 @media (hover: hover) {
-    :has(> .aar-settings-section) .setting-item.mod-navigable:hover {
+    .aar-settings-section .setting-item.mod-navigable:hover {
         background-color: var(--background-modifier-hover);
     }
 }
@@ -912,7 +909,7 @@ input.aar-input-invalid {
    already set, and Obsidian only hides the browser's stepper. It is shown back
    here, so a count is nudged with the arrows (or the arrow keys, which have
    always worked) instead of being retyped, and the browser keeps it in range. */
-:has(> .aar-settings-section) input[type='number']::-webkit-inner-spin-button {
+.aar-settings-section input[type='number']::-webkit-inner-spin-button {
     -webkit-appearance: auto;
     appearance: auto;
     opacity: 1;

--- a/tests/helpers/declarativeSettings.ts
+++ b/tests/helpers/declarativeSettings.ts
@@ -15,9 +15,9 @@
  * @module tests/helpers/declarativeSettings
  */
 
-import { PluginSettingTab, Setting } from 'obsidian';
+import { PluginSettingTab, Setting, apiVersion } from 'obsidian';
 import type { SettingDefinitionItem } from 'obsidian';
-import { at } from './assertions';
+import { __setApiVersion } from '../mocks/obsidian';
 
 /**
  * A tab's render definition, in the shape a test reads it: the framework
@@ -265,18 +265,39 @@ export interface DeclarativeFrame {
 }
 
 /**
- * The single render definition a tab declares.
+ * The first render definition a tab declares, which is the documentation
+ * callout the tab opens with. Found at any depth, since every row of the tree
+ * sits inside the block it belongs to.
  * @param definitions - What `getSettingDefinitions()` returned
  * @returns That definition, narrowed to its render shape
  */
 export const renderDefinitionOf = (
 	definitions: SettingDefinitionItem[],
 ): RenderDefinition => {
-	const definition = at(definitions, 0, 'setting definition');
-	if (!('render' in definition) || typeof definition.render !== 'function') {
+	const search = (
+		entries: ReadonlyArray<RowDefinition | GroupDefinition>,
+	): RenderDefinition | undefined => {
+		for (const entry of entries) {
+			if ('type' in entry) {
+				const nested = search(entry.items ?? []);
+				if (nested) {
+					return nested;
+				}
+				continue;
+			}
+			if (typeof entry.render === 'function') {
+				return entry as RenderDefinition;
+			}
+		}
+		return undefined;
+	};
+	const found = search(
+		definitions as ReadonlyArray<RowDefinition | GroupDefinition>,
+	);
+	if (!found) {
 		throw new Error('The tab declares no render definition');
 	}
-	return definition as RenderDefinition;
+	return found;
 };
 
 /** Builds the DOM the framework wraps a definition in. */
@@ -328,20 +349,25 @@ export const releaseThroughFramework = (frame: DeclarativeFrame): void => {
 };
 
 /**
- * Runs a body against an Obsidian that has no `SettingTab.update()`, the
- * method 1.13 added alongside the declarative render. Its absence is what a
- * tab probes for when it picks the imperative path, and since that choice is
- * made in the constructor, the tab under test has to be built inside the body.
- * @param body - Runs while the prototype models the older Obsidian
+ * Runs a body against an Obsidian older than 1.13, the version that brought
+ * the declarative settings API and the `SettingTab.update()` that re-renders
+ * from it. The reported app version is what a tab asks when it picks the
+ * imperative path, and since that choice is made in the constructor, the tab
+ * under test has to be built inside the body. `update()` goes with the version
+ * it arrived in, so the older prototype does not carry it either.
+ * @param body - Runs while the mock models the older Obsidian
  * @returns Whatever the body returned
  */
-export const withoutFrameworkUpdate = <T>(body: () => T): T => {
+export const withoutDeclarativeSettings = <T>(body: () => T): T => {
 	const base = PluginSettingTab.prototype as { update?: () => void };
 	const update = base.update;
+	const version = apiVersion;
 	delete base.update;
+	__setApiVersion('1.12.3');
 	try {
 		return body();
 	} finally {
+		__setApiVersion(version);
 		if (update) {
 			base.update = update;
 		}

--- a/tests/mocks/obsidian.ts
+++ b/tests/mocks/obsidian.ts
@@ -1130,8 +1130,45 @@ export const Platform = {
 	isMobileApp: false,
 };
 
-/** Mock of obsidian's module-level API version export. */
-export const apiVersion = '1.12.3';
+/**
+ * Mock of obsidian's module-level API version export, holding the version the
+ * plugin builds against. Writable because it is also what requireApiVersion()
+ * answers from: a test that models an older Obsidian moves it (through
+ * __setApiVersion) rather than keeping a second version beside this one.
+ */
+export let apiVersion = '1.13.0';
+
+/**
+ * Sets the app version the mock reports, for a test that models a specific
+ * Obsidian. Restore the previous value when the test is done.
+ * @param version - Version to report from now on
+ */
+export function __setApiVersion(version: string): void {
+	apiVersion = version;
+}
+
+/**
+ * Mock of obsidian's requireApiVersion: whether the running app is at least
+ * the requested version, compared the way the real one compares - numerically,
+ * segment by segment.
+ * @param version - Lowest version the caller needs
+ * @returns Whether the reported version is that version or newer
+ */
+export function requireApiVersion(version: string): boolean {
+	const parse = (value: string): number[] =>
+		value.split('.').map((part) => Number.parseInt(part, 10) || 0);
+	const running = parse(apiVersion);
+	const required = parse(version);
+	const segments = Math.max(running.length, required.length);
+	for (let index = 0; index < segments; index++) {
+		const here = running[index] ?? 0;
+		const needed = required[index] ?? 0;
+		if (here !== needed) {
+			return here > needed;
+		}
+	}
+	return true;
+}
 
 /**
  * Mock AbstractInputSuggest: enough surface for components that attach

--- a/tests/unit/SettingsTab.test.ts
+++ b/tests/unit/SettingsTab.test.ts
@@ -13,7 +13,7 @@ import {
 	renderThroughFramework,
 	rowIn,
 	rowOf,
-	withoutFrameworkUpdate,
+	withoutDeclarativeSettings,
 	type DeclarativeFrame,
 	type GroupDefinition,
 	type RenderDefinition,
@@ -538,7 +538,7 @@ describe('AudioRecorderSettingTab', () => {
 		beforeEach(() => {
 			// The render mode is picked when the tab is constructed, so the
 			// older Obsidian only has to be modelled for that one call.
-			legacyTab = withoutFrameworkUpdate(
+			legacyTab = withoutDeclarativeSettings(
 				() => new AudioRecorderSettingTab(new App(), mockPlugin),
 			);
 		});
@@ -1086,7 +1086,7 @@ describe('AudioRecorderSettingTab', () => {
 		});
 
 		it('releases the finished playback when the imperative path rebuilds', async () => {
-			const legacyTab = withoutFrameworkUpdate(
+			const legacyTab = withoutDeclarativeSettings(
 				() => new AudioRecorderSettingTab(new App(), mockPlugin),
 			);
 			legacyTab.display();

--- a/tests/unit/SystemDiagnostics.test.ts
+++ b/tests/unit/SystemDiagnostics.test.ts
@@ -112,7 +112,7 @@ describe('SystemDiagnostics.collectEnvironment', () => {
 	it("reads the API version from obsidian's module export", () => {
 		const result = SystemDiagnostics.collectEnvironment(makeApp());
 
-		expect(result.obsidianVersion).toBe('1.12.3');
+		expect(result.obsidianVersion).toBe('1.13.0');
 	});
 
 	it('reads electron and node versions from process.versions', () => {
@@ -462,7 +462,7 @@ describe('SystemDiagnostics.collect', () => {
 		expect(result).toHaveProperty('audioDevices');
 		expect(result).toHaveProperty('audioCapabilities');
 		expect(result).toHaveProperty('activeRecordingConfig');
-		expect(result.environment.obsidianVersion).toBe('1.12.3');
+		expect(result.environment.obsidianVersion).toBe('1.13.0');
 		expect(result.pluginSettings.recordingFormat).toBe(FORMAT_WEBM);
 		expect(Array.isArray(result.audioDevices)).toBe(true);
 	});

--- a/tests/unit/settingsDefinitions.test.ts
+++ b/tests/unit/settingsDefinitions.test.ts
@@ -1079,6 +1079,49 @@ describe('settings definitions', () => {
 				expect.objectContaining({ name: 'Part duration' }),
 			);
 		});
+
+		it('leaves no row loose beside the blocks, at any level', () => {
+			// What the whole scope of those rules rests on: Obsidian collects
+			// every run of rows outside a group into a block of its own, and
+			// such a block carries no class for the stylesheet to find.
+			const tree = build() as Array<RowDefinition | GroupDefinition>;
+			const containers = [
+				{ name: 'the tab', items: tree },
+				...everyContainer(tree)
+					.filter((entry) => entry.type === 'page')
+					.map((page) => ({
+						name: page.name ?? '',
+						items: page.items,
+					})),
+			];
+
+			for (const container of containers) {
+				const loose = container.items
+					.filter((item) => !('type' in item))
+					.map((item) => item.name);
+
+				expect([container.name, loose]).toEqual([container.name, []]);
+			}
+		});
+
+		it('keeps a block of multi-line editors to text areas alone', () => {
+			// The layout that block declares applies to every row in it, so a
+			// switch or a picker sharing it would be stacked along with them.
+			const stacked = everyContainer(
+				build() as Array<RowDefinition | GroupDefinition>,
+			).filter((entry) =>
+				(entry.cls ?? '').split(' ').includes(STACKED_TEXT_CLASS),
+			);
+
+			expect(stacked.length).toBeGreaterThan(0);
+			for (const block of stacked) {
+				expect(
+					block.items.map(
+						(item) => (item as RowDefinition).control?.type,
+					),
+				).toEqual(block.items.map(() => 'textarea'));
+			}
+		});
 	});
 
 	describe('the sections that sit behind an entry', () => {


### PR DESCRIPTION
The plugin review reports two findings about the settings tab, and both are answered here by asking the question a supported way rather than by suppressing the answer.

The first is an error, because the declarative render reaches `SettingTab.update()`, which Obsidian added in 1.13 while this plugin declares `minAppVersion` 1.6.6, and it did so behind two `eslint-disable obsidianmd/no-unsupported-api` comments that the review does not accept. The rule has a sanctioned escape hatch: an API newer than `minAppVersion` is allowed when it sits under `requireApiVersion()` with a literal version, which is also Obsidian's own documented way of gating a newer API. The runtime probe for the method is therefore replaced by the version check, and the imperative fallback below 1.13 is chosen from the same answer.

```typescript
// src/settings/SettingsTab.ts - constructor
this.renderMode = createSettingsRenderMode({
    frameworkUpdate: requireApiVersion('1.13.0')
        ? (): void => {
                this.update();
            }
        : undefined,
```

That the guard is what satisfies the rule was verified rather than assumed: with `requireApiVersion('1.12.0')` in that position ESLint reports `'SettingTab.update' requires Obsidian v1.13.0, but minAppVersion is 1.6.6`, and with `'1.13.0'` the file lints clean.

The second finding is nine warnings about `:has()` in the stylesheet, where the tab used it to reach the container holding its own blocks, because a group of the definition tree takes a class while the container around it does not. Every one of those selectors was unqualified, so the browser had to test it against every element on the page, which is exactly the invalidation cost the warning is about. They are gone, and the tree now carries the marks the stylesheet needs.

Reaching them by class alone required two things of the definition tree, both verified against the rendering Obsidian actually performs. Obsidian collects each run of rows that sits outside a group into a block of its own, and such a block carries no class, so the documentation callout and the navigable entries below the blocks are declared as blocks here instead. A row cannot take a class at all, so the multi-line editors, which are laid out with the field under its name across the whole row, are kept in a block whose rows are text areas alone.

Changes in this pull request:

- The version check replaces the runtime probe for `SettingTab.update()`, and the two `eslint-disable` comments are removed with it.
- The documentation callout and the seven navigable entries are wrapped in blocks the tree declares, so no level of it leaves a row loose beside its blocks.
- The profile body and the three LLM post-processing prompts move into blocks of their own, marked `aar-stacked-text`, and the stacked layout applies to such a block as a whole.
- The block dividers, the navigable-row hover and the number stepper are scoped to `.aar-settings-section`, which removes the last `:has()` from the stylesheet.
- Two tests assert the invariants the stylesheet now rests on, namely that no container level holds a loose row and that a block of multi-line editors holds text areas alone.
- The obsidian test mock gains `requireApiVersion()` over a movable `apiVersion`, and `withoutFrameworkUpdate()` becomes `withoutDeclarativeSettings()`, which lowers that version instead of deleting a method from the prototype.

One visible consequence is worth calling out for review. The prompt of the selected LLM task and the body of a profile now sit in their own block, so each is separated from the block above it by the divider and the group spacing every other block boundary gets. Keeping them inside the previous block while removing `:has()` is not possible, because CSS without `:has()` cannot select a row by what that row contains.

```bash
anatolk@dev:~/obsidian-advanced-audio-recorder$ npm test -- --no-coverage
Test Suites: 170 passed, 170 total
Tests:       2745 passed, 2745 total
```

Lint, typecheck and the production build are clean as well.

Generated with [Claude Code](https://claude.com/claude-code)
